### PR TITLE
add os.architecure tag to the map of tags discovered from Ruby environment

### DIFF
--- a/internal/platform/scripts/ruby_env.rb
+++ b/internal/platform/scripts/ruby_env.rb
@@ -4,6 +4,7 @@ require "datadog/core/environment/platform"
 
 tags_map = {
   Datadog::CI::Ext::Test::TAG_OS_PLATFORM => ::RbConfig::CONFIG["host_os"],
+  Datadog::CI::Ext::Test::TAG_OS_ARCHITECTURE => ::RbConfig::CONFIG["host_cpu"],
   Datadog::CI::Ext::Test::TAG_OS_VERSION => Datadog::Core::Environment::Platform.kernel_release,
   Datadog::CI::Ext::Test::TAG_RUNTIME_NAME => Datadog::Core::Environment::Ext::LANG_ENGINE,
   Datadog::CI::Ext::Test::TAG_RUNTIME_VERSION => Datadog::Core::Environment::Ext::ENGINE_VERSION


### PR DESCRIPTION
I forgot to include os.architecture tag in the list of environment tags