### PR TITLE
[SDTEST-3758] Improve the sub-CI-node parallelism

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,14 @@ go test -v ./...           # Verbose testing
 - Always run `make test` after any change. Any new functionality must be covered by test.
 - Always run `make lint` after any change. Address any linting issues found.
 
+## Pull Requests
+
+When opening a pull request for this repository, use exactly these sections:
+
+1. `What`: Briefly describe the user-visible behavior change.
+2. `Why`: Explain the customer problem and motivation. Link to relevant external docs when they are part of the rationale.
+3. `E2E testing`: Provide a concrete manual end-to-end test scenario for the change.
+
 ## Architecture
 
 ### Core Components

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Runs tests using the framework you specify. If .testoptimization/ exists, DDTest
 ddtest run --platform ruby --framework rspec
 ```
 
-The default --min-parallelism and --max-parallelism equal the machine’s vCPU count, so you get full CPU utilization without extra flags.
+The default --min-parallelism and --max-parallelism equal the machine's available physical CPU core count, so you get CPU utilization without defaulting to one worker per hyperthread.
 
 **Multiple CI nodes (static split per node)**
 
@@ -138,7 +138,7 @@ First run `ddtest plan` once, share `.testoptimization/` folder to all nodes (pu
 ddtest run --platform ruby --framework rspec --ci-node <CI_NODE_INDEX>
 ```
 
-In CI‑node mode, DDTest also fans out across local CPUs on that node and further splits the assigned files between them.
+In CI-node mode, DDTest uses one local worker by default so database and other per-worker resources stay easy to isolate. To fan out within each CI node, set `--ci-node-workers` to a positive integer, or use `--ci-node-workers ncpu` to use the node's available physical CPU cores.
 
 ### Settings (flags and environment variables)
 
@@ -146,10 +146,10 @@ In CI‑node mode, DDTest also fans out across local CPUs on that node and furth
 | ------------------- | --------------------------------------------- | ---------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--platform`        | `DD_TEST_OPTIMIZATION_RUNNER_PLATFORM`        |     `ruby` | Language/platform (currently supported values: `ruby`).                                                                                                                                                              |
 | `--framework`       | `DD_TEST_OPTIMIZATION_RUNNER_FRAMEWORK`       |    `rspec` | Test framework (currently supported values: `rspec`, `minitest`).                                                                                                                                                    |
-| `--min-parallelism` | `DD_TEST_OPTIMIZATION_RUNNER_MIN_PARALLELISM` | vCPU count | Minimum workers to use for the split.                                                                                                                                                                                |
-| `--max-parallelism` | `DD_TEST_OPTIMIZATION_RUNNER_MAX_PARALLELISM` | vCPU count | Maximum workers to use for the split.                                                                                                                                                                                |
-|                     | `DD_TEST_OPTIMIZATION_RUNNER_CI_NODE`         | `-1` (off) | Restrict this run to the slice assigned to node **N** (0‑indexed). Also parallelizes within the node across its CPUs.                                                                                                |
-| `--ci-node-workers` | `DD_TEST_OPTIMIZATION_RUNNER_CI_NODE_WORKERS` | vCPU count | Number of parallel workers per CI node. Tests assigned to a CI node are further split among this many local workers.                                                                                                 |
+| `--min-parallelism` | `DD_TEST_OPTIMIZATION_RUNNER_MIN_PARALLELISM` | physical CPU count | Minimum workers to use for the split.                                                                                                                                                                                |
+| `--max-parallelism` | `DD_TEST_OPTIMIZATION_RUNNER_MAX_PARALLELISM` | physical CPU count | Maximum workers to use for the split.                                                                                                                                                                                |
+|                     | `DD_TEST_OPTIMIZATION_RUNNER_CI_NODE`         | `-1` (off) | Restrict this run to the slice assigned to node **N** (0-indexed).                                                                                                                                                   |
+| `--ci-node-workers` | `DD_TEST_OPTIMIZATION_RUNNER_CI_NODE_WORKERS` |        `1` | Number of parallel workers per CI node. Use a positive integer, or `ncpu` to use the node's available physical CPU cores. Tests assigned to a CI node are further split among this many local workers.                |
 | `--worker-env`      | `DD_TEST_OPTIMIZATION_RUNNER_WORKER_ENV`      |       `""` | Template env vars per worker: `--worker-env "DATABASE_NAME_TEST=app_test{{nodeIndex}}"`. In CI-node mode, `{{nodeIndex}}` is `ciNode * 10000 + localWorkerIndex`, ensuring uniqueness across heterogeneous CI pools. |
 | `--command`         | `DD_TEST_OPTIMIZATION_RUNNER_COMMAND`         |       `""` | Override the default test command used by the framework. When provided, takes precedence over auto-detection (e.g., `--command "bundle exec custom-rspec"`).                                                         |
 | `--tests-location`  | `DD_TEST_OPTIMIZATION_RUNNER_TESTS_LOCATION`  |       `""` | Custom glob pattern to discover test files (e.g., `--tests-location "custom/spec/**/*_spec.rb"`). Defaults to `spec/**/*_spec.rb` for RSpec, `test/**/*_test.rb` for Minitest.                                       |

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.2
 require (
 	github.com/DataDog/dd-trace-go/v2 v2.7.3
 	github.com/bmatcuk/doublestar/v4 v4.10.0
+	github.com/klauspost/cpuid/v2 v2.3.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	github.com/tinylib/msgp v1.6.4
@@ -48,7 +49,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.18.4 // indirect
-	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/linkdata/deadlock v0.5.5 // indirect
 	github.com/lufia/plan9stats v0.0.0-20260216142805-b3301c5f2a88 // indirect
 	github.com/minio/simdjson-go v0.4.5 // indirect

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -57,10 +57,10 @@ var runCmd = &cobra.Command{
 func init() {
 	rootCmd.PersistentFlags().String("platform", "ruby", "Platform that runs tests")
 	rootCmd.PersistentFlags().String("framework", "rspec", "Test framework to use")
-	rootCmd.PersistentFlags().Int("min-parallelism", defaultParallelism, "Minimum number of parallel test processes (default: number of CPUs)")
-	rootCmd.PersistentFlags().Int("max-parallelism", defaultParallelism, "Maximum number of parallel test processes (default: number of CPUs)")
+	rootCmd.PersistentFlags().Int("min-parallelism", defaultParallelism, "Minimum number of parallel test processes (default: number of physical CPUs)")
+	rootCmd.PersistentFlags().Int("max-parallelism", defaultParallelism, "Maximum number of parallel test processes (default: number of physical CPUs)")
 	rootCmd.PersistentFlags().String("worker-env", "", "Worker environment configuration")
-	rootCmd.PersistentFlags().Int("ci-node-workers", defaultParallelism, "Number of parallel workers per CI node (default: number of CPUs)")
+	rootCmd.PersistentFlags().String("ci-node-workers", "1", `Number of parallel workers per CI node (positive integer or "ncpu"; default: 1)`)
 	rootCmd.PersistentFlags().String("command", "", "Test command that ddtest should wrap")
 	rootCmd.PersistentFlags().String("tests-location", "", "Glob pattern used to discover test files")
 	rootCmd.PersistentFlags().String("runtime-tags", "", "JSON string to override runtime tags (e.g. '{\"os.platform\":\"linux\",\"runtime.version\":\"3.2.0\"}')")

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -39,6 +39,12 @@ func TestRootCommandFlags(t *testing.T) {
 		return
 	}
 
+	ciNodeWorkersFlag := rootCmd.PersistentFlags().Lookup("ci-node-workers")
+	if ciNodeWorkersFlag == nil {
+		t.Error("ci-node-workers flag should be defined")
+		return
+	}
+
 	// Check default values
 	if platformFlag.DefValue != "ruby" {
 		t.Errorf("expected platform default to be 'ruby', got %q", platformFlag.DefValue)
@@ -54,6 +60,10 @@ func TestRootCommandFlags(t *testing.T) {
 
 	if testsLocationFlag.DefValue != "" {
 		t.Errorf("expected tests-location default to be empty, got %q", testsLocationFlag.DefValue)
+	}
+
+	if ciNodeWorkersFlag.DefValue != "1" {
+		t.Errorf("expected ci-node-workers default to be '1', got %q", ciNodeWorkersFlag.DefValue)
 	}
 }
 
@@ -120,6 +130,9 @@ func TestFlagBinding(t *testing.T) {
 	if err := viper.BindPFlag("tests_location", rootCmd.PersistentFlags().Lookup("tests-location")); err != nil {
 		t.Fatalf("Error binding tests-location flag: %v", err)
 	}
+	if err := viper.BindPFlag("ci_node_workers", rootCmd.PersistentFlags().Lookup("ci-node-workers")); err != nil {
+		t.Fatalf("Error binding ci-node-workers flag: %v", err)
+	}
 
 	// Set flag values
 	if err := rootCmd.PersistentFlags().Set("platform", "python"); err != nil {
@@ -134,6 +147,9 @@ func TestFlagBinding(t *testing.T) {
 	if err := rootCmd.PersistentFlags().Set("tests-location", "spec/**/*_spec.rb"); err != nil {
 		t.Fatalf("Error setting tests-location flag: %v", err)
 	}
+	if err := rootCmd.PersistentFlags().Set("ci-node-workers", "ncpu"); err != nil {
+		t.Fatalf("Error setting ci-node-workers flag: %v", err)
+	}
 
 	// Check that viper picks up the flag values
 	if viper.GetString("platform") != "python" {
@@ -147,6 +163,9 @@ func TestFlagBinding(t *testing.T) {
 	}
 	if viper.GetString("tests_location") != "spec/**/*_spec.rb" {
 		t.Errorf("expected viper tests_location to be 'spec/**/*_spec.rb', got %q", viper.GetString("tests_location"))
+	}
+	if viper.GetString("ci_node_workers") != "ncpu" {
+		t.Errorf("expected viper ci_node_workers to be 'ncpu', got %q", viper.GetString("ci_node_workers"))
 	}
 }
 

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -5,15 +5,69 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strconv"
 	"strings"
 
+	"github.com/klauspost/cpuid/v2"
 	"github.com/spf13/viper"
 )
 
-// DefaultParallelism returns the default parallelism value, which is the number
-// of available CPUs. This respects container CPU limits in cloud CI environments.
+const (
+	defaultCiNodeWorkers = 1
+	ncpuCiNodeWorkers    = "ncpu"
+)
+
+// DefaultParallelism returns the default parallelism value.
 func DefaultParallelism() int {
-	return runtime.NumCPU()
+	return PhysicalCPUCount()
+}
+
+// PhysicalCPUCount returns the number of physical CPU cores available to this process.
+//
+// It starts from runtime.GOMAXPROCS(0), which is the number of logical CPUs the
+// Go scheduler may run on at once. That preserves explicit GOMAXPROCS settings
+// and modern Go's container-aware CPU budget instead of using the host's
+// full logical CPU count.
+//
+// It then converts that logical CPU budget to physical cores using CPU topology:
+// if cpuid reports threads-per-core, it divides by that value with a ceiling.
+// The ceiling is intentional: a one-logical-CPU quota still maps to one usable
+// physical core, and odd CPU budgets such as 3 logical CPUs on a 2-thread/core
+// machine should yield 2 physical cores instead of undercounting to 1. If
+// threads-per-core is unavailable, it derives the same ratio from reported
+// logical and physical core counts. If only the physical core count is known, it
+// caps the result to that count. If topology is unavailable entirely, it falls
+// back to the logical CPU budget, which is the safest non-zero answer.
+//
+// This is correct for ddtest's "ncpu" worker setting because the setting should
+// opt into one worker per available physical execution core, not one worker per
+// hyperthread. It also never returns less than 1, and never exceeds the process'
+// available logical CPU budget.
+func PhysicalCPUCount() int {
+	return physicalCPUCount(runtime.GOMAXPROCS(0), cpuid.CPU.ThreadsPerCore, cpuid.CPU.PhysicalCores, cpuid.CPU.LogicalCores)
+}
+
+func physicalCPUCount(availableLogicalCPUs, threadsPerCore, detectedPhysicalCores, detectedLogicalCores int) int {
+	if availableLogicalCPUs < 1 {
+		availableLogicalCPUs = 1
+	}
+	if threadsPerCore > 1 {
+		return ceilDiv(availableLogicalCPUs, threadsPerCore)
+	}
+	if detectedPhysicalCores > 0 && detectedLogicalCores > detectedPhysicalCores {
+		detectedThreadsPerCore := ceilDiv(detectedLogicalCores, detectedPhysicalCores)
+		if detectedThreadsPerCore > 1 {
+			return ceilDiv(availableLogicalCPUs, detectedThreadsPerCore)
+		}
+	}
+	if detectedPhysicalCores > 0 && detectedPhysicalCores < availableLogicalCPUs {
+		return detectedPhysicalCores
+	}
+	return availableLogicalCPUs
+}
+
+func ceilDiv(numerator, denominator int) int {
+	return (numerator + denominator - 1) / denominator
 }
 
 type Config struct {
@@ -40,6 +94,13 @@ func Init() {
 
 	setDefaults()
 
+	ciNodeWorkers, err := ParseCiNodeWorkers(viper.GetString("ci_node_workers"))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error loading config: %v\n", err)
+		os.Exit(1)
+	}
+	viper.Set("ci_node_workers", ciNodeWorkers)
+
 	config = &Config{}
 	if err := viper.Unmarshal(config); err != nil {
 		fmt.Fprintf(os.Stderr, "Error unmarshaling config: %v\n", err)
@@ -54,10 +115,31 @@ func setDefaults() {
 	viper.SetDefault("max_parallelism", DefaultParallelism())
 	viper.SetDefault("worker_env", "")
 	viper.SetDefault("ci_node", -1)
-	viper.SetDefault("ci_node_workers", DefaultParallelism())
+	viper.SetDefault("ci_node_workers", strconv.Itoa(defaultCiNodeWorkers))
 	viper.SetDefault("command", "")
 	viper.SetDefault("tests_location", "")
 	viper.SetDefault("runtime_tags", "")
+}
+
+// ParseCiNodeWorkers resolves the ci_node_workers setting from either a positive integer
+// or the "ncpu" magic value.
+func ParseCiNodeWorkers(value string) (int, error) {
+	normalized := strings.TrimSpace(value)
+	if normalized == "" {
+		return defaultCiNodeWorkers, nil
+	}
+	if strings.EqualFold(normalized, ncpuCiNodeWorkers) {
+		return PhysicalCPUCount(), nil
+	}
+
+	workers, err := strconv.Atoi(normalized)
+	if err != nil {
+		return 0, fmt.Errorf("ci_node_workers must be a positive integer or %q, got %q", ncpuCiNodeWorkers, value)
+	}
+	if workers < 1 {
+		return 0, fmt.Errorf("ci_node_workers must be greater than 0, got %d", workers)
+	}
+	return workers, nil
 }
 
 func Get() *Config {

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -2,7 +2,6 @@ package settings
 
 import (
 	"os"
-	"runtime"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -10,13 +9,80 @@ import (
 
 func TestDefaultParallelism(t *testing.T) {
 	result := DefaultParallelism()
-	expected := runtime.NumCPU()
+	expected := PhysicalCPUCount()
 
 	if result != expected {
-		t.Errorf("expected DefaultParallelism() to return %d (runtime.NumCPU()), got %d", expected, result)
+		t.Errorf("expected DefaultParallelism() to return %d (PhysicalCPUCount()), got %d", expected, result)
 	}
 	if result < 1 {
 		t.Errorf("expected DefaultParallelism() to be at least 1, got %d", result)
+	}
+}
+
+func TestPhysicalCPUCount(t *testing.T) {
+	result := PhysicalCPUCount()
+	if result < 1 {
+		t.Errorf("expected PhysicalCPUCount() to be at least 1, got %d", result)
+	}
+}
+
+func TestPhysicalCPUCountFromTopology(t *testing.T) {
+	tests := []struct {
+		name                  string
+		availableLogicalCPUs  int
+		threadsPerCore        int
+		detectedPhysicalCores int
+		detectedLogicalCores  int
+		expected              int
+	}{
+		{
+			name:                 "divides logical CPUs by threads per core",
+			availableLogicalCPUs: 8,
+			threadsPerCore:       2,
+			expected:             4,
+		},
+		{
+			name:                 "rounds up odd logical CPU quotas",
+			availableLogicalCPUs: 3,
+			threadsPerCore:       2,
+			expected:             2,
+		},
+		{
+			name:                  "uses detected topology when threads per core is missing",
+			availableLogicalCPUs:  8,
+			threadsPerCore:        1,
+			detectedPhysicalCores: 4,
+			detectedLogicalCores:  8,
+			expected:              4,
+		},
+		{
+			name:                  "does not exceed available logical CPUs",
+			availableLogicalCPUs:  2,
+			threadsPerCore:        1,
+			detectedPhysicalCores: 4,
+			detectedLogicalCores:  4,
+			expected:              2,
+		},
+		{
+			name:                 "clamps invalid available logical CPU count",
+			availableLogicalCPUs: 0,
+			threadsPerCore:       2,
+			expected:             1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := physicalCPUCount(
+				tt.availableLogicalCPUs,
+				tt.threadsPerCore,
+				tt.detectedPhysicalCores,
+				tt.detectedLogicalCores,
+			)
+			if result != tt.expected {
+				t.Errorf("expected %d, got %d", tt.expected, result)
+			}
+		})
 	}
 }
 
@@ -38,12 +104,12 @@ func TestInit(t *testing.T) {
 	if config.Framework != "rspec" {
 		t.Errorf("expected default framework to be 'rspec', got %q", config.Framework)
 	}
-	expectedParallelism := runtime.NumCPU()
+	expectedParallelism := PhysicalCPUCount()
 	if config.MinParallelism != expectedParallelism {
-		t.Errorf("expected default min_parallelism to be %d (CPU count), got %d", expectedParallelism, config.MinParallelism)
+		t.Errorf("expected default min_parallelism to be %d (physical CPU count), got %d", expectedParallelism, config.MinParallelism)
 	}
 	if config.MaxParallelism != expectedParallelism {
-		t.Errorf("expected default max_parallelism to be %d (CPU count), got %d", expectedParallelism, config.MaxParallelism)
+		t.Errorf("expected default max_parallelism to be %d (physical CPU count), got %d", expectedParallelism, config.MaxParallelism)
 	}
 	if config.WorkerEnv != "" {
 		t.Errorf("expected default worker_env to be empty, got %q", config.WorkerEnv)
@@ -51,8 +117,8 @@ func TestInit(t *testing.T) {
 	if config.CiNode != -1 {
 		t.Errorf("expected default ci_node to be -1, got %d", config.CiNode)
 	}
-	if config.CiNodeWorkers != expectedParallelism {
-		t.Errorf("expected default ci_node_workers to be %d (CPU count), got %d", expectedParallelism, config.CiNodeWorkers)
+	if config.CiNodeWorkers != 1 {
+		t.Errorf("expected default ci_node_workers to be 1, got %d", config.CiNodeWorkers)
 	}
 	if config.Command != "" {
 		t.Errorf("expected default command to be empty, got %q", config.Command)
@@ -76,12 +142,12 @@ func TestSetDefaults(t *testing.T) {
 	if viper.GetString("framework") != "rspec" {
 		t.Errorf("expected default framework to be 'rspec', got %q", viper.GetString("framework"))
 	}
-	expectedParallelism := runtime.NumCPU()
+	expectedParallelism := PhysicalCPUCount()
 	if viper.GetInt("min_parallelism") != expectedParallelism {
-		t.Errorf("expected default min_parallelism to be %d (CPU count), got %d", expectedParallelism, viper.GetInt("min_parallelism"))
+		t.Errorf("expected default min_parallelism to be %d (physical CPU count), got %d", expectedParallelism, viper.GetInt("min_parallelism"))
 	}
 	if viper.GetInt("max_parallelism") != expectedParallelism {
-		t.Errorf("expected default max_parallelism to be %d (CPU count), got %d", expectedParallelism, viper.GetInt("max_parallelism"))
+		t.Errorf("expected default max_parallelism to be %d (physical CPU count), got %d", expectedParallelism, viper.GetInt("max_parallelism"))
 	}
 	if viper.GetString("worker_env") != "" {
 		t.Errorf("expected default worker_env to be empty, got %q", viper.GetString("worker_env"))
@@ -89,8 +155,8 @@ func TestSetDefaults(t *testing.T) {
 	if viper.GetInt("ci_node") != -1 {
 		t.Errorf("expected default ci_node to be -1, got %d", viper.GetInt("ci_node"))
 	}
-	if viper.GetInt("ci_node_workers") != expectedParallelism {
-		t.Errorf("expected default ci_node_workers to be %d (CPU count), got %d", expectedParallelism, viper.GetInt("ci_node_workers"))
+	if viper.GetInt("ci_node_workers") != 1 {
+		t.Errorf("expected default ci_node_workers to be 1, got %d", viper.GetInt("ci_node_workers"))
 	}
 	if viper.GetString("command") != "" {
 		t.Errorf("expected default command to be empty, got %q", viper.GetString("command"))
@@ -225,10 +291,10 @@ func TestGetMinParallelism(t *testing.T) {
 	config = nil
 	viper.Reset()
 
-	expectedParallelism := runtime.NumCPU()
+	expectedParallelism := PhysicalCPUCount()
 	minParallelism := GetMinParallelism()
 	if minParallelism != expectedParallelism {
-		t.Errorf("expected min_parallelism to be %d (CPU count), got %d", expectedParallelism, minParallelism)
+		t.Errorf("expected min_parallelism to be %d (physical CPU count), got %d", expectedParallelism, minParallelism)
 	}
 
 	// Test with custom value
@@ -244,10 +310,10 @@ func TestGetMaxParallelism(t *testing.T) {
 	config = nil
 	viper.Reset()
 
-	expectedParallelism := runtime.NumCPU()
+	expectedParallelism := PhysicalCPUCount()
 	maxParallelism := GetMaxParallelism()
 	if maxParallelism != expectedParallelism {
-		t.Errorf("expected max_parallelism to be %d (CPU count), got %d", expectedParallelism, maxParallelism)
+		t.Errorf("expected max_parallelism to be %d (physical CPU count), got %d", expectedParallelism, maxParallelism)
 	}
 
 	// Test with custom value
@@ -409,10 +475,9 @@ func TestGetCiNodeWorkers(t *testing.T) {
 	config = nil
 	viper.Reset()
 
-	expectedParallelism := runtime.NumCPU()
 	ciNodeWorkers := GetCiNodeWorkers()
-	if ciNodeWorkers != expectedParallelism {
-		t.Errorf("expected ci_node_workers to be %d (CPU count), got %d", expectedParallelism, ciNodeWorkers)
+	if ciNodeWorkers != 1 {
+		t.Errorf("expected ci_node_workers to be 1, got %d", ciNodeWorkers)
 	}
 
 	// Test with custom value
@@ -420,6 +485,93 @@ func TestGetCiNodeWorkers(t *testing.T) {
 	ciNodeWorkers = GetCiNodeWorkers()
 	if ciNodeWorkers != 4 {
 		t.Errorf("expected ci_node_workers to be 4, got %d", ciNodeWorkers)
+	}
+}
+
+func TestParseCiNodeWorkers(t *testing.T) {
+	physicalCPUCount := PhysicalCPUCount()
+	tests := []struct {
+		name      string
+		value     string
+		expected  int
+		expectErr bool
+	}{
+		{
+			name:     "empty value uses default",
+			value:    "",
+			expected: 1,
+		},
+		{
+			name:     "positive integer",
+			value:    "4",
+			expected: 4,
+		},
+		{
+			name:     "trims whitespace",
+			value:    " 3 ",
+			expected: 3,
+		},
+		{
+			name:     "ncpu magic value",
+			value:    "ncpu",
+			expected: physicalCPUCount,
+		},
+		{
+			name:     "ncpu is case insensitive",
+			value:    "NCPU",
+			expected: physicalCPUCount,
+		},
+		{
+			name:      "rejects zero",
+			value:     "0",
+			expectErr: true,
+		},
+		{
+			name:      "rejects negative values",
+			value:     "-1",
+			expectErr: true,
+		},
+		{
+			name:      "rejects unknown strings",
+			value:     "many",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ParseCiNodeWorkers(tt.value)
+			if tt.expectErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if result != tt.expected {
+				t.Errorf("expected %d, got %d", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestEnvironmentVariableCiNodeWorkersNCPU(t *testing.T) {
+	config = nil
+	viper.Reset()
+
+	_ = os.Setenv("DD_TEST_OPTIMIZATION_RUNNER_CI_NODE_WORKERS", "ncpu")
+	defer func() {
+		_ = os.Unsetenv("DD_TEST_OPTIMIZATION_RUNNER_CI_NODE_WORKERS")
+	}()
+
+	Init()
+
+	expected := PhysicalCPUCount()
+	if config.CiNodeWorkers != expected {
+		t.Errorf("expected ci_node_workers from ncpu env var to be %d, got %d", expected, config.CiNodeWorkers)
 	}
 }
 


### PR DESCRIPTION
## What

- Sets the default number of workers per CI node to 1
- Adds magical value "ncpu" for the number of CI node workers that sets the number to the number of physical CPUs available
- Adds an algorithm for computing (guessing?) the number of physical CPUs available
- Sets default parallelism to the number of physical CPUs

## Why

CircleCI documents resource classes as vCPU budgets, and on the Docker executor CPU introspection can report total host cores rather than the job’s resource class. Therefore DDTest should not assume that detected CPU/core counts are a safe default for local worker fan-out: we have to try to calculate the number of physical cores we have based on the information we detect from the system.

Defaulting local workers inside every CI node to the CPU budget makes DDTest unexpectedly subsplit a node. That surprises customers because database isolation is no longer only a per-node concern. A setup that has one isolated test database per CircleCI node suddenly also needs isolated databases for each local worker inside that same node.

## Manual e2e scenario

1. Use a test project configured for Datadog Test Optimization and DDTest.
2. Run `ddtest plan` once and share the generated `.testoptimization/` directory with every node.
3. Run `ddtest run --ci-node <index>` without setting `--ci-node-workers`.
4. Confirm CI node runs its assigned slice with one local worker, and a per-node database name remains sufficient.
5. Re-run a node with `--ci-node-workers 2` and confirm the node is subsplit into two local workers and worker env templating produces distinct local worker indexes.
6. Re-run a node with `--ci-node-workers ncpu` and confirm the local worker count follows the available CPU-derived value for that job resource class.