### PR TITLE
[SDTEST-2479] Bug bash - improve test runner's correctness

### DIFF
--- a/internal/framework/rspec_test.go
+++ b/internal/framework/rspec_test.go
@@ -89,16 +89,18 @@ func TestRSpec_DiscoverTests_Success(t *testing.T) {
 
 	testData := []testoptimization.Test{
 		{
-			FQN:        "spec/models/user_spec.rb[1:1]",
-			Name:       "User should be valid",
-			Suite:      "User",
-			SourceFile: "spec/models/user_spec.rb",
+			FQN:             "spec/models/user_spec.rb[1:1]",
+			Name:            "User should be valid",
+			Suite:           "User",
+			SourceFile:      "spec/models/user_spec.rb",
+			SuiteSourceFile: "spec/models/user_spec.rb",
 		},
 		{
-			FQN:        "spec/controllers/users_controller_spec.rb[1:1]",
-			Name:       "UsersController GET index should return success",
-			Suite:      "UsersController",
-			SourceFile: "spec/controllers/users_controller_spec.rb",
+			FQN:             "spec/controllers/users_controller_spec.rb[1:1]",
+			Name:            "UsersController GET index should return success",
+			Suite:           "UsersController",
+			SourceFile:      "spec/controllers/users_controller_spec.rb",
+			SuiteSourceFile: "spec/controllers/users_controller_spec.rb",
 		},
 	}
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -93,9 +93,9 @@ func (tr *TestRunner) PrepareTestOptimization(ctx context.Context) error {
 	testFilesMap := make(map[string]bool)
 	for _, test := range discoveredTests {
 		if !skippableTests[test.FQN] {
-			slog.Debug("Test is not skipped", "test", test.FQN, "sourceFile", test.SourceFile)
-			if test.SourceFile != "" {
-				testFilesMap[test.SourceFile] = true
+			slog.Debug("Test is not skipped", "test", test.FQN, "sourceFile", test.SuiteSourceFile)
+			if test.SuiteSourceFile != "" {
+				testFilesMap[test.SuiteSourceFile] = true
 			}
 		} else {
 			skippableTestsCount++

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -143,10 +143,10 @@ func TestTestRunner_PrepareTestOptimization_Success(t *testing.T) {
 	mockFramework := &MockFramework{
 		FrameworkName: "rspec",
 		Tests: []testoptimization.Test{
-			{FQN: "TestSuite1.test1", SourceFile: "test/file1_test.rb"},
-			{FQN: "TestSuite1.test2", SourceFile: "test/file1_test.rb"},
-			{FQN: "TestSuite2.test3", SourceFile: "test/file2_test.rb"},
-			{FQN: "TestSuite3.test4", SourceFile: "test/file3_test.rb"},
+			{FQN: "TestSuite1.test1", SourceFile: "test/file1_test.rb", SuiteSourceFile: "test/file1_test.rb"},
+			{FQN: "TestSuite1.test2", SourceFile: "test/file1_test.rb", SuiteSourceFile: "test/file1_test.rb"},
+			{FQN: "TestSuite2.test3", SourceFile: "test/file2_test.rb", SuiteSourceFile: "test/file2_test.rb"},
+			{FQN: "TestSuite3.test4", SourceFile: "test/file3_test.rb", SuiteSourceFile: "test/file3_test.rb"},
 		},
 	}
 
@@ -272,7 +272,7 @@ func TestTestRunner_PrepareTestOptimization_OptimizationClientInitError(t *testi
 
 	mockFramework := &MockFramework{
 		Tests: []testoptimization.Test{
-			{FQN: "test1", SourceFile: "file1.rb"},
+			{FQN: "test1", SourceFile: "file1.rb", SuiteSourceFile: "file1.rb"},
 		},
 	}
 
@@ -401,8 +401,8 @@ func TestTestRunner_PrepareTestOptimization_AllTestsSkipped(t *testing.T) {
 
 	mockFramework := &MockFramework{
 		Tests: []testoptimization.Test{
-			{FQN: "test1", SourceFile: "file1.rb"},
-			{FQN: "test2", SourceFile: "file2.rb"},
+			{FQN: "test1", SourceFile: "file1.rb", SuiteSourceFile: "file1.rb"},
+			{FQN: "test2", SourceFile: "file2.rb", SuiteSourceFile: "file2.rb"},
 		},
 	}
 

--- a/internal/testoptimization/types.go
+++ b/internal/testoptimization/types.go
@@ -1,8 +1,9 @@
 package testoptimization
 
 type Test struct {
-	FQN        string `json:"fqn"`
-	Name       string `json:"name"`
-	Suite      string `json:"suite"`
-	SourceFile string `json:"sourceFile"`
+	FQN             string `json:"fqn"`
+	Name            string `json:"name"`
+	Suite           string `json:"suite"`
+	SourceFile      string `json:"sourceFile"`
+	SuiteSourceFile string `json:"suiteSourceFile"`
 }


### PR DESCRIPTION
Fixes the following issues:
- for file-level skipping we need to look at the source location of test suite, not test itself (test could be defined in shared helpers file and then included in test suites)
- don't output empty lines if any encountered as it breaks knapsack_pro runner