### PR TITLE
Bump Go toolchain to 1.26.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v5
         with:
-          go-version: "1.26.x"
+          go-version: "1.26.2"
 
       - name: Cache Go modules
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
@@ -26,9 +26,9 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.26-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-1.26.2-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-1.26-
+            ${{ runner.os }}-go-1.26.2-
 
       - name: Download dependencies
         run: go mod download
@@ -58,7 +58,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v5
         with:
-          go-version: "1.26.x"
+          go-version: "1.26.2"
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v6

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v5
         with:
-          go-version: '1.26'
+          go-version: '1.26.2'
 
       - name: Build binaries
         run: make release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v5
         with:
-          go-version: '1.26'
+          go-version: '1.26.2'
 
       - name: Build binaries
         run: make release

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ go test -v ./...           # Verbose testing
 ## Development
 
 - Uses `dd-trace-go/v2` for Datadog tracing and CI Visibility
-- Use go 1.26
+- Use go 1.26.2
 - Use `strings` and `slices` packages, don't write your own string manipulation functions
 - Always run `make test` after any change. Any new functionality must be covered by test.
 - Always run `make lint` after any change. Address any linting issues found.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ git clone https://github.com/DataDog/ddtest.git
 cd ddtest && make build
 ```
 
-This will create the `ddtest` binary in the current directory. It requires Go 1.26+.
+This will create the `ddtest` binary in the current directory. It requires Go 1.26.2+.
 
 ## Prerequisites
 
@@ -521,7 +521,7 @@ The `--runtime-tags` option lets you override your local runtime tags to match y
 
 ### Prerequisites
 
-- Go 1.26.0 or later
+- Go 1.26.2 or later
 
 ### Building
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/DataDog/ddtest
 
 go 1.26
 
+toolchain go1.26.2
+
 require (
 	github.com/DataDog/dd-trace-go/v2 v2.7.1
 	github.com/bmatcuk/doublestar/v4 v4.10.0


### PR DESCRIPTION
- pin the local Go toolchain to 1.26.2 in `go.mod`
- update CI, prerelease, and release workflows to use Go 1.26.2 consistently
- refresh repo documentation to reflect the 1.26.2 minimum required for the CVE-driven upgrade

