### PR TITLE
[SDTEST-3211] Use Datadog test suite durations endpoint

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -21,7 +21,8 @@
       "Bash(mkdir:*)",
       "Bash(make lint:*)",
       "Bash(make:*)",
-      "Bash(./ddtest:*)"
+      "Bash(./ddtest:*)",
+      "Bash(git diff:*)"
     ],
     "deny": [],
     "defaultMode": "acceptEdits"

--- a/internal/httptransport/unix_socket.go
+++ b/internal/httptransport/unix_socket.go
@@ -1,0 +1,42 @@
+package httptransport
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+func UnixSocketClient(socketPath string, timeout time.Duration) *http.Client {
+	dialer := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+		DualStack: true,
+	}
+	return &http.Client{
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return dialer.DialContext(ctx, "unix", (&net.UnixAddr{
+					Name: socketPath,
+					Net:  "unix",
+				}).String())
+			},
+			MaxIdleConns:          100,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+		},
+		Timeout: timeout,
+	}
+}
+
+func UnixSocketURL(socketPath string) *url.URL {
+	return &url.URL{
+		Scheme: "http",
+		Host:   fmt.Sprintf("UDS_%s", strings.NewReplacer(":", "_", "/", "_", `\`, "_").Replace(socketPath)),
+	}
+}

--- a/internal/httptransport/unix_socket_test.go
+++ b/internal/httptransport/unix_socket_test.go
@@ -1,0 +1,26 @@
+package httptransport
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestUnixSocketURL(t *testing.T) {
+	u := UnixSocketURL("/tmp/ddtest-agent.sock")
+
+	if got := u.String(); got != "http://UDS__tmp_ddtest-agent.sock" {
+		t.Errorf("Expected sanitized UDS URL, got %q", got)
+	}
+}
+
+func TestUnixSocketClient(t *testing.T) {
+	client := UnixSocketClient("/tmp/ddtest-agent.sock", 45*time.Second)
+
+	if client.Timeout != 45*time.Second {
+		t.Errorf("Expected timeout 45s, got %s", client.Timeout)
+	}
+	if _, ok := client.Transport.(*http.Transport); !ok {
+		t.Fatalf("Expected HTTP transport, got %T", client.Transport)
+	}
+}

--- a/internal/runner/dd_test_optimization.go
+++ b/internal/runner/dd_test_optimization.go
@@ -152,9 +152,8 @@ func (tr *TestRunner) PrepareTestOptimization(ctx context.Context) error {
 	if fullDiscoverySucceeded && len(discoveredTests) > 0 {
 		slog.Info("Using full test discovery results")
 		discoveredTestsCount, skippableTestsCount := recordDiscoveredTests(tr.suiteAggregates, tr.testFiles, discoveredTests, skippableTests, subdirPrefix)
-		tr.skippablePercentage = float64(skippableTestsCount) / float64(discoveredTestsCount) * 100.0
 
-		slog.Info("Test optimization data prepared", "skippablePercentage", tr.skippablePercentage, "skippableTestsCount", skippableTestsCount, "discoveredTestsCount", discoveredTestsCount)
+		slog.Info("Test optimization data prepared", "skippableTestsCount", skippableTestsCount, "discoveredTestsCount", discoveredTestsCount)
 	} else {
 		slog.Info("Using fast test discovery results (ITR disabled or full discovery failed)")
 		tr.skippablePercentage = 0.0
@@ -164,6 +163,7 @@ func (tr *TestRunner) PrepareTestOptimization(ctx context.Context) error {
 	resolveSuiteDurations(tr.suiteAggregates, tr.testSuiteDurations)
 	addBackendSuiteAggregates(tr.suiteAggregates, tr.testSuiteDurations, tr.testFiles, subdirPrefix)
 	tr.suitesBySourceFile = indexSuitesBySourceFile(tr.suiteAggregates)
+	tr.skippablePercentage = calculateSavedTimePercentage(tr.suiteAggregates)
 	slog.Info("Test files prepared", "testFilesCount", len(tr.testFiles))
 
 	return nil
@@ -240,12 +240,13 @@ type testSuiteKey struct {
 }
 
 type testSuiteAggregate struct {
-	Module          string
-	Suite           string
-	SourceFile      string
-	Duration        int
-	NumTests        int
-	NumTestsSkipped int
+	Module            string
+	Suite             string
+	SourceFile        string
+	TotalDuration     float64
+	EstimatedDuration float64
+	NumTests          int
+	NumTestsSkipped   int
 }
 
 func recordDiscoveredTests(
@@ -315,10 +316,18 @@ func resolveSuiteDurations(
 	testSuiteDurations map[string]map[string]testoptimization.TestSuiteDurationInfo,
 ) {
 	for key, aggregate := range suiteAggregates {
-		aggregate.Duration = (aggregate.NumTests - aggregate.NumTestsSkipped) * int(time.Second)
+		// Without backend timing data, use test counts as the estimate:
+		// TotalDuration is the full suite before ITR skips, while EstimatedDuration
+		// is the runnable remainder after skipped tests are removed.
+		aggregate.TotalDuration = float64(aggregate.NumTests) * float64(time.Second)
+		aggregate.EstimatedDuration = float64(aggregate.NumTests-aggregate.NumTestsSkipped) * float64(time.Second)
 		if suiteInfo, ok := getTestSuiteDuration(testSuiteDurations, key); ok {
 			if p50, ok := parseDurationP50(suiteInfo); ok {
-				aggregate.Duration = p50
+				aggregate.TotalDuration = p50
+				aggregate.EstimatedDuration = p50
+				if aggregate.NumTests > 0 {
+					aggregate.EstimatedDuration = p50 * float64(aggregate.NumTests-aggregate.NumTestsSkipped) / float64(aggregate.NumTests)
+				}
 			}
 		}
 		suiteAggregates[key] = aggregate
@@ -345,12 +354,13 @@ func addBackendSuiteAggregates(
 
 			if duration, ok := parseDurationP50(suiteInfo); ok {
 				suiteAggregates[key] = testSuiteAggregate{
-					Module:          module,
-					Suite:           suite,
-					SourceFile:      sourceFile,
-					Duration:        duration,
-					NumTests:        1,
-					NumTestsSkipped: 0,
+					Module:            module,
+					Suite:             suite,
+					SourceFile:        sourceFile,
+					TotalDuration:     duration,
+					EstimatedDuration: duration,
+					NumTests:          1,
+					NumTestsSkipped:   0,
 				}
 			}
 		}
@@ -368,12 +378,37 @@ func getTestSuiteDuration(
 	return testoptimization.TestSuiteDurationInfo{}, false
 }
 
-func parseDurationP50(suiteInfo testoptimization.TestSuiteDurationInfo) (int, bool) {
+func parseDurationP50(suiteInfo testoptimization.TestSuiteDurationInfo) (float64, bool) {
 	p50, err := strconv.ParseInt(suiteInfo.Duration.P50, 10, 64)
 	if err != nil {
 		return 0, false
 	}
-	return int(p50), true
+	return float64(p50), true
+}
+
+func calculateSavedTimePercentage(suiteAggregates map[testSuiteKey]testSuiteAggregate) float64 {
+	var totalDuration float64
+	var estimatedDuration float64
+
+	for _, aggregate := range suiteAggregates {
+		if aggregate.NumTests == 0 {
+			continue
+		}
+
+		totalDurationForSuite := aggregate.TotalDuration
+		if totalDurationForSuite <= 0 {
+			continue
+		}
+
+		totalDuration += totalDurationForSuite
+		estimatedDuration += aggregate.EstimatedDuration
+	}
+
+	if totalDuration == 0 {
+		return 0.0
+	}
+
+	return (totalDuration - estimatedDuration) / totalDuration * 100.0
 }
 
 func indexSuitesBySourceFile(suiteAggregates map[testSuiteKey]testSuiteAggregate) map[string][]testSuiteKey {
@@ -406,7 +441,7 @@ func (tr *TestRunner) testFileWeight(testFile string) (int, bool) {
 		return defaultTestFileWeight, true
 	}
 
-	var duration int
+	var duration float64
 	var hasRunnableSuite bool
 	for _, key := range suiteKeys {
 		aggregate := tr.suiteAggregates[key]
@@ -414,7 +449,7 @@ func (tr *TestRunner) testFileWeight(testFile string) (int, bool) {
 			continue
 		}
 		hasRunnableSuite = true
-		duration += aggregate.Duration
+		duration += aggregate.EstimatedDuration
 	}
 	if !hasRunnableSuite {
 		return 0, false
@@ -423,7 +458,7 @@ func (tr *TestRunner) testFileWeight(testFile string) (int, bool) {
 		return defaultTestFileWeight, true
 	}
 
-	weight := duration / int(time.Millisecond)
+	weight := int(duration / float64(time.Millisecond))
 	if weight < 1 {
 		return 1, true
 	}

--- a/internal/runner/dd_test_optimization.go
+++ b/internal/runner/dd_test_optimization.go
@@ -5,8 +5,13 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"os"
+	"regexp"
+	"strings"
 	"time"
 
+	"github.com/DataDog/ddtest/civisibility/constants"
+	"github.com/DataDog/ddtest/civisibility/utils"
 	"github.com/DataDog/ddtest/internal/settings"
 	"github.com/DataDog/ddtest/internal/testoptimization"
 	"golang.org/x/sync/errgroup"
@@ -55,6 +60,7 @@ func (tr *TestRunner) PrepareTestOptimization(ctx context.Context) error {
 	var fullDiscoverySucceeded bool
 	var fullDiscoveryErr error
 	var fastDiscoveryErr error
+	tr.testSuiteDurations = make(map[string]map[string]testoptimization.TestSuiteDurationInfo)
 
 	g, _ := errgroup.WithContext(ctx)
 
@@ -76,6 +82,8 @@ func (tr *TestRunner) PrepareTestOptimization(ctx context.Context) error {
 				cancelDiscovery()
 			}
 		}
+
+		tr.fetchAndStoreTestSuiteDurations()
 
 		startTime := time.Now()
 		slog.Info("Fetching skippable tests from Datadog...")
@@ -177,4 +185,69 @@ func (tr *TestRunner) PrepareTestOptimization(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func initializeDurationsFetchInputs() (string, string, error) {
+	ciTags := utils.GetCITags()
+	repositoryURL := ciTags[constants.GitRepositoryURL]
+	if repositoryURL == "" {
+		return "", "", fmt.Errorf("repository URL is required")
+	}
+
+	service := os.Getenv("DD_SERVICE")
+	if service == "" {
+		repoRegex := regexp.MustCompile(`(?m)/([a-zA-Z0-9\-_.]*)$`)
+		matches := repoRegex.FindStringSubmatch(repositoryURL)
+		if len(matches) > 1 {
+			repositoryURL = strings.TrimSuffix(matches[1], ".git")
+		}
+		service = repositoryURL
+	}
+
+	return ciTags[constants.GitRepositoryURL], service, nil
+}
+
+func (tr *TestRunner) fetchAndStoreTestSuiteDurations() {
+	repositoryURL, service, err := initializeDurationsFetchInputs()
+	if err != nil {
+		logDurationsAPIError(err)
+		tr.testSuiteDurations = make(map[string]map[string]testoptimization.TestSuiteDurationInfo)
+		return
+	}
+
+	durations, err := tr.durationsClient.GetTestSuiteDurations(repositoryURL, service)
+	if err != nil {
+		logDurationsAPIError(err)
+		tr.testSuiteDurations = make(map[string]map[string]testoptimization.TestSuiteDurationInfo)
+		return
+	}
+
+	tr.storeTestSuiteDurations(repositoryURL, service, durations)
+}
+
+func (tr *TestRunner) storeTestSuiteDurations(
+	repositoryURL, service string,
+	durations map[string]map[string]testoptimization.TestSuiteDurationInfo,
+) {
+	totalSuites := countTestSuites(durations)
+	if totalSuites == 0 {
+		slog.Warn("Test durations API returned no test suites", "service", service, "repositoryURL", repositoryURL)
+		tr.testSuiteDurations = make(map[string]map[string]testoptimization.TestSuiteDurationInfo)
+		return
+	}
+
+	slog.Debug("Found test suite durations", "service", service, "repositoryURL", repositoryURL, "testSuitesCount", totalSuites)
+	tr.testSuiteDurations = durations
+}
+
+func countTestSuites(durations map[string]map[string]testoptimization.TestSuiteDurationInfo) int {
+	totalSuites := 0
+	for _, suites := range durations {
+		totalSuites += len(suites)
+	}
+	return totalSuites
+}
+
+func logDurationsAPIError(err error) {
+	slog.Error("Test durations API errored", "error", err)
 }

--- a/internal/runner/dd_test_optimization.go
+++ b/internal/runner/dd_test_optimization.go
@@ -61,6 +61,7 @@ func (tr *TestRunner) PrepareTestOptimization(ctx context.Context) error {
 	var fullDiscoverySucceeded bool
 	var fullDiscoveryErr error
 	var fastDiscoveryErr error
+
 	tr.testFiles = make(map[string]struct{})
 	tr.suiteAggregates = make(map[testSuiteKey]testSuiteAggregate)
 	tr.suitesBySourceFile = make(map[string][]testSuiteKey)
@@ -97,7 +98,7 @@ func (tr *TestRunner) PrepareTestOptimization(ctx context.Context) error {
 		return nil
 	})
 
-	// Goroutine 2: Full test discovery (respects context cancellation)
+	// Goroutine 2: Tests discovery (respects context cancellation)
 	g.Go(func() error {
 		startTime := time.Now()
 		slog.Info("Discovering local tests...", "framework", framework.Name())
@@ -114,7 +115,7 @@ func (tr *TestRunner) PrepareTestOptimization(ctx context.Context) error {
 		return nil
 	})
 
-	// Goroutine 3: Fast test discovery (always completes)
+	// Goroutine 3: Test files discovery (fast, must always complete)
 	g.Go(func() error {
 		startTime := time.Now()
 		slog.Info("Discovering test files (fast)...", "framework", framework.Name())
@@ -148,22 +149,26 @@ func (tr *TestRunner) PrepareTestOptimization(ctx context.Context) error {
 		slog.Info("Running from subdirectory, will normalize repo-root-relative paths", "subdirPrefix", subdirPrefix)
 	}
 
-	// Process results based on which discovery method succeeded
-	if fullDiscoverySucceeded && len(discoveredTests) > 0 {
-		slog.Info("Using full test discovery results")
-		discoveredTestsCount, skippableTestsCount := recordDiscoveredTests(tr.suiteAggregates, tr.testFiles, discoveredTests, skippableTests, subdirPrefix)
-
-		slog.Info("Test optimization data prepared", "skippableTestsCount", skippableTestsCount, "discoveredTestsCount", discoveredTestsCount)
+	// if we have data on which tests exist in the local repository, we will aggregate them
+	// into a collection of testSuiteAggregate structs.
+	// This collection is used to calculate the skippable percentage and the weighted test files.
+	if fullDiscoverySucceeded {
+		tr.processDiscoveredTests(discoveredTests, skippableTests, subdirPrefix)
 	} else {
-		slog.Info("Using fast test discovery results (ITR disabled or full discovery failed)")
-		tr.skippablePercentage = 0.0
+		slog.Info("Full test discovery did not run (failed or test impact analysis is not enabled)")
 	}
 
-	recordDiscoveredTestFiles(tr.testFiles, discoveredTestFiles)
-	resolveSuiteDurations(tr.suiteAggregates, tr.testSuiteDurations)
-	addBackendSuiteAggregates(tr.suiteAggregates, tr.testSuiteDurations, tr.testFiles, subdirPrefix)
+	// Add local test files conforming to test framework pattern (spec/*_spec.rb for example)
+	tr.processDiscoveredTestFiles(discoveredTestFiles)
+
+	// Enrich test suite aggregates with the duration data we got from the backend
+	tr.resolveSuiteDurations()
+	// For the test files with no suite info, try to match them to our backend test suites data
+	tr.addBackendTestSuites(subdirPrefix)
+
 	tr.suitesBySourceFile = indexSuitesBySourceFile(tr.suiteAggregates)
 	tr.skippablePercentage = calculateSavedTimePercentage(tr.suiteAggregates)
+
 	slog.Info("Test files prepared", "testFilesCount", len(tr.testFiles))
 
 	return nil
@@ -192,26 +197,23 @@ func initializeDurationsFetchInputs() (string, string, error) {
 func (tr *TestRunner) fetchAndStoreTestSuiteDurations() {
 	repositoryURL, service, err := initializeDurationsFetchInputs()
 	if err != nil {
-		logDurationsAPIError(err)
+		slog.Error("Test durations API errored", "error", err)
 		tr.testSuiteDurations = make(map[string]map[string]testoptimization.TestSuiteDurationInfo)
 		return
 	}
 
 	durations, err := tr.durationsClient.GetTestSuiteDurations(repositoryURL, service)
 	if err != nil {
-		logDurationsAPIError(err)
+		slog.Error("Test durations API errored", "error", err)
 		tr.testSuiteDurations = make(map[string]map[string]testoptimization.TestSuiteDurationInfo)
 		return
 	}
 
-	tr.storeTestSuiteDurations(repositoryURL, service, durations)
-}
+	totalSuites := 0
+	for _, suites := range durations {
+		totalSuites += len(suites)
+	}
 
-func (tr *TestRunner) storeTestSuiteDurations(
-	repositoryURL, service string,
-	durations map[string]map[string]testoptimization.TestSuiteDurationInfo,
-) {
-	totalSuites := countTestSuites(durations)
 	if totalSuites == 0 {
 		slog.Warn("Test durations API returned no test suites", "service", service, "repositoryURL", repositoryURL)
 		tr.testSuiteDurations = make(map[string]map[string]testoptimization.TestSuiteDurationInfo)
@@ -220,18 +222,6 @@ func (tr *TestRunner) storeTestSuiteDurations(
 
 	slog.Debug("Found test suite durations", "service", service, "repositoryURL", repositoryURL, "testSuitesCount", totalSuites)
 	tr.testSuiteDurations = durations
-}
-
-func countTestSuites(durations map[string]map[string]testoptimization.TestSuiteDurationInfo) int {
-	totalSuites := 0
-	for _, suites := range durations {
-		totalSuites += len(suites)
-	}
-	return totalSuites
-}
-
-func logDurationsAPIError(err error) {
-	slog.Error("Test durations API errored", "error", err)
 }
 
 type testSuiteKey struct {
@@ -249,37 +239,41 @@ type testSuiteAggregate struct {
 	NumTestsSkipped   int
 }
 
-func recordDiscoveredTests(
-	suiteAggregates map[testSuiteKey]testSuiteAggregate,
-	testFiles map[string]struct{},
+func (tr *TestRunner) processDiscoveredTests(
 	discoveredTests []testoptimization.Test,
 	skippableTests map[string]bool,
 	subdirPrefix string,
-) (int, int) {
-	skippableTestsCount := 0
+) {
+	discoveredTestsCount := len(discoveredTests)
+	if discoveredTestsCount == 0 {
+		slog.Info("Full test discovery returned no tests, using only fast test discovery results")
+		return
+	}
 
+	slog.Info("Using full test discovery results")
+	skippableTestsCount := 0
 	for _, test := range discoveredTests {
 		normalizedSourceFile := stripCwdSubdirPrefix(test.SuiteSourceFile, subdirPrefix)
 		if normalizedSourceFile != "" {
-			testFiles[normalizedSourceFile] = struct{}{}
+			tr.testFiles[normalizedSourceFile] = struct{}{}
 		}
 
 		if !skippableTests[test.FQN()] {
 			slog.Debug("Test is not skipped", "test", test.FQN(), "sourceFile", test.SuiteSourceFile)
-			recordRunnableTest(suiteAggregates, test, normalizedSourceFile)
+			recordRunnableTest(tr.suiteAggregates, test, normalizedSourceFile)
 		} else {
-			recordSkippedTest(suiteAggregates, test, normalizedSourceFile)
+			recordSkippedTest(tr.suiteAggregates, test, normalizedSourceFile)
 			skippableTestsCount++
 		}
 	}
 
-	return len(discoveredTests), skippableTestsCount
+	slog.Info("Processed the discovered tests", "skippableTestsCount", skippableTestsCount, "discoveredTestsCount", discoveredTestsCount)
 }
 
-func recordDiscoveredTestFiles(testFiles map[string]struct{}, discoveredTestFiles []string) {
+func (tr *TestRunner) processDiscoveredTestFiles(discoveredTestFiles []string) {
 	for _, testFile := range discoveredTestFiles {
 		if testFile != "" {
-			testFiles[testFile] = struct{}{}
+			tr.testFiles[testFile] = struct{}{}
 		}
 	}
 }
@@ -311,17 +305,14 @@ func suiteAggregateForTest(suiteAggregates map[testSuiteKey]testSuiteAggregate, 
 	return aggregate
 }
 
-func resolveSuiteDurations(
-	suiteAggregates map[testSuiteKey]testSuiteAggregate,
-	testSuiteDurations map[string]map[string]testoptimization.TestSuiteDurationInfo,
-) {
-	for key, aggregate := range suiteAggregates {
+func (tr *TestRunner) resolveSuiteDurations() {
+	for key, aggregate := range tr.suiteAggregates {
 		// Without backend timing data, use test counts as the estimate:
 		// TotalDuration is the full suite before ITR skips, while EstimatedDuration
 		// is the runnable remainder after skipped tests are removed.
 		aggregate.TotalDuration = float64(aggregate.NumTests) * float64(time.Second)
 		aggregate.EstimatedDuration = float64(aggregate.NumTests-aggregate.NumTestsSkipped) * float64(time.Second)
-		if suiteInfo, ok := getTestSuiteDuration(testSuiteDurations, key); ok {
+		if suiteInfo, ok := getTestSuiteDuration(tr.testSuiteDurations, key); ok {
 			if p50, ok := parseDurationP50(suiteInfo); ok {
 				aggregate.TotalDuration = p50
 				aggregate.EstimatedDuration = p50
@@ -330,30 +321,25 @@ func resolveSuiteDurations(
 				}
 			}
 		}
-		suiteAggregates[key] = aggregate
+		tr.suiteAggregates[key] = aggregate
 	}
 }
 
-func addBackendSuiteAggregates(
-	suiteAggregates map[testSuiteKey]testSuiteAggregate,
-	testSuiteDurations map[string]map[string]testoptimization.TestSuiteDurationInfo,
-	testFiles map[string]struct{},
-	subdirPrefix string,
-) {
-	for module, suites := range testSuiteDurations {
+func (tr *TestRunner) addBackendTestSuites(subdirPrefix string) {
+	for module, suites := range tr.testSuiteDurations {
 		for suite, suiteInfo := range suites {
 			key := testSuiteKey{Module: module, Suite: suite}
-			if _, ok := suiteAggregates[key]; ok {
+			if _, ok := tr.suiteAggregates[key]; ok {
 				continue
 			}
 
 			sourceFile := stripCwdSubdirPrefix(suiteInfo.SourceFile, subdirPrefix)
-			if _, ok := testFiles[sourceFile]; !ok {
+			if _, ok := tr.testFiles[sourceFile]; !ok {
 				continue
 			}
 
 			if duration, ok := parseDurationP50(suiteInfo); ok {
-				suiteAggregates[key] = testSuiteAggregate{
+				tr.suiteAggregates[key] = testSuiteAggregate{
 					Module:            module,
 					Suite:             suite,
 					SourceFile:        sourceFile,

--- a/internal/runner/dd_test_optimization.go
+++ b/internal/runner/dd_test_optimization.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -60,6 +61,9 @@ func (tr *TestRunner) PrepareTestOptimization(ctx context.Context) error {
 	var fullDiscoverySucceeded bool
 	var fullDiscoveryErr error
 	var fastDiscoveryErr error
+	tr.testFiles = make(map[string]struct{})
+	tr.suiteAggregates = make(map[testSuiteKey]testSuiteAggregate)
+	tr.suitesBySourceFile = make(map[string][]testSuiteKey)
 	tr.testSuiteDurations = make(map[string]map[string]testoptimization.TestSuiteDurationInfo)
 
 	g, _ := errgroup.WithContext(ctx)
@@ -135,54 +139,32 @@ func (tr *TestRunner) PrepareTestOptimization(ctx context.Context) error {
 		return fmt.Errorf("both test discovery methods failed - full: %w, fast: %v", fullDiscoveryErr, fastDiscoveryErr)
 	}
 
+	// Compute subdirectory prefix once for all paths.
+	// When running from a monorepo subdirectory (e.g., "cd core && ddtest plan"),
+	// full discovery may return repo-root-relative paths (e.g., "core/spec/...").
+	// We normalize them to CWD-relative paths so workers can find the files.
+	subdirPrefix := getCwdSubdirPrefix()
+	if subdirPrefix != "" {
+		slog.Info("Running from subdirectory, will normalize repo-root-relative paths", "subdirPrefix", subdirPrefix)
+	}
+
 	// Process results based on which discovery method succeeded
 	if fullDiscoverySucceeded && len(discoveredTests) > 0 {
 		slog.Info("Using full test discovery results")
-		discoveredTestsCount := len(discoveredTests)
-		skippableTestsCount := 0
-
-		// Compute subdirectory prefix once for all paths.
-		// When running from a monorepo subdirectory (e.g., "cd core && ddtest plan"),
-		// full discovery may return repo-root-relative paths (e.g., "core/spec/...").
-		// We normalize them to CWD-relative paths so workers can find the files.
-		subdirPrefix := getCwdSubdirPrefix()
-		if subdirPrefix != "" {
-			slog.Info("Running from subdirectory, will normalize repo-root-relative paths", "subdirPrefix", subdirPrefix)
-		}
-
-		tr.testFiles = make(map[string]int)
-		for _, test := range discoveredTests {
-			if !skippableTests[test.FQN()] {
-				slog.Debug("Test is not skipped", "test", test.FQN(), "sourceFile", test.SuiteSourceFile)
-				if test.SuiteSourceFile != "" {
-					// Normalize repo-root-relative path to CWD-relative path.
-					// No-op when running from repo root or when path doesn't match subdir prefix.
-					normalizedPath := normalizeTestFilePathWithPrefix(test.SuiteSourceFile, subdirPrefix)
-					// increment the number of tests in the file
-					// it should track the test suite's duration here in the future
-					tr.testFiles[normalizedPath]++
-				}
-			} else {
-				skippableTestsCount++
-			}
-		}
+		discoveredTestsCount, skippableTestsCount := recordDiscoveredTests(tr.suiteAggregates, tr.testFiles, discoveredTests, skippableTests, subdirPrefix)
 		tr.skippablePercentage = float64(skippableTestsCount) / float64(discoveredTestsCount) * 100.0
 
 		slog.Info("Test optimization data prepared", "skippablePercentage", tr.skippablePercentage, "skippableTestsCount", skippableTestsCount, "discoveredTestsCount", discoveredTestsCount)
 	} else {
 		slog.Info("Using fast test discovery results (ITR disabled or full discovery failed)")
-		tr.testFiles = make(map[string]int)
-		for _, testFile := range discoveredTestFiles {
-			// As we don't know what tests are there we just set the number of tests to 1
-			//
-			// When we'll have data for "known test suites" with their durations we will
-			// be able to use test suites durations here
-			tr.testFiles[testFile] = 1
-		}
 		tr.skippablePercentage = 0.0
-
-		slog.Info("Test files prepared from fast discovery", "testFilesCount", len(tr.testFiles))
 	}
+
+	recordDiscoveredTestFiles(tr.testFiles, discoveredTestFiles)
+	resolveSuiteDurations(tr.suiteAggregates, tr.testSuiteDurations)
+	addBackendSuiteAggregates(tr.suiteAggregates, tr.testSuiteDurations, tr.testFiles, subdirPrefix)
+	tr.suitesBySourceFile = indexSuitesBySourceFile(tr.suiteAggregates)
+	slog.Info("Test files prepared", "testFilesCount", len(tr.testFiles))
 
 	return nil
 }
@@ -250,4 +232,200 @@ func countTestSuites(durations map[string]map[string]testoptimization.TestSuiteD
 
 func logDurationsAPIError(err error) {
 	slog.Error("Test durations API errored", "error", err)
+}
+
+type testSuiteKey struct {
+	Module string
+	Suite  string
+}
+
+type testSuiteAggregate struct {
+	Module          string
+	Suite           string
+	SourceFile      string
+	Duration        int
+	NumTests        int
+	NumTestsSkipped int
+}
+
+func recordDiscoveredTests(
+	suiteAggregates map[testSuiteKey]testSuiteAggregate,
+	testFiles map[string]struct{},
+	discoveredTests []testoptimization.Test,
+	skippableTests map[string]bool,
+	subdirPrefix string,
+) (int, int) {
+	skippableTestsCount := 0
+
+	for _, test := range discoveredTests {
+		normalizedSourceFile := stripCwdSubdirPrefix(test.SuiteSourceFile, subdirPrefix)
+		if normalizedSourceFile != "" {
+			testFiles[normalizedSourceFile] = struct{}{}
+		}
+
+		if !skippableTests[test.FQN()] {
+			slog.Debug("Test is not skipped", "test", test.FQN(), "sourceFile", test.SuiteSourceFile)
+			recordRunnableTest(suiteAggregates, test, normalizedSourceFile)
+		} else {
+			recordSkippedTest(suiteAggregates, test, normalizedSourceFile)
+			skippableTestsCount++
+		}
+	}
+
+	return len(discoveredTests), skippableTestsCount
+}
+
+func recordDiscoveredTestFiles(testFiles map[string]struct{}, discoveredTestFiles []string) {
+	for _, testFile := range discoveredTestFiles {
+		if testFile != "" {
+			testFiles[testFile] = struct{}{}
+		}
+	}
+}
+
+func recordRunnableTest(suiteAggregates map[testSuiteKey]testSuiteAggregate, test testoptimization.Test, sourceFile string) {
+	aggregate := suiteAggregateForTest(suiteAggregates, test, sourceFile)
+	aggregate.NumTests++
+	suiteAggregates[testSuiteKey{Module: test.Module, Suite: test.Suite}] = aggregate
+}
+
+func recordSkippedTest(suiteAggregates map[testSuiteKey]testSuiteAggregate, test testoptimization.Test, sourceFile string) {
+	aggregate := suiteAggregateForTest(suiteAggregates, test, sourceFile)
+	aggregate.NumTests++
+	aggregate.NumTestsSkipped++
+	suiteAggregates[testSuiteKey{Module: test.Module, Suite: test.Suite}] = aggregate
+}
+
+func suiteAggregateForTest(suiteAggregates map[testSuiteKey]testSuiteAggregate, test testoptimization.Test, sourceFile string) testSuiteAggregate {
+	key := testSuiteKey{
+		Module: test.Module,
+		Suite:  test.Suite,
+	}
+	aggregate := suiteAggregates[key]
+	if aggregate.SourceFile == "" {
+		aggregate.Module = test.Module
+		aggregate.Suite = test.Suite
+		aggregate.SourceFile = sourceFile
+	}
+	return aggregate
+}
+
+func resolveSuiteDurations(
+	suiteAggregates map[testSuiteKey]testSuiteAggregate,
+	testSuiteDurations map[string]map[string]testoptimization.TestSuiteDurationInfo,
+) {
+	for key, aggregate := range suiteAggregates {
+		aggregate.Duration = (aggregate.NumTests - aggregate.NumTestsSkipped) * int(time.Second)
+		if suiteInfo, ok := getTestSuiteDuration(testSuiteDurations, key); ok {
+			if p50, ok := parseDurationP50(suiteInfo); ok {
+				aggregate.Duration = p50
+			}
+		}
+		suiteAggregates[key] = aggregate
+	}
+}
+
+func addBackendSuiteAggregates(
+	suiteAggregates map[testSuiteKey]testSuiteAggregate,
+	testSuiteDurations map[string]map[string]testoptimization.TestSuiteDurationInfo,
+	testFiles map[string]struct{},
+	subdirPrefix string,
+) {
+	for module, suites := range testSuiteDurations {
+		for suite, suiteInfo := range suites {
+			key := testSuiteKey{Module: module, Suite: suite}
+			if _, ok := suiteAggregates[key]; ok {
+				continue
+			}
+
+			sourceFile := stripCwdSubdirPrefix(suiteInfo.SourceFile, subdirPrefix)
+			if _, ok := testFiles[sourceFile]; !ok {
+				continue
+			}
+
+			if duration, ok := parseDurationP50(suiteInfo); ok {
+				suiteAggregates[key] = testSuiteAggregate{
+					Module:          module,
+					Suite:           suite,
+					SourceFile:      sourceFile,
+					Duration:        duration,
+					NumTests:        1,
+					NumTestsSkipped: 0,
+				}
+			}
+		}
+	}
+}
+
+func getTestSuiteDuration(
+	testSuiteDurations map[string]map[string]testoptimization.TestSuiteDurationInfo,
+	key testSuiteKey,
+) (testoptimization.TestSuiteDurationInfo, bool) {
+	if suiteDurations, ok := testSuiteDurations[key.Module]; ok {
+		suiteInfo, ok := suiteDurations[key.Suite]
+		return suiteInfo, ok
+	}
+	return testoptimization.TestSuiteDurationInfo{}, false
+}
+
+func parseDurationP50(suiteInfo testoptimization.TestSuiteDurationInfo) (int, bool) {
+	p50, err := strconv.ParseInt(suiteInfo.Duration.P50, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return int(p50), true
+}
+
+func indexSuitesBySourceFile(suiteAggregates map[testSuiteKey]testSuiteAggregate) map[string][]testSuiteKey {
+	sourceFileLookup := make(map[string][]testSuiteKey)
+	for key, aggregate := range suiteAggregates {
+		if aggregate.SourceFile == "" {
+			continue
+		}
+
+		sourceFileLookup[aggregate.SourceFile] = append(sourceFileLookup[aggregate.SourceFile], key)
+	}
+	return sourceFileLookup
+}
+
+func (tr *TestRunner) weightedTestFiles() map[string]int {
+	testFileWeights := make(map[string]int, len(tr.testFiles))
+	for testFile := range tr.testFiles {
+		weight, ok := tr.testFileWeight(testFile)
+		if ok {
+			testFileWeights[testFile] = weight
+		}
+	}
+	return testFileWeights
+}
+
+func (tr *TestRunner) testFileWeight(testFile string) (int, bool) {
+	const defaultTestFileWeight = int(time.Second / time.Millisecond)
+	suiteKeys := tr.suitesBySourceFile[testFile]
+	if len(suiteKeys) == 0 {
+		return defaultTestFileWeight, true
+	}
+
+	var duration int
+	var hasRunnableSuite bool
+	for _, key := range suiteKeys {
+		aggregate := tr.suiteAggregates[key]
+		if aggregate.NumTests == aggregate.NumTestsSkipped {
+			continue
+		}
+		hasRunnableSuite = true
+		duration += aggregate.Duration
+	}
+	if !hasRunnableSuite {
+		return 0, false
+	}
+	if duration <= 0 {
+		return defaultTestFileWeight, true
+	}
+
+	weight := duration / int(time.Millisecond)
+	if weight < 1 {
+		return 1, true
+	}
+	return weight, true
 }

--- a/internal/runner/dd_test_optimization_test.go
+++ b/internal/runner/dd_test_optimization_test.go
@@ -409,6 +409,76 @@ func TestTestRunner_TestFileWeight_CountFallbackForMissingSuiteDuration(t *testi
 	}
 }
 
+func TestTestRunner_TestFileWeight_InvalidP50FallsBackForFullDiscoveryAggregate(t *testing.T) {
+	runner := NewWithDependencies(&MockPlatformDetector{}, &MockTestOptimizationClient{}, &MockTestSuiteDurationsClient{}, newDefaultMockCIProviderDetector())
+	runner.testFiles = map[string]struct{}{
+		"spec/file1_test.rb": {},
+	}
+	runner.suiteAggregates = map[testSuiteKey]testSuiteAggregate{
+		{Module: "rspec", Suite: "Suite1"}: {
+			Module:          "rspec",
+			Suite:           "Suite1",
+			SourceFile:      "spec/file1_test.rb",
+			NumTests:        3,
+			NumTestsSkipped: 1,
+		},
+	}
+
+	testSuiteDurations := map[string]map[string]testoptimization.TestSuiteDurationInfo{
+		"rspec": {
+			"Suite1": {
+				SourceFile: "spec/file1_test.rb",
+				Duration:   testoptimization.DurationPercentiles{P50: "not-a-number"},
+			},
+		},
+	}
+
+	resolveSuiteDurations(runner.suiteAggregates, testSuiteDurations)
+	runner.suitesBySourceFile = indexSuitesBySourceFile(runner.suiteAggregates)
+
+	aggregate := runner.suiteAggregates[testSuiteKey{Module: "rspec", Suite: "Suite1"}]
+	expectedTotalDuration := 3 * float64(time.Second)
+	if aggregate.TotalDuration != expectedTotalDuration {
+		t.Errorf("Expected invalid p50 to keep count-based total duration %.0f, got %.0f", expectedTotalDuration, aggregate.TotalDuration)
+	}
+
+	expectedEstimatedDuration := 2 * int(time.Second/time.Millisecond)
+	if weight, ok := runner.testFileWeight("spec/file1_test.rb"); !ok || weight != expectedEstimatedDuration {
+		t.Errorf("Expected invalid p50 to use runnable count fallback %d, got weight=%d ok=%t", expectedEstimatedDuration, weight, ok)
+	}
+}
+
+func TestTestRunner_TestFileWeight_SubMillisecondP50MinimumWeight(t *testing.T) {
+	runner := NewWithDependencies(&MockPlatformDetector{}, &MockTestOptimizationClient{}, &MockTestSuiteDurationsClient{}, newDefaultMockCIProviderDetector())
+	runner.testFiles = map[string]struct{}{
+		"spec/fast_test.rb": {},
+	}
+	runner.suiteAggregates = map[testSuiteKey]testSuiteAggregate{
+		{Module: "rspec", Suite: "FastSuite"}: {
+			Module:     "rspec",
+			Suite:      "FastSuite",
+			SourceFile: "spec/fast_test.rb",
+			NumTests:   1,
+		},
+	}
+
+	testSuiteDurations := map[string]map[string]testoptimization.TestSuiteDurationInfo{
+		"rspec": {
+			"FastSuite": {
+				SourceFile: "spec/fast_test.rb",
+				Duration:   testoptimization.DurationPercentiles{P50: "500000"},
+			},
+		},
+	}
+
+	resolveSuiteDurations(runner.suiteAggregates, testSuiteDurations)
+	runner.suitesBySourceFile = indexSuitesBySourceFile(runner.suiteAggregates)
+
+	if weight, ok := runner.testFileWeight("spec/fast_test.rb"); !ok || weight != 1 {
+		t.Errorf("Expected sub-millisecond p50 to use minimum weight 1, got weight=%d ok=%t", weight, ok)
+	}
+}
+
 func TestTestRunner_TestFileWeight_SkipsFullySkippedSuites(t *testing.T) {
 	runner := NewWithDependencies(&MockPlatformDetector{}, &MockTestOptimizationClient{}, &MockTestSuiteDurationsClient{}, newDefaultMockCIProviderDetector())
 	runner.testFiles = map[string]struct{}{
@@ -436,6 +506,53 @@ func TestTestRunner_TestFileWeight_SkipsFullySkippedSuites(t *testing.T) {
 
 	if weightedFiles := runner.weightedTestFiles(); len(weightedFiles) != 0 {
 		t.Errorf("Expected fully skipped suite file to be omitted from weighted files, got %v", weightedFiles)
+	}
+}
+
+func TestCalculateSavedTimePercentage_IgnoresInvalidDurationAggregates(t *testing.T) {
+	suiteAggregates := map[testSuiteKey]testSuiteAggregate{
+		{Module: "rspec", Suite: "ZeroTests"}: {
+			TotalDuration:     10,
+			EstimatedDuration: 5,
+			NumTests:          0,
+		},
+		{Module: "rspec", Suite: "ZeroDuration"}: {
+			TotalDuration:     0,
+			EstimatedDuration: 0,
+			NumTests:          1,
+		},
+		{Module: "rspec", Suite: "NegativeDuration"}: {
+			TotalDuration:     -10,
+			EstimatedDuration: 0,
+			NumTests:          1,
+		},
+	}
+
+	if percentage := calculateSavedTimePercentage(suiteAggregates); percentage != 0.0 {
+		t.Errorf("Expected invalid duration aggregates to produce 0 saved time percentage, got %.2f", percentage)
+	}
+}
+
+func TestIndexSuitesBySourceFile_IgnoresEmptySourceFile(t *testing.T) {
+	suiteAggregates := map[testSuiteKey]testSuiteAggregate{
+		{Module: "rspec", Suite: "MissingSource"}: {
+			Module: "rspec",
+			Suite:  "MissingSource",
+		},
+		{Module: "rspec", Suite: "WithSource"}: {
+			Module:     "rspec",
+			Suite:      "WithSource",
+			SourceFile: "spec/with_source_spec.rb",
+		},
+	}
+
+	suitesBySourceFile := indexSuitesBySourceFile(suiteAggregates)
+
+	if _, ok := suitesBySourceFile[""]; ok {
+		t.Error("Expected empty source file to be ignored")
+	}
+	if got := suitesBySourceFile["spec/with_source_spec.rb"]; len(got) != 1 || got[0] != (testSuiteKey{Module: "rspec", Suite: "WithSource"}) {
+		t.Errorf("Expected only suite with source file to be indexed, got %v", suitesBySourceFile)
 	}
 }
 

--- a/internal/runner/dd_test_optimization_test.go
+++ b/internal/runner/dd_test_optimization_test.go
@@ -14,6 +14,7 @@ import (
 
 	ciConstants "github.com/DataDog/ddtest/civisibility/constants"
 	ciUtils "github.com/DataDog/ddtest/civisibility/utils"
+	ciNet "github.com/DataDog/ddtest/civisibility/utils/net"
 	"github.com/DataDog/ddtest/internal/settings"
 	"github.com/DataDog/ddtest/internal/testoptimization"
 )
@@ -383,7 +384,7 @@ func TestTestRunner_TestFileWeight_CountFallbackForMissingSuiteDuration(t *testi
 		},
 	}
 
-	testSuiteDurations := map[string]map[string]testoptimization.TestSuiteDurationInfo{
+	runner.testSuiteDurations = map[string]map[string]testoptimization.TestSuiteDurationInfo{
 		"rspec": {
 			"Suite1": {
 				SourceFile: "spec/file1_test.rb",
@@ -392,7 +393,7 @@ func TestTestRunner_TestFileWeight_CountFallbackForMissingSuiteDuration(t *testi
 		},
 	}
 
-	resolveSuiteDurations(runner.suiteAggregates, testSuiteDurations)
+	runner.resolveSuiteDurations()
 	runner.suitesBySourceFile = indexSuitesBySourceFile(runner.suiteAggregates)
 
 	if weight, ok := runner.testFileWeight("spec/file1_test.rb"); !ok || weight != 11 {
@@ -424,7 +425,7 @@ func TestTestRunner_TestFileWeight_InvalidP50FallsBackForFullDiscoveryAggregate(
 		},
 	}
 
-	testSuiteDurations := map[string]map[string]testoptimization.TestSuiteDurationInfo{
+	runner.testSuiteDurations = map[string]map[string]testoptimization.TestSuiteDurationInfo{
 		"rspec": {
 			"Suite1": {
 				SourceFile: "spec/file1_test.rb",
@@ -433,7 +434,7 @@ func TestTestRunner_TestFileWeight_InvalidP50FallsBackForFullDiscoveryAggregate(
 		},
 	}
 
-	resolveSuiteDurations(runner.suiteAggregates, testSuiteDurations)
+	runner.resolveSuiteDurations()
 	runner.suitesBySourceFile = indexSuitesBySourceFile(runner.suiteAggregates)
 
 	aggregate := runner.suiteAggregates[testSuiteKey{Module: "rspec", Suite: "Suite1"}]
@@ -462,7 +463,7 @@ func TestTestRunner_TestFileWeight_SubMillisecondP50MinimumWeight(t *testing.T) 
 		},
 	}
 
-	testSuiteDurations := map[string]map[string]testoptimization.TestSuiteDurationInfo{
+	runner.testSuiteDurations = map[string]map[string]testoptimization.TestSuiteDurationInfo{
 		"rspec": {
 			"FastSuite": {
 				SourceFile: "spec/fast_test.rb",
@@ -471,7 +472,7 @@ func TestTestRunner_TestFileWeight_SubMillisecondP50MinimumWeight(t *testing.T) 
 		},
 	}
 
-	resolveSuiteDurations(runner.suiteAggregates, testSuiteDurations)
+	runner.resolveSuiteDurations()
 	runner.suitesBySourceFile = indexSuitesBySourceFile(runner.suiteAggregates)
 
 	if weight, ok := runner.testFileWeight("spec/fast_test.rb"); !ok || weight != 1 {
@@ -694,6 +695,66 @@ func TestTestRunner_PrepareTestOptimization_IgnoresBackendDurationsForUndiscover
 
 	if weight, ok := runner.testFileWeight("spec/discovered_spec.rb"); !ok || weight != int(time.Second/time.Millisecond) {
 		t.Errorf("Expected discovered file without backend aggregate to use default 1 second, got weight=%d ok=%t", weight, ok)
+	}
+}
+
+func TestTestRunner_PrepareTestOptimization_FastDiscoveryDoesNotRunStaleBackendFilesWhenSkippingDisabled(t *testing.T) {
+	ctx := context.Background()
+	ciUtils.ResetCITags()
+	t.Cleanup(ciUtils.ResetCITags)
+
+	mockFramework := &MockFramework{
+		FrameworkName:    "rspec",
+		TestFiles:        []string{"spec/local_spec.rb"},
+		DiscoverTestsErr: errors.New("full discovery cancelled because test skipping is disabled"),
+	}
+	mockPlatform := &MockPlatform{
+		PlatformName: "ruby",
+		Tags: map[string]string{
+			ciConstants.GitRepositoryURL: "github.com/DataDog/ddtest",
+		},
+		Framework: mockFramework,
+	}
+	mockOptimizationClient := &MockTestOptimizationClient{
+		Settings: &ciNet.SettingsResponseData{
+			ItrEnabled:    true,
+			TestsSkipping: false,
+		},
+	}
+	mockDurationsClient := &MockTestSuiteDurationsClient{
+		Durations: map[string]map[string]testoptimization.TestSuiteDurationInfo{
+			"rspec": {
+				"LocalSuite": {
+					SourceFile: "spec/local_spec.rb",
+					Duration:   testoptimization.DurationPercentiles{P50: "11000000"},
+				},
+				"DeletedSuite": {
+					SourceFile: "spec/deleted_spec.rb",
+					Duration:   testoptimization.DurationPercentiles{P50: "99000000"},
+				},
+			},
+		},
+	}
+
+	runner := NewWithDependencies(&MockPlatformDetector{Platform: mockPlatform}, mockOptimizationClient, mockDurationsClient, newDefaultMockCIProviderDetector())
+
+	err := runner.PrepareTestOptimization(ctx)
+	if err != nil {
+		t.Fatalf("PrepareTestOptimization() should not fail, got: %v", err)
+	}
+
+	weightedFiles := runner.weightedTestFiles()
+	if len(weightedFiles) != 1 {
+		t.Fatalf("Expected only local fast-discovery file to be runnable, got %v", weightedFiles)
+	}
+	if _, ok := weightedFiles["spec/local_spec.rb"]; !ok {
+		t.Errorf("Expected local fast-discovery file to be runnable, got %v", weightedFiles)
+	}
+	if _, ok := weightedFiles["spec/deleted_spec.rb"]; ok {
+		t.Errorf("Expected stale backend file not to be runnable, got %v", weightedFiles)
+	}
+	if _, ok := runner.suiteAggregates[testSuiteKey{Module: "rspec", Suite: "DeletedSuite"}]; ok {
+		t.Errorf("Expected stale backend suite not to be added, got aggregates %v", runner.suiteAggregates)
 	}
 }
 

--- a/internal/runner/dd_test_optimization_test.go
+++ b/internal/runner/dd_test_optimization_test.go
@@ -1,20 +1,38 @@
 package runner
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	ciConstants "github.com/DataDog/ddtest/civisibility/constants"
+	ciUtils "github.com/DataDog/ddtest/civisibility/utils"
 	"github.com/DataDog/ddtest/internal/settings"
 	"github.com/DataDog/ddtest/internal/testoptimization"
 )
 
+func captureLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	originalLogger := slog.Default()
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	slog.SetDefault(logger)
+	t.Cleanup(func() {
+		slog.SetDefault(originalLogger)
+	})
+	return &buf
+}
+
 func TestTestRunner_PrepareTestOptimization_Success(t *testing.T) {
 	ctx := context.Background()
+	ciUtils.ResetCITags()
+	t.Cleanup(ciUtils.ResetCITags)
 
 	// Setup mocks
 	mockFramework := &MockFramework{
@@ -46,8 +64,18 @@ func TestTestRunner_PrepareTestOptimization_Success(t *testing.T) {
 			"TestSuite3.test4.": true, // Skip test4
 		},
 	}
+	mockDurationsClient := &MockTestSuiteDurationsClient{
+		Durations: map[string]map[string]testoptimization.TestSuiteDurationInfo{
+			"module1": {
+				"suite1": {
+					SourceFile: "test/file1_test.rb",
+					Duration:   testoptimization.DurationPercentiles{P50: "1", P90: "2"},
+				},
+			},
+		},
+	}
 
-	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, newDefaultMockCIProviderDetector())
+	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, mockDurationsClient, newDefaultMockCIProviderDetector())
 
 	err := runner.PrepareTestOptimization(ctx)
 
@@ -92,6 +120,151 @@ func TestTestRunner_PrepareTestOptimization_Success(t *testing.T) {
 		t.Errorf("PrepareTestOptimization() should calculate skippable percentage as %.2f, got %.2f",
 			expectedPercentage, runner.skippablePercentage)
 	}
+
+	if !mockDurationsClient.Called {
+		t.Error("PrepareTestOptimization() should fetch test suite durations")
+	}
+}
+
+func TestTestRunner_PrepareTestOptimization_DurationsErrorContinues(t *testing.T) {
+	ctx := context.Background()
+	ciUtils.ResetCITags()
+	t.Cleanup(ciUtils.ResetCITags)
+	logs := captureLogs(t)
+
+	mockFramework := &MockFramework{
+		FrameworkName: "rspec",
+		Tests: []testoptimization.Test{
+			{Suite: "Suite", Name: "test1", Parameters: "", SuiteSourceFile: "spec/file1_test.rb"},
+		},
+	}
+	mockPlatform := &MockPlatform{
+		PlatformName: "ruby",
+		Tags: map[string]string{
+			ciConstants.GitRepositoryURL: "github.com/DataDog/ddtest",
+		},
+		Framework: mockFramework,
+	}
+	mockPlatformDetector := &MockPlatformDetector{Platform: mockPlatform}
+	mockOptimizationClient := &MockTestOptimizationClient{}
+	mockDurationsClient := &MockTestSuiteDurationsClient{Err: errors.New("durations backend failed")}
+
+	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, mockDurationsClient, newDefaultMockCIProviderDetector())
+
+	err := runner.PrepareTestOptimization(ctx)
+	if err != nil {
+		t.Fatalf("PrepareTestOptimization() should not fail when durations API errors, got: %v", err)
+	}
+
+	if len(runner.testSuiteDurations) != 0 {
+		t.Errorf("Expected empty in-memory test suite durations on error, got %v", runner.testSuiteDurations)
+	}
+
+	if !strings.Contains(logs.String(), "level=ERROR") || !strings.Contains(logs.String(), "Test durations API errored") {
+		t.Errorf("Expected ERROR log for durations API failure, got logs: %s", logs.String())
+	}
+}
+
+func TestTestRunner_PrepareTestOptimization_EmptyDurationsWarns(t *testing.T) {
+	ctx := context.Background()
+	ciUtils.ResetCITags()
+	t.Cleanup(ciUtils.ResetCITags)
+	logs := captureLogs(t)
+
+	mockFramework := &MockFramework{
+		FrameworkName: "rspec",
+		Tests: []testoptimization.Test{
+			{Suite: "Suite", Name: "test1", Parameters: "", SuiteSourceFile: "spec/file1_test.rb"},
+		},
+	}
+	mockPlatform := &MockPlatform{
+		PlatformName: "ruby",
+		Tags: map[string]string{
+			ciConstants.GitRepositoryURL: "github.com/DataDog/ddtest",
+		},
+		Framework: mockFramework,
+	}
+	mockPlatformDetector := &MockPlatformDetector{Platform: mockPlatform}
+	mockOptimizationClient := &MockTestOptimizationClient{}
+	mockDurationsClient := &MockTestSuiteDurationsClient{
+		Durations: map[string]map[string]testoptimization.TestSuiteDurationInfo{},
+	}
+
+	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, mockDurationsClient, newDefaultMockCIProviderDetector())
+
+	err := runner.PrepareTestOptimization(ctx)
+	if err != nil {
+		t.Fatalf("PrepareTestOptimization() should not fail with empty durations, got: %v", err)
+	}
+
+	if len(runner.testSuiteDurations) != 0 {
+		t.Errorf("Expected empty in-memory test suite durations on empty response, got %v", runner.testSuiteDurations)
+	}
+
+	if !strings.Contains(logs.String(), "level=WARN") || !strings.Contains(logs.String(), "Test durations API returned no test suites") {
+		t.Errorf("Expected WARN log for empty durations response, got logs: %s", logs.String())
+	}
+}
+
+func TestTestRunner_PrepareTestOptimization_NonEmptyDurationsStoredWithoutChangingWeights(t *testing.T) {
+	ctx := context.Background()
+	ciUtils.ResetCITags()
+	t.Cleanup(ciUtils.ResetCITags)
+	logs := captureLogs(t)
+
+	mockFramework := &MockFramework{
+		FrameworkName: "rspec",
+		Tests: []testoptimization.Test{
+			{Suite: "Suite1", Name: "test1", Parameters: "", SuiteSourceFile: "spec/file1_test.rb"},
+			{Suite: "Suite1", Name: "test2", Parameters: "", SuiteSourceFile: "spec/file1_test.rb"},
+			{Suite: "Suite2", Name: "test3", Parameters: "", SuiteSourceFile: "spec/file2_test.rb"},
+		},
+	}
+	mockPlatform := &MockPlatform{
+		PlatformName: "ruby",
+		Tags: map[string]string{
+			ciConstants.GitRepositoryURL: "github.com/DataDog/ddtest",
+		},
+		Framework: mockFramework,
+	}
+	mockPlatformDetector := &MockPlatformDetector{Platform: mockPlatform}
+	mockOptimizationClient := &MockTestOptimizationClient{}
+	mockDurationsClient := &MockTestSuiteDurationsClient{
+		Durations: map[string]map[string]testoptimization.TestSuiteDurationInfo{
+			"module1": {
+				"suite1": {
+					SourceFile: "spec/file1_test.rb",
+					Duration:   testoptimization.DurationPercentiles{P50: "10", P90: "20"},
+				},
+				"suite2": {
+					SourceFile: "spec/file2_test.rb",
+					Duration:   testoptimization.DurationPercentiles{P50: "30", P90: "40"},
+				},
+			},
+		},
+	}
+
+	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, mockDurationsClient, newDefaultMockCIProviderDetector())
+
+	err := runner.PrepareTestOptimization(ctx)
+	if err != nil {
+		t.Fatalf("PrepareTestOptimization() should not fail with durations data, got: %v", err)
+	}
+
+	if len(runner.testSuiteDurations) != 1 {
+		t.Fatalf("Expected stored durations data, got %v", runner.testSuiteDurations)
+	}
+
+	if runner.testFiles["spec/file1_test.rb"] != 2 {
+		t.Errorf("Expected file1 weight to remain test-count based (2), got %d", runner.testFiles["spec/file1_test.rb"])
+	}
+	if runner.testFiles["spec/file2_test.rb"] != 1 {
+		t.Errorf("Expected file2 weight to remain test-count based (1), got %d", runner.testFiles["spec/file2_test.rb"])
+	}
+
+	if !strings.Contains(logs.String(), "level=DEBUG") || !strings.Contains(logs.String(), "Found test suite durations") || !strings.Contains(logs.String(), "testSuitesCount=2") {
+		t.Errorf("Expected DEBUG log for non-empty durations response, got logs: %s", logs.String())
+	}
 }
 
 func TestTestRunner_PrepareTestOptimization_PlatformDetectionError(t *testing.T) {
@@ -103,7 +276,7 @@ func TestTestRunner_PrepareTestOptimization_PlatformDetectionError(t *testing.T)
 
 	mockOptimizationClient := &MockTestOptimizationClient{}
 
-	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, newDefaultMockCIProviderDetector())
+	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, &MockTestSuiteDurationsClient{}, newDefaultMockCIProviderDetector())
 
 	err := runner.PrepareTestOptimization(ctx)
 
@@ -130,7 +303,7 @@ func TestTestRunner_PrepareTestOptimization_TagsCreationError(t *testing.T) {
 
 	mockOptimizationClient := &MockTestOptimizationClient{}
 
-	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, newDefaultMockCIProviderDetector())
+	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, &MockTestSuiteDurationsClient{}, newDefaultMockCIProviderDetector())
 
 	err := runner.PrepareTestOptimization(ctx)
 
@@ -166,7 +339,7 @@ func TestTestRunner_PrepareTestOptimization_OptimizationClientInitError(t *testi
 		InitializeErr: errors.New("client initialization failed"),
 	}
 
-	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, newDefaultMockCIProviderDetector())
+	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, &MockTestSuiteDurationsClient{}, newDefaultMockCIProviderDetector())
 
 	err := runner.PrepareTestOptimization(ctx)
 
@@ -194,7 +367,7 @@ func TestTestRunner_PrepareTestOptimization_FrameworkDetectionError(t *testing.T
 
 	mockOptimizationClient := &MockTestOptimizationClient{}
 
-	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, newDefaultMockCIProviderDetector())
+	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, &MockTestSuiteDurationsClient{}, newDefaultMockCIProviderDetector())
 
 	err := runner.PrepareTestOptimization(ctx)
 
@@ -226,7 +399,7 @@ func TestTestRunner_PrepareTestOptimization_TestDiscoveryError(t *testing.T) {
 
 	mockOptimizationClient := &MockTestOptimizationClient{}
 
-	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, newDefaultMockCIProviderDetector())
+	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, &MockTestSuiteDurationsClient{}, newDefaultMockCIProviderDetector())
 
 	err := runner.PrepareTestOptimization(ctx)
 
@@ -255,7 +428,7 @@ func TestTestRunner_PrepareTestOptimization_EmptyTests(t *testing.T) {
 	mockPlatformDetector := &MockPlatformDetector{Platform: mockPlatform}
 	mockOptimizationClient := &MockTestOptimizationClient{SkippableTests: map[string]bool{}}
 
-	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, newDefaultMockCIProviderDetector())
+	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, &MockTestSuiteDurationsClient{}, newDefaultMockCIProviderDetector())
 
 	err := runner.PrepareTestOptimization(ctx)
 
@@ -296,7 +469,7 @@ func TestTestRunner_PrepareTestOptimization_AllTestsSkipped(t *testing.T) {
 		},
 	}
 
-	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, newDefaultMockCIProviderDetector())
+	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, &MockTestSuiteDurationsClient{}, newDefaultMockCIProviderDetector())
 
 	err := runner.PrepareTestOptimization(ctx)
 
@@ -354,7 +527,7 @@ func TestTestRunner_PrepareTestOptimization_RuntimeTagsOverride(t *testing.T) {
 		SkippableTests: map[string]bool{},
 	}
 
-	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, newDefaultMockCIProviderDetector())
+	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, &MockTestSuiteDurationsClient{}, newDefaultMockCIProviderDetector())
 
 	err := runner.PrepareTestOptimization(ctx)
 
@@ -419,7 +592,7 @@ func TestTestRunner_PrepareTestOptimization_RuntimeTagsOverrideInvalidJSON(t *te
 
 	mockOptimizationClient := &MockTestOptimizationClient{}
 
-	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, newDefaultMockCIProviderDetector())
+	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, &MockTestSuiteDurationsClient{}, newDefaultMockCIProviderDetector())
 
 	err := runner.PrepareTestOptimization(ctx)
 
@@ -473,7 +646,7 @@ func TestTestRunner_PrepareTestOptimization_NoRuntimeTagsOverride(t *testing.T) 
 		SkippableTests: map[string]bool{},
 	}
 
-	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, newDefaultMockCIProviderDetector())
+	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, &MockTestSuiteDurationsClient{}, newDefaultMockCIProviderDetector())
 
 	err := runner.PrepareTestOptimization(ctx)
 
@@ -558,7 +731,7 @@ func TestPrepareTestOptimization_ITRFullDiscovery_SubdirRootRelativePath_Normali
 		SkippableTests: map[string]bool{}, // No tests skipped (ITR enabled but all tests need to run)
 	}
 
-	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, newDefaultMockCIProviderDetector())
+	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, &MockTestSuiteDurationsClient{}, newDefaultMockCIProviderDetector())
 
 	err := runner.PrepareTestOptimization(ctx)
 	if err != nil {
@@ -622,7 +795,7 @@ func TestPrepareTestOptimization_RepoRootRun_LeavesRepoRelativePathsUnchanged(t 
 		SkippableTests: map[string]bool{},
 	}
 
-	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, newDefaultMockCIProviderDetector())
+	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, &MockTestSuiteDurationsClient{}, newDefaultMockCIProviderDetector())
 
 	err := runner.PrepareTestOptimization(ctx)
 	if err != nil {
@@ -659,7 +832,7 @@ func TestPrepareTestOptimization_FastDiscovery_PathsRemainUnchanged(t *testing.T
 		SkippableTests: map[string]bool{},
 	}
 
-	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, newDefaultMockCIProviderDetector())
+	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, &MockTestSuiteDurationsClient{}, newDefaultMockCIProviderDetector())
 
 	err := runner.PrepareTestOptimization(ctx)
 	if err != nil {
@@ -724,7 +897,7 @@ func TestPrepareTestOptimization_ITRPathNormalization_PrefixMismatchUnchanged(t 
 		SkippableTests: map[string]bool{},
 	}
 
-	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, newDefaultMockCIProviderDetector())
+	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, &MockTestSuiteDurationsClient{}, newDefaultMockCIProviderDetector())
 
 	err := runner.PrepareTestOptimization(ctx)
 	if err != nil {
@@ -805,7 +978,7 @@ func TestPrepareTestOptimization_ITRSubdir_SkipMatching_WithSuitePathsMatchingCw
 		},
 	}
 
-	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, newDefaultMockCIProviderDetector())
+	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, &MockTestSuiteDurationsClient{}, newDefaultMockCIProviderDetector())
 
 	err := runner.PrepareTestOptimization(ctx)
 	if err != nil {

--- a/internal/runner/dd_test_optimization_test.go
+++ b/internal/runner/dd_test_optimization_test.go
@@ -133,8 +133,8 @@ func TestTestRunner_PrepareTestOptimization_Success(t *testing.T) {
 		t.Errorf("Expected Suite1 skipped test count 1, got %d", suite1.NumTestsSkipped)
 	}
 
-	if weight, ok := runner.testFileWeight("test/file1_test.rb"); !ok || weight != 7 {
-		t.Errorf("Expected file1 weight to use backend p50 converted to 7ms, got weight=%d ok=%t", weight, ok)
+	if weight, ok := runner.testFileWeight("test/file1_test.rb"); !ok || weight != 3 {
+		t.Errorf("Expected file1 weight to use backend p50 adjusted for skipped tests and converted to 3ms, got weight=%d ok=%t", weight, ok)
 	}
 
 	expectedFile2Weight := int(time.Second / time.Millisecond)
@@ -307,6 +307,60 @@ func TestTestRunner_PrepareTestOptimization_NonEmptyDurationsUsesP50ForMatchingS
 	}
 }
 
+func TestTestRunner_PrepareTestOptimization_SkippablePercentageUsesDurations(t *testing.T) {
+	ctx := context.Background()
+	ciUtils.ResetCITags()
+	t.Cleanup(ciUtils.ResetCITags)
+
+	mockFramework := &MockFramework{
+		FrameworkName: "rspec",
+		TestFiles:     []string{"spec/slow_spec.rb", "spec/fast_spec.rb"},
+		Tests: []testoptimization.Test{
+			{Module: "rspec", Suite: "SlowSuite", Name: "test1", SuiteSourceFile: "spec/slow_spec.rb"},
+			{Module: "rspec", Suite: "SlowSuite", Name: "test2", SuiteSourceFile: "spec/slow_spec.rb"},
+			{Module: "rspec", Suite: "FastSuite", Name: "test1", SuiteSourceFile: "spec/fast_spec.rb"},
+			{Module: "rspec", Suite: "FastSuite", Name: "test2", SuiteSourceFile: "spec/fast_spec.rb"},
+		},
+	}
+	mockPlatform := &MockPlatform{
+		PlatformName: "ruby",
+		Tags: map[string]string{
+			ciConstants.GitRepositoryURL: "github.com/DataDog/ddtest",
+		},
+		Framework: mockFramework,
+	}
+	skippedTest := mockFramework.Tests[0]
+	mockOptimizationClient := &MockTestOptimizationClient{
+		SkippableTests: map[string]bool{skippedTest.FQN(): true},
+	}
+	mockDurationsClient := &MockTestSuiteDurationsClient{
+		Durations: map[string]map[string]testoptimization.TestSuiteDurationInfo{
+			"rspec": {
+				"SlowSuite": {
+					SourceFile: "spec/slow_spec.rb",
+					Duration:   testoptimization.DurationPercentiles{P50: "8000000000"},
+				},
+				"FastSuite": {
+					SourceFile: "spec/fast_spec.rb",
+					Duration:   testoptimization.DurationPercentiles{P50: "2000000000"},
+				},
+			},
+		},
+	}
+
+	runner := NewWithDependencies(&MockPlatformDetector{Platform: mockPlatform}, mockOptimizationClient, mockDurationsClient, newDefaultMockCIProviderDetector())
+
+	err := runner.PrepareTestOptimization(ctx)
+	if err != nil {
+		t.Fatalf("PrepareTestOptimization() should not fail, got: %v", err)
+	}
+
+	expectedPercentage := 40.0
+	if runner.skippablePercentage != expectedPercentage {
+		t.Errorf("Expected skippable percentage to use saved time %.2f, got %.2f", expectedPercentage, runner.skippablePercentage)
+	}
+}
+
 func TestTestRunner_TestFileWeight_CountFallbackForMissingSuiteDuration(t *testing.T) {
 	runner := NewWithDependencies(&MockPlatformDetector{}, &MockTestOptimizationClient{}, &MockTestSuiteDurationsClient{}, newDefaultMockCIProviderDetector())
 	runner.testFiles = map[string]struct{}{
@@ -362,12 +416,12 @@ func TestTestRunner_TestFileWeight_SkipsFullySkippedSuites(t *testing.T) {
 	}
 	runner.suiteAggregates = map[testSuiteKey]testSuiteAggregate{
 		{Module: "rspec", Suite: "SkippedSuite"}: {
-			Module:          "rspec",
-			Suite:           "SkippedSuite",
-			SourceFile:      "spec/skipped_test.rb",
-			Duration:        int(time.Second),
-			NumTests:        2,
-			NumTestsSkipped: 2,
+			Module:            "rspec",
+			Suite:             "SkippedSuite",
+			SourceFile:        "spec/skipped_test.rb",
+			EstimatedDuration: float64(time.Second),
+			NumTests:          2,
+			NumTestsSkipped:   2,
 		},
 	}
 	runner.suitesBySourceFile = indexSuitesBySourceFile(runner.suiteAggregates)

--- a/internal/runner/dd_test_optimization_test.go
+++ b/internal/runner/dd_test_optimization_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	ciConstants "github.com/DataDog/ddtest/civisibility/constants"
 	ciUtils "github.com/DataDog/ddtest/civisibility/utils"
@@ -37,11 +38,16 @@ func TestTestRunner_PrepareTestOptimization_Success(t *testing.T) {
 	// Setup mocks
 	mockFramework := &MockFramework{
 		FrameworkName: "rspec",
+		TestFiles: []string{
+			"test/file1_test.rb",
+			"test/file2_test.rb",
+			"test/fast_only_test.rb",
+		},
 		Tests: []testoptimization.Test{
-			{Suite: "TestSuite1", Name: "test1", Parameters: "", SuiteSourceFile: "test/file1_test.rb"},
-			{Suite: "TestSuite1", Name: "test2", Parameters: "", SuiteSourceFile: "test/file1_test.rb"},
-			{Suite: "TestSuite2", Name: "test3", Parameters: "", SuiteSourceFile: "test/file2_test.rb"},
-			{Suite: "TestSuite3", Name: "test4", Parameters: "", SuiteSourceFile: "test/file3_test.rb"},
+			{Module: "rspec", Suite: "TestSuite1", Name: "test1", Parameters: "", SuiteSourceFile: "test/file1_test.rb"},
+			{Module: "rspec", Suite: "TestSuite1", Name: "test2", Parameters: "", SuiteSourceFile: "test/file1_test.rb"},
+			{Module: "rspec", Suite: "TestSuite2", Name: "test3", Parameters: "", SuiteSourceFile: "test/file2_test.rb"},
+			{Module: "rspec", Suite: "TestSuite3", Name: "test4", Parameters: "", SuiteSourceFile: "test/file3_test.rb"},
 		},
 	}
 
@@ -66,10 +72,10 @@ func TestTestRunner_PrepareTestOptimization_Success(t *testing.T) {
 	}
 	mockDurationsClient := &MockTestSuiteDurationsClient{
 		Durations: map[string]map[string]testoptimization.TestSuiteDurationInfo{
-			"module1": {
-				"suite1": {
+			"rspec": {
+				"TestSuite1": {
 					SourceFile: "test/file1_test.rb",
-					Duration:   testoptimization.DurationPercentiles{P50: "1", P90: "2"},
+					Duration:   testoptimization.DurationPercentiles{P50: "7000000", P90: "2000000"},
 				},
 			},
 		},
@@ -98,20 +104,46 @@ func TestTestRunner_PrepareTestOptimization_Success(t *testing.T) {
 		t.Error("PrepareTestOptimization() should shutdown optimization client")
 	}
 
-	// Verify test files were calculated correctly (should include file1 and file2, but not file3)
 	expectedFiles := map[string]bool{
-		"test/file1_test.rb": true, // test1 is not skipped
-		"test/file2_test.rb": true, // test3 is not skipped
+		"test/file1_test.rb":     true, // test1 is not skipped
+		"test/file2_test.rb":     true, // test3 is not skipped
+		"test/file3_test.rb":     true, // test4 is skipped but the source file is discovered
+		"test/fast_only_test.rb": true, // from fast discovery only
 	}
 
-	if len(runner.testFiles) != 2 {
-		t.Errorf("PrepareTestOptimization() should result in 2 test files, got %d", len(runner.testFiles))
+	if len(runner.testFiles) != len(expectedFiles) {
+		t.Errorf("PrepareTestOptimization() should result in %d test files, got %d", len(expectedFiles), len(runner.testFiles))
+	}
+
+	if weightedFiles := runner.weightedTestFiles(); len(weightedFiles) != 3 {
+		t.Errorf("Expected weighted files to omit fully skipped file and keep 3 files, got %v", weightedFiles)
 	}
 
 	for file := range runner.testFiles {
 		if !expectedFiles[file] {
 			t.Errorf("Unexpected test file: %s", file)
 		}
+	}
+
+	suite1 := runner.suiteAggregates[testSuiteKey{Module: "rspec", Suite: "TestSuite1"}]
+	if suite1.NumTests != 2 {
+		t.Errorf("Expected Suite1 total test count 2, got %d", suite1.NumTests)
+	}
+	if suite1.NumTestsSkipped != 1 {
+		t.Errorf("Expected Suite1 skipped test count 1, got %d", suite1.NumTestsSkipped)
+	}
+
+	if weight, ok := runner.testFileWeight("test/file1_test.rb"); !ok || weight != 7 {
+		t.Errorf("Expected file1 weight to use backend p50 converted to 7ms, got weight=%d ok=%t", weight, ok)
+	}
+
+	expectedFile2Weight := int(time.Second / time.Millisecond)
+	if weight, ok := runner.testFileWeight("test/file2_test.rb"); !ok || weight != expectedFile2Weight {
+		t.Errorf("Expected file2 weight to use count fallback %d, got weight=%d ok=%t", expectedFile2Weight, weight, ok)
+	}
+
+	if weight, ok := runner.testFileWeight("test/fast_only_test.rb"); !ok || weight != expectedFile2Weight {
+		t.Errorf("Expected fast-only file weight to use default %d, got weight=%d ok=%t", expectedFile2Weight, weight, ok)
 	}
 
 	// Verify skippable percentage was calculated correctly (2 out of 4 tests skipped = 50%)
@@ -206,7 +238,7 @@ func TestTestRunner_PrepareTestOptimization_EmptyDurationsWarns(t *testing.T) {
 	}
 }
 
-func TestTestRunner_PrepareTestOptimization_NonEmptyDurationsStoredWithoutChangingWeights(t *testing.T) {
+func TestTestRunner_PrepareTestOptimization_NonEmptyDurationsUsesP50ForMatchingSuites(t *testing.T) {
 	ctx := context.Background()
 	ciUtils.ResetCITags()
 	t.Cleanup(ciUtils.ResetCITags)
@@ -214,10 +246,11 @@ func TestTestRunner_PrepareTestOptimization_NonEmptyDurationsStoredWithoutChangi
 
 	mockFramework := &MockFramework{
 		FrameworkName: "rspec",
+		TestFiles:     []string{"spec/file1_test.rb", "spec/file2_test.rb"},
 		Tests: []testoptimization.Test{
-			{Suite: "Suite1", Name: "test1", Parameters: "", SuiteSourceFile: "spec/file1_test.rb"},
-			{Suite: "Suite1", Name: "test2", Parameters: "", SuiteSourceFile: "spec/file1_test.rb"},
-			{Suite: "Suite2", Name: "test3", Parameters: "", SuiteSourceFile: "spec/file2_test.rb"},
+			{Module: "rspec", Suite: "Suite1", Name: "test1", Parameters: "", SuiteSourceFile: "spec/file1_test.rb"},
+			{Module: "rspec", Suite: "Suite1", Name: "test2", Parameters: "", SuiteSourceFile: "spec/file1_test.rb"},
+			{Module: "rspec", Suite: "Suite2", Name: "test3", Parameters: "", SuiteSourceFile: "spec/file2_test.rb"},
 		},
 	}
 	mockPlatform := &MockPlatform{
@@ -231,14 +264,14 @@ func TestTestRunner_PrepareTestOptimization_NonEmptyDurationsStoredWithoutChangi
 	mockOptimizationClient := &MockTestOptimizationClient{}
 	mockDurationsClient := &MockTestSuiteDurationsClient{
 		Durations: map[string]map[string]testoptimization.TestSuiteDurationInfo{
-			"module1": {
-				"suite1": {
+			"rspec": {
+				"Suite1": {
 					SourceFile: "spec/file1_test.rb",
-					Duration:   testoptimization.DurationPercentiles{P50: "10", P90: "20"},
+					Duration:   testoptimization.DurationPercentiles{P50: "10000000", P90: "20000000"},
 				},
-				"suite2": {
+				"Suite2": {
 					SourceFile: "spec/file2_test.rb",
-					Duration:   testoptimization.DurationPercentiles{P50: "30", P90: "40"},
+					Duration:   testoptimization.DurationPercentiles{P50: "30000000", P90: "40000000"},
 				},
 			},
 		},
@@ -255,15 +288,337 @@ func TestTestRunner_PrepareTestOptimization_NonEmptyDurationsStoredWithoutChangi
 		t.Fatalf("Expected stored durations data, got %v", runner.testSuiteDurations)
 	}
 
-	if runner.testFiles["spec/file1_test.rb"] != 2 {
-		t.Errorf("Expected file1 weight to remain test-count based (2), got %d", runner.testFiles["spec/file1_test.rb"])
+	if _, ok := runner.testFiles["spec/file1_test.rb"]; !ok {
+		t.Error("Expected file1 in test files")
 	}
-	if runner.testFiles["spec/file2_test.rb"] != 1 {
-		t.Errorf("Expected file2 weight to remain test-count based (1), got %d", runner.testFiles["spec/file2_test.rb"])
+	if _, ok := runner.testFiles["spec/file2_test.rb"]; !ok {
+		t.Error("Expected file2 in test files")
+	}
+
+	if weight, ok := runner.testFileWeight("spec/file1_test.rb"); !ok || weight != 10 {
+		t.Errorf("Expected file1 weight to use backend p50 converted to 10ms, got weight=%d ok=%t", weight, ok)
+	}
+	if weight, ok := runner.testFileWeight("spec/file2_test.rb"); !ok || weight != 30 {
+		t.Errorf("Expected file2 weight to use backend p50 converted to 30ms, got weight=%d ok=%t", weight, ok)
 	}
 
 	if !strings.Contains(logs.String(), "level=DEBUG") || !strings.Contains(logs.String(), "Found test suite durations") || !strings.Contains(logs.String(), "testSuitesCount=2") {
 		t.Errorf("Expected DEBUG log for non-empty durations response, got logs: %s", logs.String())
+	}
+}
+
+func TestTestRunner_TestFileWeight_CountFallbackForMissingSuiteDuration(t *testing.T) {
+	runner := NewWithDependencies(&MockPlatformDetector{}, &MockTestOptimizationClient{}, &MockTestSuiteDurationsClient{}, newDefaultMockCIProviderDetector())
+	runner.testFiles = map[string]struct{}{
+		"spec/file1_test.rb":   {},
+		"spec/file2_test.rb":   {},
+		"spec/unknown_test.rb": {},
+	}
+	runner.suiteAggregates = map[testSuiteKey]testSuiteAggregate{
+		{Module: "rspec", Suite: "Suite1"}: {
+			Module:     "rspec",
+			Suite:      "Suite1",
+			SourceFile: "spec/file1_test.rb",
+			NumTests:   2,
+		},
+		{Module: "rspec", Suite: "Suite2"}: {
+			Module:     "rspec",
+			Suite:      "Suite2",
+			SourceFile: "spec/file2_test.rb",
+			NumTests:   3,
+		},
+	}
+
+	testSuiteDurations := map[string]map[string]testoptimization.TestSuiteDurationInfo{
+		"rspec": {
+			"Suite1": {
+				SourceFile: "spec/file1_test.rb",
+				Duration:   testoptimization.DurationPercentiles{P50: "11000000", P90: "22000000"},
+			},
+		},
+	}
+
+	resolveSuiteDurations(runner.suiteAggregates, testSuiteDurations)
+	runner.suitesBySourceFile = indexSuitesBySourceFile(runner.suiteAggregates)
+
+	if weight, ok := runner.testFileWeight("spec/file1_test.rb"); !ok || weight != 11 {
+		t.Errorf("Expected Suite1 file weight to use p50 converted to 11ms, got weight=%d ok=%t", weight, ok)
+	}
+
+	expectedSuite2Weight := 3 * int(time.Second/time.Millisecond)
+	if weight, ok := runner.testFileWeight("spec/file2_test.rb"); !ok || weight != expectedSuite2Weight {
+		t.Errorf("Expected Suite2 file weight to use count fallback %d, got weight=%d ok=%t", expectedSuite2Weight, weight, ok)
+	}
+
+	if weight, ok := runner.testFileWeight("spec/unknown_test.rb"); !ok || weight != int(time.Second/time.Millisecond) {
+		t.Errorf("Expected unknown file weight to use default 1 second, got weight=%d ok=%t", weight, ok)
+	}
+}
+
+func TestTestRunner_TestFileWeight_SkipsFullySkippedSuites(t *testing.T) {
+	runner := NewWithDependencies(&MockPlatformDetector{}, &MockTestOptimizationClient{}, &MockTestSuiteDurationsClient{}, newDefaultMockCIProviderDetector())
+	runner.testFiles = map[string]struct{}{
+		"spec/skipped_test.rb": {},
+	}
+	runner.suiteAggregates = map[testSuiteKey]testSuiteAggregate{
+		{Module: "rspec", Suite: "SkippedSuite"}: {
+			Module:          "rspec",
+			Suite:           "SkippedSuite",
+			SourceFile:      "spec/skipped_test.rb",
+			Duration:        int(time.Second),
+			NumTests:        2,
+			NumTestsSkipped: 2,
+		},
+	}
+	runner.suitesBySourceFile = indexSuitesBySourceFile(runner.suiteAggregates)
+
+	if _, ok := runner.suitesBySourceFile["spec/skipped_test.rb"]; !ok {
+		t.Fatal("Expected fully skipped suite to be indexed by source file")
+	}
+
+	if weight, ok := runner.testFileWeight("spec/skipped_test.rb"); ok || weight != 0 {
+		t.Errorf("Expected fully skipped suite file to have no weight, got weight=%d ok=%t", weight, ok)
+	}
+
+	if weightedFiles := runner.weightedTestFiles(); len(weightedFiles) != 0 {
+		t.Errorf("Expected fully skipped suite file to be omitted from weighted files, got %v", weightedFiles)
+	}
+}
+
+func TestTestRunner_PrepareTestOptimization_FastDiscoveryUsesBackendDurations(t *testing.T) {
+	ctx := context.Background()
+	ciUtils.ResetCITags()
+	t.Cleanup(ciUtils.ResetCITags)
+
+	mockFramework := &MockFramework{
+		FrameworkName:    "rspec",
+		TestFiles:        []string{"spec/backend_only_spec.rb"},
+		DiscoverTestsErr: errors.New("full discovery failed"),
+	}
+	mockPlatform := &MockPlatform{
+		PlatformName: "ruby",
+		Tags: map[string]string{
+			ciConstants.GitRepositoryURL: "github.com/DataDog/ddtest",
+		},
+		Framework: mockFramework,
+	}
+	mockDurationsClient := &MockTestSuiteDurationsClient{
+		Durations: map[string]map[string]testoptimization.TestSuiteDurationInfo{
+			"rspec": {
+				"BackendOnlySuite": {
+					SourceFile: "spec/backend_only_spec.rb",
+					Duration:   testoptimization.DurationPercentiles{P50: "42000000", P90: "84000000"},
+				},
+			},
+		},
+	}
+
+	runner := NewWithDependencies(&MockPlatformDetector{Platform: mockPlatform}, &MockTestOptimizationClient{}, mockDurationsClient, newDefaultMockCIProviderDetector())
+
+	err := runner.PrepareTestOptimization(ctx)
+	if err != nil {
+		t.Fatalf("PrepareTestOptimization() should not fail when full discovery fails but fast discovery succeeds, got: %v", err)
+	}
+
+	if weight, ok := runner.testFileWeight("spec/backend_only_spec.rb"); !ok || weight != 42 {
+		t.Errorf("Expected fast-discovery file to use backend p50 converted to 42ms, got weight=%d ok=%t", weight, ok)
+	}
+}
+
+func TestTestRunner_PrepareTestOptimization_BackendDurationSubdirMatchesFastDiscovery(t *testing.T) {
+	ctx := context.Background()
+	ciUtils.ResetCITags()
+	t.Cleanup(ciUtils.ResetCITags)
+
+	repoRoot := t.TempDir()
+	initGitRepo(t, repoRoot)
+	coreDir := filepath.Join(repoRoot, "core")
+	_ = os.MkdirAll(filepath.Join(coreDir, "spec", "models"), 0755)
+
+	oldWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldWd) }()
+	_ = os.Chdir(coreDir)
+
+	mockFramework := &MockFramework{
+		FrameworkName:    "rspec",
+		TestFiles:        []string{"spec/models/order_spec.rb"},
+		DiscoverTestsErr: errors.New("full discovery failed"),
+	}
+	mockPlatform := &MockPlatform{
+		PlatformName: "ruby",
+		Tags: map[string]string{
+			ciConstants.GitRepositoryURL: repoRoot,
+		},
+		Framework: mockFramework,
+	}
+	mockDurationsClient := &MockTestSuiteDurationsClient{
+		Durations: map[string]map[string]testoptimization.TestSuiteDurationInfo{
+			"rspec": {
+				"OrderSuite": {
+					SourceFile: "core/spec/models/order_spec.rb",
+					Duration:   testoptimization.DurationPercentiles{P50: "55000000", P90: "110000000"},
+				},
+			},
+		},
+	}
+	ciUtils.AddCITagsMap(map[string]string{ciConstants.GitRepositoryURL: repoRoot})
+
+	runner := NewWithDependencies(&MockPlatformDetector{Platform: mockPlatform}, &MockTestOptimizationClient{}, mockDurationsClient, newDefaultMockCIProviderDetector())
+
+	err := runner.PrepareTestOptimization(ctx)
+	if err != nil {
+		t.Fatalf("PrepareTestOptimization() should not fail, got: %v", err)
+	}
+	if !mockDurationsClient.Called {
+		t.Fatal("Expected durations client to be called")
+	}
+
+	if weight, ok := runner.testFileWeight("spec/models/order_spec.rb"); !ok || weight != 55 {
+		t.Errorf("Expected subdir fast-discovery file to use backend p50 converted to 55ms, got weight=%d ok=%t", weight, ok)
+	}
+
+	if got := runner.testSuiteDurations["rspec"]["OrderSuite"].SourceFile; got != "core/spec/models/order_spec.rb" {
+		t.Errorf("Expected raw backend source file to remain git-root-relative, got %q", got)
+	}
+}
+
+func TestTestRunner_PrepareTestOptimization_IgnoresBackendDurationsForUndiscoveredFiles(t *testing.T) {
+	ctx := context.Background()
+	ciUtils.ResetCITags()
+	t.Cleanup(ciUtils.ResetCITags)
+
+	mockFramework := &MockFramework{
+		FrameworkName:    "rspec",
+		TestFiles:        []string{"spec/discovered_spec.rb"},
+		DiscoverTestsErr: errors.New("full discovery failed"),
+	}
+	mockPlatform := &MockPlatform{
+		PlatformName: "ruby",
+		Tags: map[string]string{
+			ciConstants.GitRepositoryURL: "github.com/DataDog/ddtest",
+		},
+		Framework: mockFramework,
+	}
+	mockDurationsClient := &MockTestSuiteDurationsClient{
+		Durations: map[string]map[string]testoptimization.TestSuiteDurationInfo{
+			"rspec": {
+				"StaleSuite": {
+					SourceFile: "spec/stale_spec.rb",
+					Duration:   testoptimization.DurationPercentiles{P50: "99000000", P90: "198000000"},
+				},
+			},
+		},
+	}
+
+	runner := NewWithDependencies(&MockPlatformDetector{Platform: mockPlatform}, &MockTestOptimizationClient{}, mockDurationsClient, newDefaultMockCIProviderDetector())
+
+	err := runner.PrepareTestOptimization(ctx)
+	if err != nil {
+		t.Fatalf("PrepareTestOptimization() should not fail, got: %v", err)
+	}
+
+	if len(runner.suiteAggregates) != 0 {
+		t.Errorf("Expected stale backend suite to be ignored, got aggregates: %v", runner.suiteAggregates)
+	}
+
+	if weight, ok := runner.testFileWeight("spec/discovered_spec.rb"); !ok || weight != int(time.Second/time.Millisecond) {
+		t.Errorf("Expected discovered file without backend aggregate to use default 1 second, got weight=%d ok=%t", weight, ok)
+	}
+}
+
+func TestTestRunner_PrepareTestOptimization_BackendDoesNotReintroduceFullySkippedSuite(t *testing.T) {
+	ctx := context.Background()
+	ciUtils.ResetCITags()
+	t.Cleanup(ciUtils.ResetCITags)
+
+	skippedTest := testoptimization.Test{
+		Module:          "rspec",
+		Suite:           "SkippedSuite",
+		Name:            "test1",
+		SuiteSourceFile: "spec/skipped_spec.rb",
+	}
+	mockFramework := &MockFramework{
+		FrameworkName: "rspec",
+		TestFiles:     []string{"spec/skipped_spec.rb"},
+		Tests:         []testoptimization.Test{skippedTest},
+	}
+	mockPlatform := &MockPlatform{
+		PlatformName: "ruby",
+		Tags: map[string]string{
+			ciConstants.GitRepositoryURL: "github.com/DataDog/ddtest",
+		},
+		Framework: mockFramework,
+	}
+	mockOptimizationClient := &MockTestOptimizationClient{
+		SkippableTests: map[string]bool{skippedTest.FQN(): true},
+	}
+	mockDurationsClient := &MockTestSuiteDurationsClient{
+		Durations: map[string]map[string]testoptimization.TestSuiteDurationInfo{
+			"rspec": {
+				"SkippedSuite": {
+					SourceFile: "spec/skipped_spec.rb",
+					Duration:   testoptimization.DurationPercentiles{P50: "99000000", P90: "198000000"},
+				},
+			},
+		},
+	}
+
+	runner := NewWithDependencies(&MockPlatformDetector{Platform: mockPlatform}, mockOptimizationClient, mockDurationsClient, newDefaultMockCIProviderDetector())
+
+	err := runner.PrepareTestOptimization(ctx)
+	if err != nil {
+		t.Fatalf("PrepareTestOptimization() should not fail, got: %v", err)
+	}
+
+	aggregate := runner.suiteAggregates[testSuiteKey{Module: "rspec", Suite: "SkippedSuite"}]
+	if aggregate.NumTests != 1 || aggregate.NumTestsSkipped != 1 {
+		t.Errorf("Expected full-discovery skip metadata to remain intact, got %+v", aggregate)
+	}
+
+	if weight, ok := runner.testFileWeight("spec/skipped_spec.rb"); ok || weight != 0 {
+		t.Errorf("Expected fully skipped suite to be omitted despite backend duration, got weight=%d ok=%t", weight, ok)
+	}
+}
+
+func TestRecordRunnableAndSkippedTest_CountsTestsPerSuite(t *testing.T) {
+	suiteAggregates := make(map[testSuiteKey]testSuiteAggregate)
+
+	recordRunnableTest(suiteAggregates, testoptimization.Test{
+		Module:          "rspec",
+		Suite:           "Suite1",
+		Name:            "test1",
+		SuiteSourceFile: "spec/file1_test.rb",
+	}, "spec/file1_test.rb")
+	recordSkippedTest(suiteAggregates, testoptimization.Test{
+		Module:          "rspec",
+		Suite:           "Suite1",
+		Name:            "test2",
+		SuiteSourceFile: "spec/file1_test.rb",
+	}, "spec/file1_test.rb")
+	recordRunnableTest(suiteAggregates, testoptimization.Test{
+		Module:          "rspec",
+		Suite:           "Suite2",
+		Name:            "test3",
+		SuiteSourceFile: "spec/file2_test.rb",
+	}, "spec/file2_test.rb")
+
+	suite1 := suiteAggregates[testSuiteKey{Module: "rspec", Suite: "Suite1"}]
+	if suite1.NumTests != 2 {
+		t.Errorf("Expected Suite1 test count 2, got %d", suite1.NumTests)
+	}
+	if suite1.NumTestsSkipped != 1 {
+		t.Errorf("Expected Suite1 skipped test count 1, got %d", suite1.NumTestsSkipped)
+	}
+	if suite1.SourceFile != "spec/file1_test.rb" {
+		t.Errorf("Expected Suite1 source file spec/file1_test.rb, got %s", suite1.SourceFile)
+	}
+
+	suite2 := suiteAggregates[testSuiteKey{Module: "rspec", Suite: "Suite2"}]
+	if suite2.NumTests != 1 {
+		t.Errorf("Expected Suite2 test count 1, got %d", suite2.NumTests)
+	}
+	if suite2.NumTestsSkipped != 0 {
+		t.Errorf("Expected Suite2 skipped test count 0, got %d", suite2.NumTestsSkipped)
 	}
 }
 
@@ -451,8 +806,8 @@ func TestTestRunner_PrepareTestOptimization_AllTestsSkipped(t *testing.T) {
 
 	mockFramework := &MockFramework{
 		Tests: []testoptimization.Test{
-			{Suite: "", Name: "test1", Parameters: "", SuiteSourceFile: "file1.rb"},
-			{Suite: "", Name: "test2", Parameters: "", SuiteSourceFile: "file2.rb"},
+			{Suite: "Suite1", Name: "test1", Parameters: "", SuiteSourceFile: "file1.rb"},
+			{Suite: "Suite2", Name: "test2", Parameters: "", SuiteSourceFile: "file2.rb"},
 		},
 	}
 
@@ -464,8 +819,8 @@ func TestTestRunner_PrepareTestOptimization_AllTestsSkipped(t *testing.T) {
 	mockPlatformDetector := &MockPlatformDetector{Platform: mockPlatform}
 	mockOptimizationClient := &MockTestOptimizationClient{
 		SkippableTests: map[string]bool{
-			".test1.": true,
-			".test2.": true,
+			"Suite1.test1.": true,
+			"Suite2.test2.": true,
 		},
 	}
 
@@ -477,8 +832,12 @@ func TestTestRunner_PrepareTestOptimization_AllTestsSkipped(t *testing.T) {
 		t.Errorf("PrepareTestOptimization() should handle all tests skipped, got: %v", err)
 	}
 
-	if len(runner.testFiles) != 0 {
-		t.Errorf("PrepareTestOptimization() should result in 0 test files when all tests are skipped, got %d", len(runner.testFiles))
+	if len(runner.testFiles) != 2 {
+		t.Errorf("PrepareTestOptimization() should keep all discovered files even when all tests are skipped, got %d", len(runner.testFiles))
+	}
+
+	if weightedFiles := runner.weightedTestFiles(); len(weightedFiles) != 0 {
+		t.Errorf("PrepareTestOptimization() should result in 0 weighted files when all tests are skipped, got %v", weightedFiles)
 	}
 
 	if runner.skippablePercentage != 100.0 {
@@ -992,19 +1351,28 @@ func TestPrepareTestOptimization_ITRSubdir_SkipMatching_WithSuitePathsMatchingCw
 			expectedSkippablePercentage, runner.skippablePercentage)
 	}
 
-	// Only order_spec.rb should remain in testFiles (role_spec.rb tests were skipped).
-	// The SuiteSourceFile path should be normalized from "core/spec/..." to "spec/..." (CWD-relative).
+	// All discovered source files should remain in testFiles, while weightedTestFiles omits the fully skipped role_spec.rb.
+	// The SuiteSourceFile paths should be normalized from "core/spec/..." to "spec/..." (CWD-relative).
 	expectedFiles := map[string]bool{
+		"spec/models/role_spec.rb":  true,
 		"spec/models/order_spec.rb": true,
 	}
 
-	if len(runner.testFiles) != 1 {
-		t.Fatalf("Expected 1 test file (only order_spec.rb), got %d: %v", len(runner.testFiles), runner.testFiles)
+	if len(runner.testFiles) != 2 {
+		t.Fatalf("Expected 2 discovered test files, got %d: %v", len(runner.testFiles), runner.testFiles)
 	}
 
 	for file := range runner.testFiles {
 		if !expectedFiles[file] {
 			t.Errorf("Unexpected test file path %q", file)
 		}
+	}
+
+	weightedFiles := runner.weightedTestFiles()
+	if len(weightedFiles) != 1 {
+		t.Fatalf("Expected 1 weighted test file (only order_spec.rb), got %d: %v", len(weightedFiles), weightedFiles)
+	}
+	if _, ok := weightedFiles["spec/models/order_spec.rb"]; !ok {
+		t.Errorf("Expected weighted test files to contain only order_spec.rb, got %v", weightedFiles)
 	}
 }

--- a/internal/runner/path_normalization.go
+++ b/internal/runner/path_normalization.go
@@ -51,11 +51,11 @@ func getCwdSubdirPrefix() string {
 	return filepath.ToSlash(rel)
 }
 
-// normalizeTestFilePathWithPrefix converts a test file path that may be repo-root-relative
-// to a CWD-relative path. This is needed when running ddtest from a monorepo
-// subdirectory (e.g., "cd core && ddtest plan") where full test discovery returns
-// paths relative to the git root (e.g., "core/spec/...") but workers need
-// paths relative to CWD (e.g., "spec/...").
+// stripCwdSubdirPrefix converts a test file path that may be repo-root-relative
+// to a CWD-relative path by stripping the current subdirectory prefix. This is
+// needed when running ddtest from a monorepo subdirectory (e.g., "cd core && ddtest plan")
+// where full test discovery returns paths relative to the git root (e.g., "core/spec/...")
+// but workers need paths relative to CWD (e.g., "spec/...").
 //
 // The subdirPrefix should be computed once via getCwdSubdirPrefix() and reused
 // across all paths to avoid repeated git calls.
@@ -65,7 +65,7 @@ func getCwdSubdirPrefix() string {
 //   - If CWD is the git root (subdirPrefix is ""), the path is returned unchanged
 //   - Absolute paths are returned unchanged
 //   - Empty paths are returned unchanged
-func normalizeTestFilePathWithPrefix(path string, subdirPrefix string) string {
+func stripCwdSubdirPrefix(path string, subdirPrefix string) string {
 	if path == "" || subdirPrefix == "" {
 		return path
 	}

--- a/internal/runner/path_normalization_test.go
+++ b/internal/runner/path_normalization_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestNormalizePath_SubdirPrefixMatch_StripsPrefix(t *testing.T) {
+func TestStripCwdSubdirPrefix_SubdirPrefixMatch_StripsPrefix(t *testing.T) {
 	// Simulates: git root = /repo, CWD = /repo/core
 	// Path "core/spec/models/order_spec.rb" -> "spec/models/order_spec.rb"
 	repoRoot := t.TempDir()
@@ -21,14 +21,14 @@ func TestNormalizePath_SubdirPrefixMatch_StripsPrefix(t *testing.T) {
 	_ = os.Chdir(coreDir)
 
 	prefix := getCwdSubdirPrefix()
-	result := normalizeTestFilePathWithPrefix("core/spec/models/order_spec.rb", prefix)
+	result := stripCwdSubdirPrefix("core/spec/models/order_spec.rb", prefix)
 	expected := "spec/models/order_spec.rb"
 	if result != expected {
 		t.Errorf("Expected %q, got %q", expected, result)
 	}
 }
 
-func TestNormalizePath_NestedSubdirPrefixMatch_StripsFullPrefix(t *testing.T) {
+func TestStripCwdSubdirPrefix_NestedSubdirPrefixMatch_StripsFullPrefix(t *testing.T) {
 	// Simulates: git root = /repo, CWD = /repo/packages/core
 	// Path "packages/core/spec/user_spec.rb" -> "spec/user_spec.rb"
 	repoRoot := t.TempDir()
@@ -42,14 +42,14 @@ func TestNormalizePath_NestedSubdirPrefixMatch_StripsFullPrefix(t *testing.T) {
 	_ = os.Chdir(nestedDir)
 
 	prefix := getCwdSubdirPrefix()
-	result := normalizeTestFilePathWithPrefix("packages/core/spec/user_spec.rb", prefix)
+	result := stripCwdSubdirPrefix("packages/core/spec/user_spec.rb", prefix)
 	expected := "spec/user_spec.rb"
 	if result != expected {
 		t.Errorf("Expected %q, got %q", expected, result)
 	}
 }
 
-func TestNormalizePath_AlreadyRelative_NoChange(t *testing.T) {
+func TestStripCwdSubdirPrefix_AlreadyRelative_NoChange(t *testing.T) {
 	// When path doesn't start with subdir prefix, it's already CWD-relative
 	repoRoot := t.TempDir()
 	initGitRepoInDir(t, repoRoot)
@@ -63,14 +63,14 @@ func TestNormalizePath_AlreadyRelative_NoChange(t *testing.T) {
 
 	// This path is already CWD-relative (doesn't start with "core/")
 	prefix := getCwdSubdirPrefix()
-	result := normalizeTestFilePathWithPrefix("spec/models/order_spec.rb", prefix)
+	result := stripCwdSubdirPrefix("spec/models/order_spec.rb", prefix)
 	expected := "spec/models/order_spec.rb"
 	if result != expected {
 		t.Errorf("Expected %q (unchanged), got %q", expected, result)
 	}
 }
 
-func TestNormalizePath_PrefixMismatch_NoChange(t *testing.T) {
+func TestStripCwdSubdirPrefix_PrefixMismatch_NoChange(t *testing.T) {
 	// CWD is "api/" but path has "core/" prefix - should NOT be stripped
 	repoRoot := t.TempDir()
 	initGitRepoInDir(t, repoRoot)
@@ -83,14 +83,14 @@ func TestNormalizePath_PrefixMismatch_NoChange(t *testing.T) {
 	_ = os.Chdir(apiDir)
 
 	prefix := getCwdSubdirPrefix()
-	result := normalizeTestFilePathWithPrefix("core/spec/models/order_spec.rb", prefix)
+	result := stripCwdSubdirPrefix("core/spec/models/order_spec.rb", prefix)
 	expected := "core/spec/models/order_spec.rb"
 	if result != expected {
 		t.Errorf("Expected %q (unchanged), got %q", expected, result)
 	}
 }
 
-func TestNormalizePath_AtRepoRoot_NoChange(t *testing.T) {
+func TestStripCwdSubdirPrefix_AtRepoRoot_NoChange(t *testing.T) {
 	// When CWD == git root, no prefix to strip
 	repoRoot := t.TempDir()
 	initGitRepoInDir(t, repoRoot)
@@ -100,14 +100,14 @@ func TestNormalizePath_AtRepoRoot_NoChange(t *testing.T) {
 	_ = os.Chdir(repoRoot)
 
 	prefix := getCwdSubdirPrefix()
-	result := normalizeTestFilePathWithPrefix("spec/models/order_spec.rb", prefix)
+	result := stripCwdSubdirPrefix("spec/models/order_spec.rb", prefix)
 	expected := "spec/models/order_spec.rb"
 	if result != expected {
 		t.Errorf("Expected %q (unchanged), got %q", expected, result)
 	}
 }
 
-func TestNormalizePath_GitRootUnavailable_NoChange(t *testing.T) {
+func TestStripCwdSubdirPrefix_GitRootUnavailable_NoChange(t *testing.T) {
 	// When not in a git repo, normalization should be a no-op (fail-safe)
 	tempDir := t.TempDir()
 
@@ -116,14 +116,14 @@ func TestNormalizePath_GitRootUnavailable_NoChange(t *testing.T) {
 	_ = os.Chdir(tempDir)
 
 	prefix := getCwdSubdirPrefix()
-	result := normalizeTestFilePathWithPrefix("core/spec/models/order_spec.rb", prefix)
+	result := stripCwdSubdirPrefix("core/spec/models/order_spec.rb", prefix)
 	expected := "core/spec/models/order_spec.rb"
 	if result != expected {
 		t.Errorf("Expected %q (unchanged when git root unavailable), got %q", expected, result)
 	}
 }
 
-func TestNormalizePath_AbsolutePath_NoChange(t *testing.T) {
+func TestStripCwdSubdirPrefix_AbsolutePath_NoChange(t *testing.T) {
 	// Absolute paths should not be modified
 	repoRoot := t.TempDir()
 	initGitRepoInDir(t, repoRoot)
@@ -137,14 +137,14 @@ func TestNormalizePath_AbsolutePath_NoChange(t *testing.T) {
 
 	absPath := "/absolute/path/to/spec.rb"
 	prefix := getCwdSubdirPrefix()
-	result := normalizeTestFilePathWithPrefix(absPath, prefix)
+	result := stripCwdSubdirPrefix(absPath, prefix)
 	if result != absPath {
 		t.Errorf("Expected %q (absolute path unchanged), got %q", absPath, result)
 	}
 }
 
-func TestNormalizePath_EmptyPath_NoChange(t *testing.T) {
-	result := normalizeTestFilePathWithPrefix("", "core")
+func TestStripCwdSubdirPrefix_EmptyPath_NoChange(t *testing.T) {
+	result := stripCwdSubdirPrefix("", "core")
 	if result != "" {
 		t.Errorf("Expected empty string, got %q", result)
 	}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -22,8 +22,9 @@ type Runner interface {
 }
 
 type TestRunner struct {
-	// the keys are file paths, the values are "durations" - currently just the number of tests in a file
-	testFiles           map[string]int
+	testFiles           map[string]struct{}
+	suiteAggregates     map[testSuiteKey]testSuiteAggregate
+	suitesBySourceFile  map[string][]testSuiteKey
 	testSuiteDurations  map[string]map[string]testoptimization.TestSuiteDurationInfo
 	skippablePercentage float64
 	platformDetector    platform.PlatformDetector
@@ -34,7 +35,9 @@ type TestRunner struct {
 
 func New() *TestRunner {
 	return &TestRunner{
-		testFiles:           make(map[string]int),
+		testFiles:           make(map[string]struct{}),
+		suiteAggregates:     make(map[testSuiteKey]testSuiteAggregate),
+		suitesBySourceFile:  make(map[string][]testSuiteKey),
 		testSuiteDurations:  make(map[string]map[string]testoptimization.TestSuiteDurationInfo),
 		skippablePercentage: 0.0,
 		platformDetector:    platform.NewPlatformDetector(),
@@ -51,7 +54,9 @@ func NewWithDependencies(
 	ciProviderDetector ciprovider.CIProviderDetector,
 ) *TestRunner {
 	return &TestRunner{
-		testFiles:           make(map[string]int),
+		testFiles:           make(map[string]struct{}),
+		suiteAggregates:     make(map[testSuiteKey]testSuiteAggregate),
+		suitesBySourceFile:  make(map[string][]testSuiteKey),
 		testSuiteDurations:  make(map[string]map[string]testoptimization.TestSuiteDurationInfo),
 		skippablePercentage: 0.0,
 		platformDetector:    platformDetector,
@@ -72,8 +77,9 @@ func (tr *TestRunner) Plan(ctx context.Context) error {
 		return fmt.Errorf("failed to create output directory: %w", err)
 	}
 
-	testFileNames := make([]string, 0, len(tr.testFiles))
-	for testFile := range tr.testFiles {
+	weightedTestFiles := tr.weightedTestFiles()
+	testFileNames := make([]string, 0, len(weightedTestFiles))
+	for testFile := range weightedTestFiles {
 		testFileNames = append(testFileNames, testFile)
 	}
 	slices.Sort(testFileNames)
@@ -112,11 +118,11 @@ func (tr *TestRunner) Plan(ctx context.Context) error {
 	}
 
 	// Split test files for runners
-	if err := CreateTestSplits(tr.testFiles, parallelRunners, constants.TestFilesOutputPath); err != nil {
+	if err := CreateTestSplits(weightedTestFiles, parallelRunners, constants.TestFilesOutputPath); err != nil {
 		return fmt.Errorf("failed to create test splits: %w", err)
 	}
 
-	slog.Info("Test execution planning completed", "parallelRunners", parallelRunners, "testFilesCount", len(tr.testFiles))
+	slog.Info("Test execution planning completed", "parallelRunners", parallelRunners, "testFilesCount", len(weightedTestFiles))
 
 	return nil
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -24,28 +24,39 @@ type Runner interface {
 type TestRunner struct {
 	// the keys are file paths, the values are "durations" - currently just the number of tests in a file
 	testFiles           map[string]int
+	testSuiteDurations  map[string]map[string]testoptimization.TestSuiteDurationInfo
 	skippablePercentage float64
 	platformDetector    platform.PlatformDetector
 	optimizationClient  testoptimization.TestOptimizationClient
+	durationsClient     testoptimization.TestSuiteDurationsClient
 	ciProviderDetector  ciprovider.CIProviderDetector
 }
 
 func New() *TestRunner {
 	return &TestRunner{
 		testFiles:           make(map[string]int),
+		testSuiteDurations:  make(map[string]map[string]testoptimization.TestSuiteDurationInfo),
 		skippablePercentage: 0.0,
 		platformDetector:    platform.NewPlatformDetector(),
 		optimizationClient:  testoptimization.NewDatadogClient(),
+		durationsClient:     testoptimization.NewDurationsClient(),
 		ciProviderDetector:  ciprovider.NewCIProviderDetector(),
 	}
 }
 
-func NewWithDependencies(platformDetector platform.PlatformDetector, optimizationClient testoptimization.TestOptimizationClient, ciProviderDetector ciprovider.CIProviderDetector) *TestRunner {
+func NewWithDependencies(
+	platformDetector platform.PlatformDetector,
+	optimizationClient testoptimization.TestOptimizationClient,
+	durationsClient testoptimization.TestSuiteDurationsClient,
+	ciProviderDetector ciprovider.CIProviderDetector,
+) *TestRunner {
 	return &TestRunner{
 		testFiles:           make(map[string]int),
+		testSuiteDurations:  make(map[string]map[string]testoptimization.TestSuiteDurationInfo),
 		skippablePercentage: 0.0,
 		platformDetector:    platformDetector,
 		optimizationClient:  optimizationClient,
+		durationsClient:     durationsClient,
 		ciProviderDetector:  ciProviderDetector,
 	}
 }

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -226,6 +226,14 @@ func TestNew(t *testing.T) {
 		t.Error("New() should initialize testFiles to empty map")
 	}
 
+	if len(runner.suiteAggregates) != 0 {
+		t.Error("New() should initialize suiteAggregates to empty map")
+	}
+
+	if len(runner.suitesBySourceFile) != 0 {
+		t.Error("New() should initialize suitesBySourceFile to empty map")
+	}
+
 	if runner.skippablePercentage != 0.0 {
 		t.Errorf("New() should initialize skippablePercentage to 0.0, got %f", runner.skippablePercentage)
 	}
@@ -266,6 +274,18 @@ func TestNewWithDependencies(t *testing.T) {
 
 	if runner.durationsClient != mockDurationsClient {
 		t.Error("NewWithDependencies() should use injected durationsClient")
+	}
+
+	if len(runner.testFiles) != 0 {
+		t.Error("NewWithDependencies() should initialize testFiles to empty map")
+	}
+
+	if len(runner.suiteAggregates) != 0 {
+		t.Error("NewWithDependencies() should initialize suiteAggregates to empty map")
+	}
+
+	if len(runner.suitesBySourceFile) != 0 {
+		t.Error("NewWithDependencies() should initialize suitesBySourceFile to empty map")
 	}
 }
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -158,6 +158,27 @@ func (m *MockTestOptimizationClient) StoreCacheAndExit() {
 	m.ShutdownCalled = true
 }
 
+type MockTestSuiteDurationsClient struct {
+	Durations     map[string]map[string]testoptimization.TestSuiteDurationInfo
+	Err           error
+	Called        bool
+	RepositoryURL string
+	Service       string
+}
+
+func (m *MockTestSuiteDurationsClient) GetTestSuiteDurations(repositoryURL, service string) (map[string]map[string]testoptimization.TestSuiteDurationInfo, error) {
+	m.Called = true
+	m.RepositoryURL = repositoryURL
+	m.Service = service
+	if m.Err != nil {
+		return nil, m.Err
+	}
+	if m.Durations == nil {
+		return map[string]map[string]testoptimization.TestSuiteDurationInfo{}, nil
+	}
+	return m.Durations, nil
+}
+
 // MockCIProvider mocks a CI provider
 type MockCIProvider struct {
 	ProviderName    string
@@ -216,14 +237,19 @@ func TestNew(t *testing.T) {
 	if runner.optimizationClient == nil {
 		t.Error("New() should initialize optimizationClient")
 	}
+
+	if runner.durationsClient == nil {
+		t.Error("New() should initialize durationsClient")
+	}
 }
 
 func TestNewWithDependencies(t *testing.T) {
 	mockPlatformDetector := &MockPlatformDetector{}
 	mockOptimizationClient := &MockTestOptimizationClient{}
+	mockDurationsClient := &MockTestSuiteDurationsClient{}
 	mockCIProviderDetector := newDefaultMockCIProviderDetector()
 
-	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, mockCIProviderDetector)
+	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, mockDurationsClient, mockCIProviderDetector)
 
 	if runner == nil {
 		t.Error("NewWithDependencies() should return non-nil TestRunner")
@@ -236,6 +262,10 @@ func TestNewWithDependencies(t *testing.T) {
 
 	if runner.optimizationClient != mockOptimizationClient {
 		t.Error("NewWithDependencies() should use injected optimizationClient")
+	}
+
+	if runner.durationsClient != mockDurationsClient {
+		t.Error("NewWithDependencies() should use injected durationsClient")
 	}
 }
 
@@ -286,7 +316,7 @@ func TestTestRunner_Setup_WithParallelRunners(t *testing.T) {
 		},
 	}
 
-	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, newDefaultMockCIProviderDetector())
+	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, &MockTestSuiteDurationsClient{}, newDefaultMockCIProviderDetector())
 
 	// Run Setup
 	err := runner.Plan(context.Background())
@@ -356,7 +386,7 @@ func TestTestRunner_Setup_WithCIProvider(t *testing.T) {
 		CIProvider: mockCIProvider,
 	}
 
-	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, mockCIProviderDetector)
+	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, &MockTestSuiteDurationsClient{}, mockCIProviderDetector)
 
 	// Run Setup
 	err := runner.Plan(context.Background())
@@ -410,7 +440,7 @@ func TestTestRunner_Setup_CIProviderDetectionFailure(t *testing.T) {
 		Err: errors.New("no CI provider detected"),
 	}
 
-	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, mockCIProviderDetector)
+	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, &MockTestSuiteDurationsClient{}, mockCIProviderDetector)
 
 	// Run Setup - should succeed even if CI provider detection fails
 	err := runner.Plan(context.Background())
@@ -455,7 +485,7 @@ func TestTestRunner_Setup_CIProviderConfigureFailure(t *testing.T) {
 		CIProvider: mockCIProvider,
 	}
 
-	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, mockCIProviderDetector)
+	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, &MockTestSuiteDurationsClient{}, mockCIProviderDetector)
 
 	// Run Setup - should succeed even if CI provider configuration fails
 	err := runner.Plan(context.Background())
@@ -511,7 +541,7 @@ func TestTestRunner_Setup_WithTestSplit(t *testing.T) {
 			SkippableTests: map[string]bool{}, // No tests skipped
 		}
 
-		runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, newDefaultMockCIProviderDetector())
+		runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, &MockTestSuiteDurationsClient{}, newDefaultMockCIProviderDetector())
 
 		// Run Setup
 		err := runner.Plan(context.Background())
@@ -599,7 +629,7 @@ func TestTestRunner_Setup_WithTestSplit(t *testing.T) {
 		// Reinitialize settings to pick up environment variables
 		settings.Init()
 
-		runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, newDefaultMockCIProviderDetector())
+		runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, &MockTestSuiteDurationsClient{}, newDefaultMockCIProviderDetector())
 
 		// Run Setup
 		err := runner.Plan(context.Background())
@@ -716,7 +746,7 @@ func TestTestRunner_Plan_SubdirRootRelativeDiscovery_WritesNormalizedPaths(t *te
 		SkippableTests: map[string]bool{},
 	}
 
-	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, newDefaultMockCIProviderDetector())
+	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, &MockTestSuiteDurationsClient{}, newDefaultMockCIProviderDetector())
 
 	err := runner.Plan(context.Background())
 	if err != nil {

--- a/internal/testoptimization/durations_client.go
+++ b/internal/testoptimization/durations_client.go
@@ -276,6 +276,8 @@ func (c *DatadogDurationsAPI) doPost(requestURL string, body interface{}) (*dura
 		return nil, fmt.Errorf("unexpected status code %d: %s", resp.StatusCode, truncateBody(respBody))
 	}
 
+	slog.Debug("test_suite_durations", "responseBody", string(respBody))
+
 	var responseObject durationsResponse
 	if err := json.Unmarshal(respBody, &responseObject); err != nil {
 		return nil, fmt.Errorf("unmarshalling response: %w", err)

--- a/internal/testoptimization/durations_client.go
+++ b/internal/testoptimization/durations_client.go
@@ -1,0 +1,293 @@
+package testoptimization
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"math"
+	"math/rand/v2"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/DataDog/ddtest/civisibility"
+	"github.com/DataDog/ddtest/civisibility/constants"
+)
+
+const (
+	durationsRequestType string = "ci_app_ddtest_test_suite_durations_request"
+	durationsURLPath     string = "api/v2/ci/ddtest/test_suite_durations"
+
+	defaultDurationsPageSize int = 500
+	maxDurationsRetries      int = 3
+)
+
+type (
+	// request types
+
+	durationsRequest struct {
+		Data durationsRequestData `json:"data"`
+	}
+
+	durationsRequestData struct {
+		Type       string                     `json:"type"`
+		Attributes durationsRequestAttributes `json:"attributes"`
+	}
+
+	durationsRequestAttributes struct {
+		RepositoryURL string                    `json:"repository_url"`
+		Service       string                    `json:"service,omitempty"`
+		PageInfo      *durationsRequestPageInfo `json:"page_info,omitempty"`
+	}
+
+	durationsRequestPageInfo struct {
+		PageSize  int    `json:"page_size,omitempty"`
+		PageState string `json:"page_state,omitempty"`
+	}
+
+	// response types
+
+	durationsResponse struct {
+		Data struct {
+			ID         string                      `json:"id"`
+			Type       string                      `json:"type"`
+			Attributes durationsResponseAttributes `json:"attributes"`
+		} `json:"data"`
+	}
+
+	durationsResponseAttributes struct {
+		TestSuites map[string]map[string]TestSuiteDurationInfo `json:"test_suites"`
+		PageInfo   *durationsResponsePageInfo                  `json:"page_info,omitempty"`
+	}
+
+	durationsResponsePageInfo struct {
+		Cursor  string `json:"cursor,omitempty"`
+		Size    int    `json:"size,omitempty"`
+		HasNext bool   `json:"has_next"`
+	}
+
+	// public response types
+
+	TestSuiteDurationInfo struct {
+		SourceFile string              `json:"source_file"`
+		Duration   DurationPercentiles `json:"duration"`
+	}
+
+	DurationPercentiles struct {
+		P50 string `json:"p50"`
+		P90 string `json:"p90"`
+	}
+)
+
+// TestSuiteDurationsClient defines the interface for fetching test suite durations
+type TestSuiteDurationsClient interface {
+	GetTestSuiteDurations(repositoryURL, service string) (map[string]map[string]TestSuiteDurationInfo, error)
+}
+
+// DurationsAPI abstracts the HTTP endpoint for testability (equivalent of CIVisibilityIntegrations)
+type DurationsAPI interface {
+	FetchTestSuiteDurations(repositoryURL, service, cursor string, pageSize int) (*durationsResponseAttributes, error)
+}
+
+// DatadogDurationsClient implements TestSuiteDurationsClient (equivalent of DatadogClient)
+type DatadogDurationsClient struct {
+	api DurationsAPI
+}
+
+func NewDurationsClient() *DatadogDurationsClient {
+	return &DatadogDurationsClient{
+		api: NewDatadogDurationsAPI(),
+	}
+}
+
+func NewDurationsClientWithDependencies(api DurationsAPI) *DatadogDurationsClient {
+	return &DatadogDurationsClient{
+		api: api,
+	}
+}
+
+func (c *DatadogDurationsClient) GetTestSuiteDurations(repositoryURL, service string) (map[string]map[string]TestSuiteDurationInfo, error) {
+	startTime := time.Now()
+	allSuites := make(map[string]map[string]TestSuiteDurationInfo)
+
+	slog.Debug("Fetching test suite durations...")
+
+	cursor := ""
+	for {
+		data, err := c.api.FetchTestSuiteDurations(repositoryURL, service, cursor, defaultDurationsPageSize)
+		if err != nil {
+			return nil, fmt.Errorf("fetching test suite durations: %w", err)
+		}
+
+		for module, suites := range data.TestSuites {
+			if _, ok := allSuites[module]; !ok {
+				allSuites[module] = make(map[string]TestSuiteDurationInfo)
+			}
+			for suite, info := range suites {
+				allSuites[module][suite] = info
+			}
+		}
+
+		if data.PageInfo == nil || !data.PageInfo.HasNext {
+			break
+		}
+		cursor = data.PageInfo.Cursor
+	}
+
+	duration := time.Since(startTime)
+	totalSuites := 0
+	for _, suites := range allSuites {
+		totalSuites += len(suites)
+	}
+	slog.Debug("Finished fetching test suite durations", "modules", len(allSuites), "suites", totalSuites, "duration", duration)
+
+	return allSuites, nil
+}
+
+// DatadogDurationsAPI implements DurationsAPI using real HTTP calls (equivalent of DatadogCIVisibilityIntegrations)
+type DatadogDurationsAPI struct {
+	baseURL    string
+	headers    map[string]string
+	httpClient *http.Client
+}
+
+func NewDatadogDurationsAPI() *DatadogDurationsAPI {
+	headers := map[string]string{}
+	var baseURL string
+
+	agentlessEnabled := civisibility.BoolEnv(constants.CIVisibilityAgentlessEnabledEnvironmentVariable, false)
+	if agentlessEnabled {
+		apiKey := os.Getenv(constants.APIKeyEnvironmentVariable)
+		if apiKey == "" {
+			slog.Error("An API key is required for agentless mode. Use the DD_API_KEY env variable to set it")
+			return nil
+		}
+		headers["dd-api-key"] = apiKey
+
+		agentlessURL := os.Getenv(constants.CIVisibilityAgentlessURLEnvironmentVariable)
+		if agentlessURL == "" {
+			site := "datadoghq.com"
+			if v := os.Getenv("DD_SITE"); v != "" {
+				site = v
+			}
+			baseURL = fmt.Sprintf("https://api.%s", site)
+		} else {
+			baseURL = agentlessURL
+		}
+	} else {
+		headers["X-Datadog-EVP-Subdomain"] = "api"
+		agentURL := civisibility.AgentURLFromEnv()
+		baseURL = agentURL.String()
+	}
+
+	id := fmt.Sprint(rand.Uint64() & math.MaxInt64)
+	headers["trace_id"] = id
+	headers["parent_id"] = id
+
+	slog.Debug("DurationsAPI: client created",
+		"agentless", agentlessEnabled, "url", baseURL)
+
+	return &DatadogDurationsAPI{
+		baseURL: baseURL,
+		headers: headers,
+		httpClient: &http.Client{
+			Timeout: 45 * time.Second,
+		},
+	}
+}
+
+func (c *DatadogDurationsAPI) FetchTestSuiteDurations(repositoryURL, service, cursor string, pageSize int) (*durationsResponseAttributes, error) {
+	if repositoryURL == "" {
+		return nil, fmt.Errorf("repository URL is required")
+	}
+
+	var pageInfo *durationsRequestPageInfo
+	if pageSize > 0 || cursor != "" {
+		pageInfo = &durationsRequestPageInfo{
+			PageSize:  pageSize,
+			PageState: cursor,
+		}
+	}
+
+	body := durationsRequest{
+		Data: durationsRequestData{
+			Type: durationsRequestType,
+			Attributes: durationsRequestAttributes{
+				RepositoryURL: repositoryURL,
+				Service:       service,
+				PageInfo:      pageInfo,
+			},
+		},
+	}
+
+	requestURL := c.getURLPath(durationsURLPath)
+
+	var lastErr error
+	for attempt := range maxDurationsRetries {
+		result, err := c.doPost(requestURL, body)
+		if err == nil {
+			return result, nil
+		}
+		lastErr = err
+		slog.Debug("DurationsAPI: request failed, retrying", "attempt", attempt+1, "error", err)
+		time.Sleep(time.Duration(100*(1<<uint(attempt))) * time.Millisecond)
+	}
+
+	return nil, fmt.Errorf("max retries exceeded: %w", lastErr)
+}
+
+func (c *DatadogDurationsAPI) getURLPath(urlPath string) string {
+	if _, ok := c.headers["dd-api-key"]; ok {
+		return fmt.Sprintf("%s/%s", c.baseURL, urlPath)
+	}
+	return fmt.Sprintf("%s/%s/%s", c.baseURL, "evp_proxy/v2", urlPath)
+}
+
+func (c *DatadogDurationsAPI) doPost(requestURL string, body interface{}) (*durationsResponseAttributes, error) {
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling request body: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, requestURL, strings.NewReader(string(jsonBody)))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	for key, value := range c.headers {
+		req.Header.Set(key, value)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("sending request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response body: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("unexpected status code %d: %s", resp.StatusCode, truncateBody(respBody))
+	}
+
+	var responseObject durationsResponse
+	if err := json.Unmarshal(respBody, &responseObject); err != nil {
+		return nil, fmt.Errorf("unmarshalling response: %w", err)
+	}
+
+	return &responseObject.Data.Attributes, nil
+}
+
+func truncateBody(body []byte) string {
+	s := string(body)
+	if len(s) > 256 {
+		return s[:256] + "..."
+	}
+	return s
+}

--- a/internal/testoptimization/durations_client.go
+++ b/internal/testoptimization/durations_client.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/DataDog/ddtest/civisibility"
 	"github.com/DataDog/ddtest/civisibility/constants"
+	"github.com/DataDog/ddtest/internal/httptransport"
 )
 
 const (
@@ -151,18 +152,26 @@ type DatadogDurationsAPI struct {
 	baseURL    string
 	headers    map[string]string
 	httpClient *http.Client
+	err        error
 }
 
 func NewDatadogDurationsAPI() *DatadogDurationsAPI {
 	headers := map[string]string{}
 	var baseURL string
+	httpClient := &http.Client{
+		Timeout: 45 * time.Second,
+	}
 
 	agentlessEnabled := civisibility.BoolEnv(constants.CIVisibilityAgentlessEnabledEnvironmentVariable, false)
 	if agentlessEnabled {
 		apiKey := os.Getenv(constants.APIKeyEnvironmentVariable)
 		if apiKey == "" {
 			slog.Error("An API key is required for agentless mode. Use the DD_API_KEY env variable to set it")
-			return nil
+			return &DatadogDurationsAPI{
+				headers:    headers,
+				httpClient: httpClient,
+				err:        fmt.Errorf("DD_API_KEY is required when DD_CIVISIBILITY_AGENTLESS_ENABLED is true"),
+			}
 		}
 		headers["dd-api-key"] = apiKey
 
@@ -179,6 +188,10 @@ func NewDatadogDurationsAPI() *DatadogDurationsAPI {
 	} else {
 		headers["X-Datadog-EVP-Subdomain"] = "api"
 		agentURL := civisibility.AgentURLFromEnv()
+		if agentURL.Scheme == "unix" {
+			httpClient = httptransport.UnixSocketClient(agentURL.Path, 45*time.Second)
+			agentURL = httptransport.UnixSocketURL(agentURL.Path)
+		}
 		baseURL = agentURL.String()
 	}
 
@@ -190,15 +203,16 @@ func NewDatadogDurationsAPI() *DatadogDurationsAPI {
 		"agentless", agentlessEnabled, "url", baseURL)
 
 	return &DatadogDurationsAPI{
-		baseURL: baseURL,
-		headers: headers,
-		httpClient: &http.Client{
-			Timeout: 45 * time.Second,
-		},
+		baseURL:    baseURL,
+		headers:    headers,
+		httpClient: httpClient,
 	}
 }
 
 func (c *DatadogDurationsAPI) FetchTestSuiteDurations(repositoryURL, service, cursor string, pageSize int) (*durationsResponseAttributes, error) {
+	if c.err != nil {
+		return nil, c.err
+	}
 	if repositoryURL == "" {
 		return nil, fmt.Errorf("repository URL is required")
 	}

--- a/internal/testoptimization/durations_client_test.go
+++ b/internal/testoptimization/durations_client_test.go
@@ -1,0 +1,444 @@
+package testoptimization
+
+import (
+	"fmt"
+	"testing"
+)
+
+// MockDurationsAPI implements DurationsAPI for testing (equivalent of MockCIVisibilityIntegrations)
+type MockDurationsAPI struct {
+	FetchCalled    bool
+	RepositoryURL  string
+	Service        string
+	Cursors        []string
+	Responses      []*durationsResponseAttributes
+	ResponseErrors []error
+	callIndex      int
+}
+
+func (m *MockDurationsAPI) FetchTestSuiteDurations(repositoryURL, service, cursor string, pageSize int) (*durationsResponseAttributes, error) {
+	m.FetchCalled = true
+	m.RepositoryURL = repositoryURL
+	m.Service = service
+	m.Cursors = append(m.Cursors, cursor)
+
+	if m.callIndex < len(m.ResponseErrors) && m.ResponseErrors[m.callIndex] != nil {
+		err := m.ResponseErrors[m.callIndex]
+		m.callIndex++
+		return nil, err
+	}
+
+	if m.callIndex < len(m.Responses) {
+		resp := m.Responses[m.callIndex]
+		m.callIndex++
+		return resp, nil
+	}
+
+	return &durationsResponseAttributes{
+		TestSuites: make(map[string]map[string]TestSuiteDurationInfo),
+	}, nil
+}
+
+func TestNewDurationsClientWithDependencies(t *testing.T) {
+	mockAPI := &MockDurationsAPI{}
+	client := NewDurationsClientWithDependencies(mockAPI)
+
+	if client == nil {
+		t.Error("NewDurationsClientWithDependencies() should return non-nil client")
+	}
+}
+
+func TestDurationsClient_GetTestSuiteDurations_SinglePage(t *testing.T) {
+	mockAPI := &MockDurationsAPI{
+		Responses: []*durationsResponseAttributes{
+			{
+				TestSuites: map[string]map[string]TestSuiteDurationInfo{
+					"module1": {
+						"suite1": {
+							SourceFile: "spec/user_spec.rb",
+							Duration:   DurationPercentiles{P50: "280000000", P90: "350000000"},
+						},
+						"suite2": {
+							SourceFile: "spec/order_spec.rb",
+							Duration:   DurationPercentiles{P50: "100000000", P90: "150000000"},
+						},
+					},
+					"module2": {
+						"suite3": {
+							SourceFile: "spec/product_spec.rb",
+							Duration:   DurationPercentiles{P50: "500000000", P90: "600000000"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	client := NewDurationsClientWithDependencies(mockAPI)
+	result, err := client.GetTestSuiteDurations("github.com/DataDog/foo", "my-service")
+
+	if err != nil {
+		t.Errorf("GetTestSuiteDurations() should not return error, got: %v", err)
+	}
+
+	if !mockAPI.FetchCalled {
+		t.Error("GetTestSuiteDurations() should call FetchTestSuiteDurations")
+	}
+
+	if mockAPI.RepositoryURL != "github.com/DataDog/foo" {
+		t.Errorf("Expected repository URL 'github.com/DataDog/foo', got '%s'", mockAPI.RepositoryURL)
+	}
+
+	if mockAPI.Service != "my-service" {
+		t.Errorf("Expected service 'my-service', got '%s'", mockAPI.Service)
+	}
+
+	if len(result) != 2 {
+		t.Errorf("Expected 2 modules, got %d", len(result))
+	}
+
+	module1, exists := result["module1"]
+	if !exists {
+		t.Error("Expected module1 to exist")
+		return
+	}
+
+	if len(module1) != 2 {
+		t.Errorf("Expected 2 suites in module1, got %d", len(module1))
+	}
+
+	suite1, exists := module1["suite1"]
+	if !exists {
+		t.Error("Expected suite1 to exist in module1")
+		return
+	}
+
+	if suite1.SourceFile != "spec/user_spec.rb" {
+		t.Errorf("Expected source file 'spec/user_spec.rb', got '%s'", suite1.SourceFile)
+	}
+	if suite1.Duration.P50 != "280000000" {
+		t.Errorf("Expected P50 '280000000', got '%s'", suite1.Duration.P50)
+	}
+	if suite1.Duration.P90 != "350000000" {
+		t.Errorf("Expected P90 '350000000', got '%s'", suite1.Duration.P90)
+	}
+
+	module2, exists := result["module2"]
+	if !exists {
+		t.Error("Expected module2 to exist")
+		return
+	}
+
+	if len(module2) != 1 {
+		t.Errorf("Expected 1 suite in module2, got %d", len(module2))
+	}
+}
+
+func TestDurationsClient_GetTestSuiteDurations_Pagination(t *testing.T) {
+	mockAPI := &MockDurationsAPI{
+		Responses: []*durationsResponseAttributes{
+			{
+				TestSuites: map[string]map[string]TestSuiteDurationInfo{
+					"module1": {
+						"suite1": {
+							SourceFile: "spec/user_spec.rb",
+							Duration:   DurationPercentiles{P50: "280000000", P90: "350000000"},
+						},
+					},
+				},
+				PageInfo: &durationsResponsePageInfo{
+					Cursor:  "abc123",
+					Size:    500,
+					HasNext: true,
+				},
+			},
+			{
+				TestSuites: map[string]map[string]TestSuiteDurationInfo{
+					"module1": {
+						"suite2": {
+							SourceFile: "spec/order_spec.rb",
+							Duration:   DurationPercentiles{P50: "100000000", P90: "150000000"},
+						},
+					},
+					"module2": {
+						"suite3": {
+							SourceFile: "spec/product_spec.rb",
+							Duration:   DurationPercentiles{P50: "500000000", P90: "600000000"},
+						},
+					},
+				},
+				PageInfo: &durationsResponsePageInfo{
+					Cursor:  "",
+					Size:    500,
+					HasNext: false,
+				},
+			},
+		},
+	}
+
+	client := NewDurationsClientWithDependencies(mockAPI)
+	result, err := client.GetTestSuiteDurations("github.com/DataDog/foo", "my-service")
+
+	if err != nil {
+		t.Errorf("GetTestSuiteDurations() should not return error, got: %v", err)
+	}
+
+	// Verify pagination cursors were passed correctly
+	if len(mockAPI.Cursors) != 2 {
+		t.Errorf("Expected 2 API calls, got %d", len(mockAPI.Cursors))
+	}
+
+	if mockAPI.Cursors[0] != "" {
+		t.Errorf("First call should have empty cursor, got '%s'", mockAPI.Cursors[0])
+	}
+
+	if mockAPI.Cursors[1] != "abc123" {
+		t.Errorf("Second call should have cursor 'abc123', got '%s'", mockAPI.Cursors[1])
+	}
+
+	// Verify merged results
+	if len(result) != 2 {
+		t.Errorf("Expected 2 modules, got %d", len(result))
+	}
+
+	module1, exists := result["module1"]
+	if !exists {
+		t.Error("Expected module1 to exist")
+		return
+	}
+
+	if len(module1) != 2 {
+		t.Errorf("Expected 2 suites in module1 (merged from both pages), got %d", len(module1))
+	}
+
+	if _, exists := module1["suite1"]; !exists {
+		t.Error("Expected suite1 to exist in module1 (from page 1)")
+	}
+	if _, exists := module1["suite2"]; !exists {
+		t.Error("Expected suite2 to exist in module1 (from page 2)")
+	}
+
+	module2, exists := result["module2"]
+	if !exists {
+		t.Error("Expected module2 to exist")
+		return
+	}
+
+	if len(module2) != 1 {
+		t.Errorf("Expected 1 suite in module2, got %d", len(module2))
+	}
+}
+
+func TestDurationsClient_GetTestSuiteDurations_EmptyResponse(t *testing.T) {
+	mockAPI := &MockDurationsAPI{
+		Responses: []*durationsResponseAttributes{
+			{
+				TestSuites: map[string]map[string]TestSuiteDurationInfo{},
+			},
+		},
+	}
+
+	client := NewDurationsClientWithDependencies(mockAPI)
+	result, err := client.GetTestSuiteDurations("github.com/DataDog/foo", "my-service")
+
+	if err != nil {
+		t.Errorf("GetTestSuiteDurations() should not return error, got: %v", err)
+	}
+
+	if result == nil {
+		t.Error("GetTestSuiteDurations() should return non-nil map even with empty data")
+	}
+
+	if len(result) != 0 {
+		t.Errorf("GetTestSuiteDurations() should return empty map, got %d modules", len(result))
+	}
+}
+
+func TestDurationsClient_GetTestSuiteDurations_NilTestSuites(t *testing.T) {
+	mockAPI := &MockDurationsAPI{
+		Responses: []*durationsResponseAttributes{
+			{
+				TestSuites: nil,
+			},
+		},
+	}
+
+	client := NewDurationsClientWithDependencies(mockAPI)
+	result, err := client.GetTestSuiteDurations("github.com/DataDog/foo", "my-service")
+
+	if err != nil {
+		t.Errorf("GetTestSuiteDurations() should not return error, got: %v", err)
+	}
+
+	if result == nil {
+		t.Error("GetTestSuiteDurations() should return non-nil map even with nil test suites")
+	}
+
+	if len(result) != 0 {
+		t.Errorf("GetTestSuiteDurations() should return empty map, got %d modules", len(result))
+	}
+}
+
+func TestDurationsClient_GetTestSuiteDurations_APIError(t *testing.T) {
+	mockAPI := &MockDurationsAPI{
+		ResponseErrors: []error{fmt.Errorf("connection refused")},
+	}
+
+	client := NewDurationsClientWithDependencies(mockAPI)
+	result, err := client.GetTestSuiteDurations("github.com/DataDog/foo", "my-service")
+
+	if err == nil {
+		t.Error("GetTestSuiteDurations() should return error when API fails")
+	}
+
+	if result != nil {
+		t.Error("GetTestSuiteDurations() should return nil result when API fails")
+	}
+}
+
+func TestDurationsClient_GetTestSuiteDurations_PaginationError(t *testing.T) {
+	mockAPI := &MockDurationsAPI{
+		Responses: []*durationsResponseAttributes{
+			{
+				TestSuites: map[string]map[string]TestSuiteDurationInfo{
+					"module1": {
+						"suite1": {
+							SourceFile: "spec/user_spec.rb",
+							Duration:   DurationPercentiles{P50: "280000000", P90: "350000000"},
+						},
+					},
+				},
+				PageInfo: &durationsResponsePageInfo{
+					Cursor:  "abc123",
+					Size:    500,
+					HasNext: true,
+				},
+			},
+		},
+		ResponseErrors: []error{nil, fmt.Errorf("timeout on second page")},
+	}
+
+	client := NewDurationsClientWithDependencies(mockAPI)
+	result, err := client.GetTestSuiteDurations("github.com/DataDog/foo", "my-service")
+
+	if err == nil {
+		t.Error("GetTestSuiteDurations() should return error when pagination fails")
+	}
+
+	if result != nil {
+		t.Error("GetTestSuiteDurations() should return nil result when pagination fails")
+	}
+}
+
+func TestDurationsClient_GetTestSuiteDurations_NilPageInfo(t *testing.T) {
+	mockAPI := &MockDurationsAPI{
+		Responses: []*durationsResponseAttributes{
+			{
+				TestSuites: map[string]map[string]TestSuiteDurationInfo{
+					"module1": {
+						"suite1": {
+							SourceFile: "spec/user_spec.rb",
+							Duration:   DurationPercentiles{P50: "280000000", P90: "350000000"},
+						},
+					},
+				},
+				PageInfo: nil,
+			},
+		},
+	}
+
+	client := NewDurationsClientWithDependencies(mockAPI)
+	result, err := client.GetTestSuiteDurations("github.com/DataDog/foo", "my-service")
+
+	if err != nil {
+		t.Errorf("GetTestSuiteDurations() should not return error, got: %v", err)
+	}
+
+	if len(result) != 1 {
+		t.Errorf("Expected 1 module, got %d", len(result))
+	}
+
+	// Should only make one API call (no pagination)
+	if len(mockAPI.Cursors) != 1 {
+		t.Errorf("Expected 1 API call when PageInfo is nil, got %d", len(mockAPI.Cursors))
+	}
+}
+
+func TestDurationsClient_GetTestSuiteDurations_ThreePages(t *testing.T) {
+	mockAPI := &MockDurationsAPI{
+		Responses: []*durationsResponseAttributes{
+			{
+				TestSuites: map[string]map[string]TestSuiteDurationInfo{
+					"module1": {
+						"suite1": {
+							SourceFile: "spec/a_spec.rb",
+							Duration:   DurationPercentiles{P50: "100", P90: "200"},
+						},
+					},
+				},
+				PageInfo: &durationsResponsePageInfo{Cursor: "page2", HasNext: true},
+			},
+			{
+				TestSuites: map[string]map[string]TestSuiteDurationInfo{
+					"module1": {
+						"suite2": {
+							SourceFile: "spec/b_spec.rb",
+							Duration:   DurationPercentiles{P50: "300", P90: "400"},
+						},
+					},
+				},
+				PageInfo: &durationsResponsePageInfo{Cursor: "page3", HasNext: true},
+			},
+			{
+				TestSuites: map[string]map[string]TestSuiteDurationInfo{
+					"module1": {
+						"suite3": {
+							SourceFile: "spec/c_spec.rb",
+							Duration:   DurationPercentiles{P50: "500", P90: "600"},
+						},
+					},
+				},
+				PageInfo: &durationsResponsePageInfo{HasNext: false},
+			},
+		},
+	}
+
+	client := NewDurationsClientWithDependencies(mockAPI)
+	result, err := client.GetTestSuiteDurations("github.com/DataDog/foo", "my-service")
+
+	if err != nil {
+		t.Errorf("GetTestSuiteDurations() should not return error, got: %v", err)
+	}
+
+	if len(mockAPI.Cursors) != 3 {
+		t.Errorf("Expected 3 API calls, got %d", len(mockAPI.Cursors))
+	}
+
+	if mockAPI.Cursors[0] != "" {
+		t.Errorf("First cursor should be empty, got '%s'", mockAPI.Cursors[0])
+	}
+	if mockAPI.Cursors[1] != "page2" {
+		t.Errorf("Second cursor should be 'page2', got '%s'", mockAPI.Cursors[1])
+	}
+	if mockAPI.Cursors[2] != "page3" {
+		t.Errorf("Third cursor should be 'page3', got '%s'", mockAPI.Cursors[2])
+	}
+
+	module1 := result["module1"]
+	if len(module1) != 3 {
+		t.Errorf("Expected 3 suites merged in module1, got %d", len(module1))
+	}
+}
+
+func TestDatadogDurationsAPI_FetchTestSuiteDurations_EmptyRepositoryURL(t *testing.T) {
+	api := &DatadogDurationsAPI{
+		baseURL: "https://api.datadoghq.com",
+		headers: map[string]string{"dd-api-key": "test-key"},
+	}
+
+	_, err := api.FetchTestSuiteDurations("", "my-service", "", 100)
+
+	if err == nil {
+		t.Error("FetchTestSuiteDurations() should return error when repository URL is empty")
+	}
+}

--- a/internal/testoptimization/durations_client_test.go
+++ b/internal/testoptimization/durations_client_test.go
@@ -2,7 +2,12 @@ package testoptimization
 
 import (
 	"fmt"
+	"net/http"
+	"os"
+	"strings"
 	"testing"
+
+	"github.com/DataDog/ddtest/civisibility/constants"
 )
 
 // MockDurationsAPI implements DurationsAPI for testing (equivalent of MockCIVisibilityIntegrations)
@@ -440,5 +445,48 @@ func TestDatadogDurationsAPI_FetchTestSuiteDurations_EmptyRepositoryURL(t *testi
 
 	if err == nil {
 		t.Error("FetchTestSuiteDurations() should return error when repository URL is empty")
+	}
+}
+
+func TestNewDatadogDurationsAPI_AgentlessMissingAPIKeyReturnsErroringClient(t *testing.T) {
+	t.Setenv(constants.CIVisibilityAgentlessEnabledEnvironmentVariable, "true")
+	t.Setenv(constants.APIKeyEnvironmentVariable, "")
+
+	api := NewDatadogDurationsAPI()
+	if api == nil {
+		t.Fatal("NewDatadogDurationsAPI() should return an erroring client, not nil")
+	}
+
+	_, err := api.FetchTestSuiteDurations("github.com/DataDog/foo", "my-service", "", 100)
+	if err == nil {
+		t.Fatal("FetchTestSuiteDurations() should return an error when API key is missing")
+	}
+	if !strings.Contains(err.Error(), constants.APIKeyEnvironmentVariable) {
+		t.Errorf("Expected error to mention missing API key, got %v", err)
+	}
+}
+
+func TestNewDatadogDurationsAPI_AgentUnixSocketConfiguresHTTPTransport(t *testing.T) {
+	socketPath := "/tmp/ddtest-agent.sock"
+	t.Setenv(constants.CIVisibilityAgentlessEnabledEnvironmentVariable, "false")
+	t.Setenv("DD_TRACE_AGENT_URL", "unix://"+socketPath)
+	t.Setenv("DD_AGENT_HOST", "")
+	t.Setenv("DD_TRACE_AGENT_PORT", "")
+	t.Cleanup(func() {
+		_ = os.Unsetenv("DD_TRACE_AGENT_URL")
+	})
+
+	api := NewDatadogDurationsAPI()
+	if api == nil {
+		t.Fatal("NewDatadogDurationsAPI() should return a client")
+	}
+	if api.baseURL != "http://UDS__tmp_ddtest-agent.sock" {
+		t.Errorf("Expected UDS base URL host, got %q", api.baseURL)
+	}
+	if api.httpClient == nil {
+		t.Fatal("Expected HTTP client to be configured")
+	}
+	if _, ok := api.httpClient.Transport.(*http.Transport); !ok {
+		t.Fatalf("Expected Unix socket HTTP transport, got %T", api.httpClient.Transport)
 	}
 }


### PR DESCRIPTION
## Summary
Adds support for the test suite durations backend API and uses that data to improve ddtest planning.

- Adds a Datadog test suite durations client for `POST /api/v2/ci/ddtest/test_suite_durations`, including pagination and in-memory storage.
- Fetches suite durations during test optimization setup without failing planning when the API errors or returns no data.
- Tracks discovered tests as suite aggregates with total duration, estimated runnable duration, test count, and skipped test count.
- Uses backend p50 durations to weight test files for splitting, with count-based fallbacks when backend data is unavailable.
- Calculates skippable percentage from estimated saved duration instead of raw skipped test count.
- Handles repo-root vs subdirectory execution paths so backend source files can match locally discovered files.
- Ensures backend-only/stale suites are only added when their source file exists in local discovery results.

## Testing
Automated validation:
- `make test`
- `make lint`

E2E validation should cover:

- Full discovery with ITR enabled: verify discovered suites are aggregated, skipped tests are omitted from runnable files, and backend p50 durations affect split weights.
- Fast discovery path with ITR/test skipping disabled: verify ddtest runs only locally discovered test files and does not reintroduce deleted/stale files returned by the backend.
- Backend durations API behavior: verify successful non-empty response, empty response warning, and API error handling all keep planning non-fatal.
- Duration-based skippable percentage: verify the output percentage and parallel runner count reflect saved time, not skipped test count.
- Missing/invalid backend durations: verify ddtest falls back to count-based suite duration and still creates valid splits.
- Subdirectory execution: run ddtest from a repo subdirectory and verify git-root-relative backend source files map to CWD-relative runnable files.
- Split execution: verify generated test split files contain only runnable local test files and are weighted by backend durations where available.