### PR TITLE
Pin golangci-lint to v2.11.4 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,5 +63,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v6
         with:
-          version: latest
+          version: v2.11.4
           args: --timeout=5m


### PR DESCRIPTION
## Summary
- Pin `golangci-lint` from `latest` to `v2.11.4` in CI workflow to reduce supply chain attack surface by ensuring a known, audited version is used

## Test plan
- [x] CI lint job passes with the pinned version

🤖 Generated with [Claude Code](https://claude.com/claude-code)