### PR TITLE
[SDTEST-3759] Use cached weights for CI node subsplits

### DIFF
--- a/internal/runner/ci_node_executor.go
+++ b/internal/runner/ci_node_executor.go
@@ -14,13 +14,13 @@ import (
 
 // runCINodeTests executes tests for a specific CI node (one split, not the whole tests set).
 // It further splits the node's tests among local workers based on ci_node_workers setting.
-func runCINodeTests(ctx context.Context, framework framework.Framework, workerEnvMap map[string]string, ciNode int) error {
-	return runCINodeTestsWithWorkers(ctx, framework, workerEnvMap, ciNode, settings.GetCiNodeWorkers())
+func runCINodeTests(ctx context.Context, framework framework.Framework, workerEnvMap map[string]string, ciNode int, testFileWeights map[string]int) error {
+	return runCINodeTestsWithWorkers(ctx, framework, workerEnvMap, ciNode, settings.GetCiNodeWorkers(), testFileWeights)
 }
 
 // runCINodeTestsWithWorkers is the internal implementation that accepts ciNodeWorkers as a parameter
 // for easier testing.
-func runCINodeTestsWithWorkers(ctx context.Context, framework framework.Framework, workerEnvMap map[string]string, ciNode int, ciNodeWorkers int) error {
+func runCINodeTestsWithWorkers(ctx context.Context, framework framework.Framework, workerEnvMap map[string]string, ciNode int, ciNodeWorkers int, testFileWeights map[string]int) error {
 	runnerFilePath := fmt.Sprintf("%s/runner-%d", constants.TestsSplitDir, ciNode)
 	if _, err := os.Stat(runnerFilePath); os.IsNotExist(err) {
 		return fmt.Errorf("runner file for ci-node %d does not exist: %s", ciNode, runnerFilePath)
@@ -46,7 +46,7 @@ func runCINodeTestsWithWorkers(ctx context.Context, framework framework.Framewor
 	slog.Info("Running tests for CI node in parallel mode",
 		"ciNode", ciNode, "ciNodeWorkers", ciNodeWorkers, "testFilesCount", len(testFiles))
 
-	groups := subsplitTestsBetweenWorkers(testFiles, ciNodeWorkers)
+	groups := subsplitTestsBetweenWorkers(testFiles, ciNodeWorkers, testFileWeights)
 
 	var g errgroup.Group
 	for workerIndex, groupFiles := range groups {
@@ -66,21 +66,22 @@ func runCINodeTestsWithWorkers(ctx context.Context, framework framework.Framewor
 }
 
 // subsplitTestsBetweenWorkers splits a CI node's test files among local workers
-// using simple round-robin distribution.
-func subsplitTestsBetweenWorkers(testFiles []string, n int) [][]string {
+// using the same weighted distribution algorithm used for CI node splits.
+func subsplitTestsBetweenWorkers(testFiles []string, n int, testFileWeights map[string]int) [][]string {
 	if n <= 0 {
 		n = 1
 	}
 
-	result := make([][]string, n)
-	for i := range result {
-		result[i] = []string{}
+	weightedTestFiles := make(map[string]int, len(testFiles))
+	for _, testFile := range testFiles {
+		weight := defaultTestFileWeight
+		if testFileWeights != nil {
+			if cachedWeight, ok := testFileWeights[testFile]; ok && cachedWeight > 0 {
+				weight = cachedWeight
+			}
+		}
+		weightedTestFiles[testFile] = weight
 	}
 
-	for i, file := range testFiles {
-		groupIndex := i % n
-		result[groupIndex] = append(result[groupIndex], file)
-	}
-
-	return result
+	return DistributeTestFiles(weightedTestFiles, n)
 }

--- a/internal/runner/ci_node_executor.go
+++ b/internal/runner/ci_node_executor.go
@@ -8,19 +8,12 @@ import (
 
 	"github.com/DataDog/ddtest/internal/constants"
 	"github.com/DataDog/ddtest/internal/framework"
-	"github.com/DataDog/ddtest/internal/settings"
 	"golang.org/x/sync/errgroup"
 )
 
 // runCINodeTests executes tests for a specific CI node (one split, not the whole tests set).
 // It further splits the node's tests among local workers based on ci_node_workers setting.
-func runCINodeTests(ctx context.Context, framework framework.Framework, workerEnvMap map[string]string, ciNode int, testFileWeights map[string]int) error {
-	return runCINodeTestsWithWorkers(ctx, framework, workerEnvMap, ciNode, settings.GetCiNodeWorkers(), testFileWeights)
-}
-
-// runCINodeTestsWithWorkers is the internal implementation that accepts ciNodeWorkers as a parameter
-// for easier testing.
-func runCINodeTestsWithWorkers(ctx context.Context, framework framework.Framework, workerEnvMap map[string]string, ciNode int, ciNodeWorkers int, testFileWeights map[string]int) error {
+func runCINodeTests(ctx context.Context, framework framework.Framework, workerEnvMap map[string]string, ciNode int, ciNodeWorkers int, testFileWeights map[string]int) error {
 	runnerFilePath := fmt.Sprintf("%s/runner-%d", constants.TestsSplitDir, ciNode)
 	if _, err := os.Stat(runnerFilePath); os.IsNotExist(err) {
 		return fmt.Errorf("runner file for ci-node %d does not exist: %s", ciNode, runnerFilePath)
@@ -46,6 +39,9 @@ func runCINodeTestsWithWorkers(ctx context.Context, framework framework.Framewor
 	slog.Info("Running tests for CI node in parallel mode",
 		"ciNode", ciNode, "ciNodeWorkers", ciNodeWorkers, "testFilesCount", len(testFiles))
 
+	if testFileWeights == nil {
+		testFileWeights = map[string]int{}
+	}
 	groups := subsplitTestsBetweenWorkers(testFiles, ciNodeWorkers, testFileWeights)
 
 	var g errgroup.Group
@@ -53,6 +49,11 @@ func runCINodeTestsWithWorkers(ctx context.Context, framework framework.Framewor
 		if len(groupFiles) == 0 {
 			continue
 		}
+
+		slog.Debug("Assigned test files to CI node worker",
+			"ciNode", ciNode,
+			"workerIndex", workerIndex,
+			"testFiles", groupFiles)
 
 		g.Go(func() error {
 			return runTestBatch(ctx, framework, groupFiles, workerEnvMap, ciNode, workerIndex)
@@ -72,16 +73,14 @@ func subsplitTestsBetweenWorkers(testFiles []string, n int, testFileWeights map[
 		n = 1
 	}
 
-	weightedTestFiles := make(map[string]int, len(testFiles))
+	nodeTestFiles := make(map[string]int, len(testFiles))
 	for _, testFile := range testFiles {
-		weight := defaultTestFileWeight
-		if testFileWeights != nil {
-			if cachedWeight, ok := testFileWeights[testFile]; ok && cachedWeight > 0 {
-				weight = cachedWeight
-			}
+		if cachedWeight, ok := testFileWeights[testFile]; ok && cachedWeight > 0 {
+			nodeTestFiles[testFile] = cachedWeight
+		} else {
+			nodeTestFiles[testFile] = defaultTestFileWeight
 		}
-		weightedTestFiles[testFile] = weight
 	}
 
-	return DistributeTestFiles(weightedTestFiles, n)
+	return DistributeTestFiles(nodeTestFiles, n)
 }

--- a/internal/runner/ci_node_executor_test.go
+++ b/internal/runner/ci_node_executor_test.go
@@ -27,9 +27,9 @@ func TestRunCINodeTests_SingleWorker(t *testing.T) {
 	}
 
 	// Test with single worker (ciNodeWorkers=1)
-	err := runCINodeTestsWithWorkers(context.Background(), mockFramework, map[string]string{}, 1, 1, nil)
+	err := runCINodeTests(context.Background(), mockFramework, map[string]string{}, 1, 1, nil)
 	if err != nil {
-		t.Fatalf("runCINodeTestsWithWorkers() should not return error, got: %v", err)
+		t.Fatalf("runCINodeTests() should not return error, got: %v", err)
 	}
 
 	// Verify RunTests was called exactly once
@@ -50,6 +50,7 @@ func TestRunCINodeTests_MultipleWorkers(t *testing.T) {
 	oldWd, _ := os.Getwd()
 	defer func() { _ = os.Chdir(oldWd) }()
 	_ = os.Chdir(tempDir)
+	logs := captureLogs(t)
 
 	// Setup test split directory and files - 4 test files for ci-node 1
 	_ = os.MkdirAll(filepath.Join(constants.PlanDirectory, "tests-split"), 0755)
@@ -62,9 +63,9 @@ func TestRunCINodeTests_MultipleWorkers(t *testing.T) {
 	}
 
 	// Test with 2 workers on ci-node 1
-	err := runCINodeTestsWithWorkers(context.Background(), mockFramework, map[string]string{}, 1, 2, nil)
+	err := runCINodeTests(context.Background(), mockFramework, map[string]string{}, 1, 2, nil)
 	if err != nil {
-		t.Fatalf("runCINodeTestsWithWorkers() should not return error, got: %v", err)
+		t.Fatalf("runCINodeTests() should not return error, got: %v", err)
 	}
 
 	// Verify RunTests was called twice (once per worker)
@@ -83,6 +84,21 @@ func TestRunCINodeTests_MultipleWorkers(t *testing.T) {
 	expectedFiles := []string{"test/file1_test.rb", "test/file2_test.rb", "test/file3_test.rb", "test/file4_test.rb"}
 	if !slices.Equal(allFiles, expectedFiles) {
 		t.Errorf("Expected all test files %v to be distributed, got %v", expectedFiles, allFiles)
+	}
+
+	logOutput := logs.String()
+	if strings.Contains(logOutput, "Assigned tests to CI node worker") {
+		t.Errorf("Expected no INFO logs for CI node worker assignments, got logs: %s", logOutput)
+	}
+	if strings.Count(logOutput, "Assigned test files to CI node worker") != 2 ||
+		!strings.Contains(logOutput, "ciNode=1") ||
+		!strings.Contains(logOutput, "workerIndex=0") ||
+		!strings.Contains(logOutput, "workerIndex=1") ||
+		!strings.Contains(logOutput, "test/file1_test.rb") ||
+		!strings.Contains(logOutput, "test/file2_test.rb") ||
+		!strings.Contains(logOutput, "test/file3_test.rb") ||
+		!strings.Contains(logOutput, "test/file4_test.rb") {
+		t.Errorf("Expected DEBUG logs with assigned CI node worker test files, got logs: %s", logOutput)
 	}
 }
 
@@ -108,9 +124,9 @@ func TestRunCINodeTests_NodeIndexMatchesCINode(t *testing.T) {
 	}
 
 	// Test with 2 workers on ci-node 1
-	err := runCINodeTestsWithWorkers(context.Background(), mockFramework, workerEnvMap, 1, 2, nil)
+	err := runCINodeTests(context.Background(), mockFramework, workerEnvMap, 1, 2, nil)
 	if err != nil {
-		t.Fatalf("runCINodeTestsWithWorkers() should not return error, got: %v", err)
+		t.Fatalf("runCINodeTests() should not return error, got: %v", err)
 	}
 
 	// Verify RunTests was called twice
@@ -161,9 +177,9 @@ func TestRunCINodeTests_SingleWorkerNodeIndex(t *testing.T) {
 		"WORKER_INDEX": "{{workerIndex}}",
 	}
 
-	err := runCINodeTestsWithWorkers(context.Background(), mockFramework, workerEnvMap, 2, 1, nil)
+	err := runCINodeTests(context.Background(), mockFramework, workerEnvMap, 2, 1, nil)
 	if err != nil {
-		t.Fatalf("runCINodeTestsWithWorkers() should not return error, got: %v", err)
+		t.Fatalf("runCINodeTests() should not return error, got: %v", err)
 	}
 
 	calls := mockFramework.GetRunTestsCalls()
@@ -190,9 +206,9 @@ func TestRunCINodeTests_FileNotFound(t *testing.T) {
 
 	mockFramework := &MockFramework{FrameworkName: "rspec"}
 
-	err := runCINodeTestsWithWorkers(context.Background(), mockFramework, map[string]string{}, 2, 1, nil)
+	err := runCINodeTests(context.Background(), mockFramework, map[string]string{}, 2, 1, nil)
 	if err == nil {
-		t.Error("runCINodeTestsWithWorkers() should return error when runner file doesn't exist")
+		t.Error("runCINodeTests() should return error when runner file doesn't exist")
 	}
 
 	expectedMsg := "runner file for ci-node 2 does not exist"
@@ -214,9 +230,9 @@ func TestRunCINodeTests_EmptyFile(t *testing.T) {
 	mockFramework := &MockFramework{FrameworkName: "rspec"}
 
 	// Should not error for empty file, just not run any tests
-	err := runCINodeTestsWithWorkers(context.Background(), mockFramework, map[string]string{}, 0, 2, nil)
+	err := runCINodeTests(context.Background(), mockFramework, map[string]string{}, 0, 2, nil)
 	if err != nil {
-		t.Fatalf("runCINodeTestsWithWorkers() should not return error for empty file, got: %v", err)
+		t.Fatalf("runCINodeTests() should not return error for empty file, got: %v", err)
 	}
 
 	// Verify no tests were run
@@ -228,7 +244,7 @@ func TestRunCINodeTests_EmptyFile(t *testing.T) {
 func TestSubsplitTestsBetweenWorkers(t *testing.T) {
 	t.Run("even split", func(t *testing.T) {
 		files := []string{"a", "b", "c", "d"}
-		result := subsplitTestsBetweenWorkers(files, 2, nil)
+		result := subsplitTestsBetweenWorkers(files, 2, map[string]int{})
 
 		if len(result) != 2 {
 			t.Fatalf("Expected 2 groups, got %d", len(result))
@@ -248,7 +264,7 @@ func TestSubsplitTestsBetweenWorkers(t *testing.T) {
 
 	t.Run("uneven split", func(t *testing.T) {
 		files := []string{"a", "b", "c", "d", "e"}
-		result := subsplitTestsBetweenWorkers(files, 2, nil)
+		result := subsplitTestsBetweenWorkers(files, 2, map[string]int{})
 
 		if len(result) != 2 {
 			t.Fatalf("Expected 2 groups, got %d", len(result))
@@ -268,7 +284,7 @@ func TestSubsplitTestsBetweenWorkers(t *testing.T) {
 
 	t.Run("more groups than files", func(t *testing.T) {
 		files := []string{"a", "b"}
-		result := subsplitTestsBetweenWorkers(files, 4, nil)
+		result := subsplitTestsBetweenWorkers(files, 4, map[string]int{})
 
 		if len(result) != 4 {
 			t.Fatalf("Expected 4 groups, got %d", len(result))
@@ -291,7 +307,7 @@ func TestSubsplitTestsBetweenWorkers(t *testing.T) {
 
 	t.Run("single group", func(t *testing.T) {
 		files := []string{"a", "b", "c"}
-		result := subsplitTestsBetweenWorkers(files, 1, nil)
+		result := subsplitTestsBetweenWorkers(files, 1, map[string]int{})
 
 		if len(result) != 1 {
 			t.Fatalf("Expected 1 group, got %d", len(result))
@@ -303,7 +319,7 @@ func TestSubsplitTestsBetweenWorkers(t *testing.T) {
 	})
 
 	t.Run("empty input", func(t *testing.T) {
-		result := subsplitTestsBetweenWorkers([]string{}, 3, nil)
+		result := subsplitTestsBetweenWorkers([]string{}, 3, map[string]int{})
 
 		if len(result) != 3 {
 			t.Fatalf("Expected 3 groups, got %d", len(result))
@@ -318,7 +334,7 @@ func TestSubsplitTestsBetweenWorkers(t *testing.T) {
 
 	t.Run("zero groups defaults to 1", func(t *testing.T) {
 		files := []string{"a", "b"}
-		result := subsplitTestsBetweenWorkers(files, 0, nil)
+		result := subsplitTestsBetweenWorkers(files, 0, map[string]int{})
 
 		if len(result) != 1 {
 			t.Fatalf("Expected 1 group for n=0, got %d", len(result))

--- a/internal/runner/ci_node_executor_test.go
+++ b/internal/runner/ci_node_executor_test.go
@@ -27,7 +27,7 @@ func TestRunCINodeTests_SingleWorker(t *testing.T) {
 	}
 
 	// Test with single worker (ciNodeWorkers=1)
-	err := runCINodeTestsWithWorkers(context.Background(), mockFramework, map[string]string{}, 1, 1)
+	err := runCINodeTestsWithWorkers(context.Background(), mockFramework, map[string]string{}, 1, 1, nil)
 	if err != nil {
 		t.Fatalf("runCINodeTestsWithWorkers() should not return error, got: %v", err)
 	}
@@ -62,7 +62,7 @@ func TestRunCINodeTests_MultipleWorkers(t *testing.T) {
 	}
 
 	// Test with 2 workers on ci-node 1
-	err := runCINodeTestsWithWorkers(context.Background(), mockFramework, map[string]string{}, 1, 2)
+	err := runCINodeTestsWithWorkers(context.Background(), mockFramework, map[string]string{}, 1, 2, nil)
 	if err != nil {
 		t.Fatalf("runCINodeTestsWithWorkers() should not return error, got: %v", err)
 	}
@@ -108,7 +108,7 @@ func TestRunCINodeTests_NodeIndexMatchesCINode(t *testing.T) {
 	}
 
 	// Test with 2 workers on ci-node 1
-	err := runCINodeTestsWithWorkers(context.Background(), mockFramework, workerEnvMap, 1, 2)
+	err := runCINodeTestsWithWorkers(context.Background(), mockFramework, workerEnvMap, 1, 2, nil)
 	if err != nil {
 		t.Fatalf("runCINodeTestsWithWorkers() should not return error, got: %v", err)
 	}
@@ -161,7 +161,7 @@ func TestRunCINodeTests_SingleWorkerNodeIndex(t *testing.T) {
 		"WORKER_INDEX": "{{workerIndex}}",
 	}
 
-	err := runCINodeTestsWithWorkers(context.Background(), mockFramework, workerEnvMap, 2, 1)
+	err := runCINodeTestsWithWorkers(context.Background(), mockFramework, workerEnvMap, 2, 1, nil)
 	if err != nil {
 		t.Fatalf("runCINodeTestsWithWorkers() should not return error, got: %v", err)
 	}
@@ -190,7 +190,7 @@ func TestRunCINodeTests_FileNotFound(t *testing.T) {
 
 	mockFramework := &MockFramework{FrameworkName: "rspec"}
 
-	err := runCINodeTestsWithWorkers(context.Background(), mockFramework, map[string]string{}, 2, 1)
+	err := runCINodeTestsWithWorkers(context.Background(), mockFramework, map[string]string{}, 2, 1, nil)
 	if err == nil {
 		t.Error("runCINodeTestsWithWorkers() should return error when runner file doesn't exist")
 	}
@@ -214,7 +214,7 @@ func TestRunCINodeTests_EmptyFile(t *testing.T) {
 	mockFramework := &MockFramework{FrameworkName: "rspec"}
 
 	// Should not error for empty file, just not run any tests
-	err := runCINodeTestsWithWorkers(context.Background(), mockFramework, map[string]string{}, 0, 2)
+	err := runCINodeTestsWithWorkers(context.Background(), mockFramework, map[string]string{}, 0, 2, nil)
 	if err != nil {
 		t.Fatalf("runCINodeTestsWithWorkers() should not return error for empty file, got: %v", err)
 	}
@@ -228,13 +228,13 @@ func TestRunCINodeTests_EmptyFile(t *testing.T) {
 func TestSubsplitTestsBetweenWorkers(t *testing.T) {
 	t.Run("even split", func(t *testing.T) {
 		files := []string{"a", "b", "c", "d"}
-		result := subsplitTestsBetweenWorkers(files, 2)
+		result := subsplitTestsBetweenWorkers(files, 2, nil)
 
 		if len(result) != 2 {
 			t.Fatalf("Expected 2 groups, got %d", len(result))
 		}
 
-		// Round-robin: a->0, b->1, c->0, d->1
+		// Equal default weights keep this balanced as a->0, b->1, c->0, d->1.
 		expected0 := []string{"a", "c"}
 		expected1 := []string{"b", "d"}
 
@@ -248,13 +248,13 @@ func TestSubsplitTestsBetweenWorkers(t *testing.T) {
 
 	t.Run("uneven split", func(t *testing.T) {
 		files := []string{"a", "b", "c", "d", "e"}
-		result := subsplitTestsBetweenWorkers(files, 2)
+		result := subsplitTestsBetweenWorkers(files, 2, nil)
 
 		if len(result) != 2 {
 			t.Fatalf("Expected 2 groups, got %d", len(result))
 		}
 
-		// Round-robin: a->0, b->1, c->0, d->1, e->0
+		// Equal default weights keep this balanced as a->0, b->1, c->0, d->1, e->0.
 		expected0 := []string{"a", "c", "e"}
 		expected1 := []string{"b", "d"}
 
@@ -268,7 +268,7 @@ func TestSubsplitTestsBetweenWorkers(t *testing.T) {
 
 	t.Run("more groups than files", func(t *testing.T) {
 		files := []string{"a", "b"}
-		result := subsplitTestsBetweenWorkers(files, 4)
+		result := subsplitTestsBetweenWorkers(files, 4, nil)
 
 		if len(result) != 4 {
 			t.Fatalf("Expected 4 groups, got %d", len(result))
@@ -291,7 +291,7 @@ func TestSubsplitTestsBetweenWorkers(t *testing.T) {
 
 	t.Run("single group", func(t *testing.T) {
 		files := []string{"a", "b", "c"}
-		result := subsplitTestsBetweenWorkers(files, 1)
+		result := subsplitTestsBetweenWorkers(files, 1, nil)
 
 		if len(result) != 1 {
 			t.Fatalf("Expected 1 group, got %d", len(result))
@@ -303,7 +303,7 @@ func TestSubsplitTestsBetweenWorkers(t *testing.T) {
 	})
 
 	t.Run("empty input", func(t *testing.T) {
-		result := subsplitTestsBetweenWorkers([]string{}, 3)
+		result := subsplitTestsBetweenWorkers([]string{}, 3, nil)
 
 		if len(result) != 3 {
 			t.Fatalf("Expected 3 groups, got %d", len(result))
@@ -318,7 +318,7 @@ func TestSubsplitTestsBetweenWorkers(t *testing.T) {
 
 	t.Run("zero groups defaults to 1", func(t *testing.T) {
 		files := []string{"a", "b"}
-		result := subsplitTestsBetweenWorkers(files, 0)
+		result := subsplitTestsBetweenWorkers(files, 0, nil)
 
 		if len(result) != 1 {
 			t.Fatalf("Expected 1 group for n=0, got %d", len(result))
@@ -326,6 +326,29 @@ func TestSubsplitTestsBetweenWorkers(t *testing.T) {
 
 		if !slices.Equal(result[0], files) {
 			t.Errorf("Expected all files in single group, got %v", result[0])
+		}
+	})
+
+	t.Run("weighted split keeps heavy file isolated", func(t *testing.T) {
+		files := []string{"a", "b", "c", "d"}
+		weights := map[string]int{
+			"a": 100,
+			"b": 1,
+			"c": 1,
+			"d": 1,
+		}
+
+		result := subsplitTestsBetweenWorkers(files, 2, weights)
+
+		if len(result) != 2 {
+			t.Fatalf("Expected 2 groups, got %d", len(result))
+		}
+
+		if !slices.Equal(result[0], []string{"a"}) {
+			t.Errorf("Expected heavy file to be alone in group 0, got %v", result[0])
+		}
+		if !slices.Equal(result[1], []string{"b", "c", "d"}) {
+			t.Errorf("Expected light files in group 1, got %v", result[1])
 		}
 	})
 }

--- a/internal/runner/dd_test_optimization.go
+++ b/internal/runner/dd_test_optimization.go
@@ -169,6 +169,7 @@ func (tr *TestRunner) PrepareTestOptimization(ctx context.Context) error {
 
 	tr.suitesBySourceFile = indexSuitesBySourceFile(tr.suiteAggregates)
 	tr.skippablePercentage = calculateSavedTimePercentage(tr.suiteAggregates)
+	tr.testFileWeights = tr.weightedTestFiles()
 
 	slog.Info("Test files prepared", "testFilesCount", len(tr.testFiles))
 
@@ -188,32 +189,44 @@ func initializeDurationsFetchInputs() (string, string, error) {
 }
 
 func (tr *TestRunner) fetchAndStoreTestSuiteDurations() {
+	startTime := time.Now()
 	repositoryURL, service, err := initializeDurationsFetchInputs()
 	if err != nil {
-		slog.Error("Test durations API errored", "error", err)
+		slog.Error("Test durations API errored", "duration", time.Since(startTime), "error", err)
 		tr.testSuiteDurations = make(map[string]map[string]testoptimization.TestSuiteDurationInfo)
 		return
 	}
 
 	durations, err := tr.durationsClient.GetTestSuiteDurations(repositoryURL, service)
 	if err != nil {
-		slog.Error("Test durations API errored", "error", err)
+		slog.Error("Test durations API errored",
+			"service", service,
+			"repositoryURL", repositoryURL,
+			"duration", time.Since(startTime),
+			"error", err)
 		tr.testSuiteDurations = make(map[string]map[string]testoptimization.TestSuiteDurationInfo)
 		return
 	}
 
-	totalSuites := 0
-	for _, suites := range durations {
-		totalSuites += len(suites)
-	}
+	totalSuites := countTestSuites(durations)
 
 	if totalSuites == 0 {
-		slog.Warn("Test durations API returned no test suites", "service", service, "repositoryURL", repositoryURL)
+		slog.Warn("Test durations API returned no test suites",
+			"service", service,
+			"repositoryURL", repositoryURL,
+			"modulesCount", len(durations),
+			"testSuitesCount", totalSuites,
+			"duration", time.Since(startTime))
 		tr.testSuiteDurations = make(map[string]map[string]testoptimization.TestSuiteDurationInfo)
 		return
 	}
 
-	slog.Debug("Found test suite durations", "service", service, "repositoryURL", repositoryURL, "testSuitesCount", totalSuites)
+	slog.Info("Fetched test suite durations",
+		"service", service,
+		"repositoryURL", repositoryURL,
+		"modulesCount", len(durations),
+		"testSuitesCount", totalSuites,
+		"duration", time.Since(startTime))
 	tr.testSuiteDurations = durations
 }
 
@@ -474,15 +487,4 @@ func (tr *TestRunner) testFileWeight(testFile string) (int, bool) {
 		return 1, true
 	}
 	return weight, true
-}
-
-func (tr *TestRunner) knownTestFileWeights() map[string]int {
-	testFileWeights := make(map[string]int, len(tr.suitesBySourceFile))
-	for testFile := range tr.suitesBySourceFile {
-		weight, ok := tr.testFileWeight(testFile)
-		if ok {
-			testFileWeights[testFile] = weight
-		}
-	}
-	return testFileWeights
 }

--- a/internal/runner/dd_test_optimization.go
+++ b/internal/runner/dd_test_optimization.go
@@ -2,9 +2,11 @@ package runner
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"maps"
+	"slices"
 	"strconv"
 	"time"
 
@@ -14,6 +16,8 @@ import (
 	"github.com/DataDog/ddtest/internal/testoptimization"
 	"golang.org/x/sync/errgroup"
 )
+
+const defaultTestFileWeight = int(time.Second / time.Millisecond)
 
 func (tr *TestRunner) PrepareTestOptimization(ctx context.Context) error {
 	detectedPlatform, err := tr.platformDetector.DetectPlatform()
@@ -214,18 +218,33 @@ func (tr *TestRunner) fetchAndStoreTestSuiteDurations() {
 }
 
 type testSuiteKey struct {
-	Module string
-	Suite  string
+	Module string `json:"module"`
+	Suite  string `json:"suite"`
+}
+
+func (key testSuiteKey) MarshalText() ([]byte, error) {
+	return json.Marshal([2]string{key.Module, key.Suite})
+}
+
+func (key *testSuiteKey) UnmarshalText(text []byte) error {
+	var values [2]string
+	if err := json.Unmarshal(text, &values); err != nil {
+		return err
+	}
+
+	key.Module = values[0]
+	key.Suite = values[1]
+	return nil
 }
 
 type testSuiteAggregate struct {
-	Module            string
-	Suite             string
-	SourceFile        string
-	TotalDuration     float64
-	EstimatedDuration float64
-	NumTests          int
-	NumTestsSkipped   int
+	Module            string  `json:"module"`
+	Suite             string  `json:"suite"`
+	SourceFile        string  `json:"sourceFile"`
+	TotalDuration     float64 `json:"totalDuration"`
+	EstimatedDuration float64 `json:"estimatedDuration"`
+	NumTests          int     `json:"numTests"`
+	NumTestsSkipped   int     `json:"numTestsSkipped"`
 }
 
 func (tr *TestRunner) processDiscoveredTests(
@@ -395,6 +414,24 @@ func indexSuitesBySourceFile(suiteAggregates map[testSuiteKey]testSuiteAggregate
 
 		sourceFileLookup[aggregate.SourceFile] = append(sourceFileLookup[aggregate.SourceFile], key)
 	}
+
+	for sourceFile := range sourceFileLookup {
+		slices.SortFunc(sourceFileLookup[sourceFile], func(a, b testSuiteKey) int {
+			if a.Module < b.Module {
+				return -1
+			}
+			if a.Module > b.Module {
+				return 1
+			}
+			if a.Suite < b.Suite {
+				return -1
+			}
+			if a.Suite > b.Suite {
+				return 1
+			}
+			return 0
+		})
+	}
 	return sourceFileLookup
 }
 
@@ -410,7 +447,6 @@ func (tr *TestRunner) weightedTestFiles() map[string]int {
 }
 
 func (tr *TestRunner) testFileWeight(testFile string) (int, bool) {
-	const defaultTestFileWeight = int(time.Second / time.Millisecond)
 	suiteKeys := tr.suitesBySourceFile[testFile]
 	if len(suiteKeys) == 0 {
 		return defaultTestFileWeight, true
@@ -438,4 +474,15 @@ func (tr *TestRunner) testFileWeight(testFile string) (int, bool) {
 		return 1, true
 	}
 	return weight, true
+}
+
+func (tr *TestRunner) knownTestFileWeights() map[string]int {
+	testFileWeights := make(map[string]int, len(tr.suitesBySourceFile))
+	for testFile := range tr.suitesBySourceFile {
+		weight, ok := tr.testFileWeight(testFile)
+		if ok {
+			testFileWeights[testFile] = weight
+		}
+	}
+	return testFileWeights
 }

--- a/internal/runner/dd_test_optimization_test.go
+++ b/internal/runner/dd_test_optimization_test.go
@@ -119,6 +119,19 @@ func TestTestRunner_PrepareTestOptimization_Success(t *testing.T) {
 	if weightedFiles := runner.weightedTestFiles(); len(weightedFiles) != 3 {
 		t.Errorf("Expected weighted files to omit fully skipped file and keep 3 files, got %v", weightedFiles)
 	}
+	expectedTestFileWeights := map[string]int{
+		"test/file1_test.rb":     3,
+		"test/file2_test.rb":     defaultTestFileWeight,
+		"test/fast_only_test.rb": defaultTestFileWeight,
+	}
+	if len(runner.testFileWeights) != len(expectedTestFileWeights) {
+		t.Errorf("Expected precomputed test file weights to have %d entries, got %v", len(expectedTestFileWeights), runner.testFileWeights)
+	}
+	for testFile, expectedWeight := range expectedTestFileWeights {
+		if runner.testFileWeights[testFile] != expectedWeight {
+			t.Errorf("Expected precomputed weight for %s to be %d, got %d", testFile, expectedWeight, runner.testFileWeights[testFile])
+		}
+	}
 
 	for file := range runner.testFiles {
 		if !expectedFiles[file] {
@@ -193,7 +206,7 @@ func TestTestRunner_PrepareTestOptimization_DurationsErrorContinues(t *testing.T
 		t.Errorf("Expected empty in-memory test suite durations on error, got %v", runner.testSuiteDurations)
 	}
 
-	if !strings.Contains(logs.String(), "level=ERROR") || !strings.Contains(logs.String(), "Test durations API errored") {
+	if !strings.Contains(logs.String(), "level=ERROR") || !strings.Contains(logs.String(), "Test durations API errored") || !strings.Contains(logs.String(), "duration=") {
 		t.Errorf("Expected ERROR log for durations API failure, got logs: %s", logs.String())
 	}
 }
@@ -234,7 +247,10 @@ func TestTestRunner_PrepareTestOptimization_EmptyDurationsWarns(t *testing.T) {
 		t.Errorf("Expected empty in-memory test suite durations on empty response, got %v", runner.testSuiteDurations)
 	}
 
-	if !strings.Contains(logs.String(), "level=WARN") || !strings.Contains(logs.String(), "Test durations API returned no test suites") {
+	if !strings.Contains(logs.String(), "level=WARN") ||
+		!strings.Contains(logs.String(), "Test durations API returned no test suites") ||
+		!strings.Contains(logs.String(), "testSuitesCount=0") ||
+		!strings.Contains(logs.String(), "duration=") {
 		t.Errorf("Expected WARN log for empty durations response, got logs: %s", logs.String())
 	}
 }
@@ -303,8 +319,12 @@ func TestTestRunner_PrepareTestOptimization_NonEmptyDurationsUsesP50ForMatchingS
 		t.Errorf("Expected file2 weight to use backend p50 converted to 30ms, got weight=%d ok=%t", weight, ok)
 	}
 
-	if !strings.Contains(logs.String(), "level=DEBUG") || !strings.Contains(logs.String(), "Found test suite durations") || !strings.Contains(logs.String(), "testSuitesCount=2") {
-		t.Errorf("Expected DEBUG log for non-empty durations response, got logs: %s", logs.String())
+	if !strings.Contains(logs.String(), "level=INFO") ||
+		!strings.Contains(logs.String(), "Fetched test suite durations") ||
+		!strings.Contains(logs.String(), "modulesCount=1") ||
+		!strings.Contains(logs.String(), "testSuitesCount=2") ||
+		!strings.Contains(logs.String(), "duration=") {
+		t.Errorf("Expected INFO log for non-empty durations response, got logs: %s", logs.String())
 	}
 }
 

--- a/internal/runner/distribution.go
+++ b/internal/runner/distribution.go
@@ -36,6 +36,9 @@ func DistributeTestFiles(testFiles map[string]int, parallelRunners int) [][]stri
 	}
 
 	sort.Slice(files, func(i, j int) bool {
+		if files[i].count == files[j].count {
+			return files[i].path < files[j].path
+		}
 		return files[i].count > files[j].count
 	})
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -77,6 +78,10 @@ func (tr *TestRunner) Plan(ctx context.Context) error {
 		return fmt.Errorf("failed to create output directory: %w", err)
 	}
 
+	if err := tr.storeTestSuiteDurationsCache(); err != nil {
+		return fmt.Errorf("failed to store test suite durations cache: %w", err)
+	}
+
 	weightedTestFiles := tr.weightedTestFiles()
 	testFileNames := make([]string, 0, len(weightedTestFiles))
 	for testFile := range weightedTestFiles {
@@ -137,6 +142,17 @@ func (tr *TestRunner) Run(ctx context.Context) error {
 			return fmt.Errorf("failed to run planning phase: %w", err)
 		}
 	}
+
+	if err := tr.restoreTestSuiteDurationsCache(); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			slog.Debug("Test suite durations cache not found; CI-node subsplits will use default weights",
+				"file", testoptimization.TestSuiteDurationsCacheFile)
+		} else {
+			slog.Warn("Failed to restore test suite durations cache; CI-node subsplits will use default weights",
+				"file", testoptimization.TestSuiteDurationsCacheFile, "error", err)
+		}
+	}
+
 	runnersData, err := os.ReadFile(constants.ParallelRunnersOutputPath)
 	if err != nil {
 		return fmt.Errorf("failed to read parallel runners count from %s: %w", constants.ParallelRunnersOutputPath, err)
@@ -169,7 +185,7 @@ func (tr *TestRunner) Run(ctx context.Context) error {
 
 	ciNode := settings.GetCiNode()
 	if ciNode >= 0 {
-		return runCINodeTests(ctx, framework, workerEnvMap, ciNode)
+		return runCINodeTests(ctx, framework, workerEnvMap, ciNode, tr.knownTestFileWeights())
 	} else if parallelRunners > 1 {
 		return runParallelTests(ctx, framework, workerEnvMap)
 	} else {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -27,6 +27,7 @@ type TestRunner struct {
 	suiteAggregates     map[testSuiteKey]testSuiteAggregate
 	suitesBySourceFile  map[string][]testSuiteKey
 	testSuiteDurations  map[string]map[string]testoptimization.TestSuiteDurationInfo
+	testFileWeights     map[string]int
 	skippablePercentage float64
 	platformDetector    platform.PlatformDetector
 	optimizationClient  testoptimization.TestOptimizationClient
@@ -40,6 +41,7 @@ func New() *TestRunner {
 		suiteAggregates:     make(map[testSuiteKey]testSuiteAggregate),
 		suitesBySourceFile:  make(map[string][]testSuiteKey),
 		testSuiteDurations:  make(map[string]map[string]testoptimization.TestSuiteDurationInfo),
+		testFileWeights:     make(map[string]int),
 		skippablePercentage: 0.0,
 		platformDetector:    platform.NewPlatformDetector(),
 		optimizationClient:  testoptimization.NewDatadogClient(),
@@ -59,6 +61,7 @@ func NewWithDependencies(
 		suiteAggregates:     make(map[testSuiteKey]testSuiteAggregate),
 		suitesBySourceFile:  make(map[string][]testSuiteKey),
 		testSuiteDurations:  make(map[string]map[string]testoptimization.TestSuiteDurationInfo),
+		testFileWeights:     make(map[string]int),
 		skippablePercentage: 0.0,
 		platformDetector:    platformDetector,
 		optimizationClient:  optimizationClient,
@@ -82,9 +85,8 @@ func (tr *TestRunner) Plan(ctx context.Context) error {
 		return fmt.Errorf("failed to store test suite durations cache: %w", err)
 	}
 
-	weightedTestFiles := tr.weightedTestFiles()
-	testFileNames := make([]string, 0, len(weightedTestFiles))
-	for testFile := range weightedTestFiles {
+	testFileNames := make([]string, 0, len(tr.testFileWeights))
+	for testFile := range tr.testFileWeights {
 		testFileNames = append(testFileNames, testFile)
 	}
 	slices.Sort(testFileNames)
@@ -123,11 +125,11 @@ func (tr *TestRunner) Plan(ctx context.Context) error {
 	}
 
 	// Split test files for runners
-	if err := CreateTestSplits(weightedTestFiles, parallelRunners, constants.TestFilesOutputPath); err != nil {
+	if err := CreateTestSplits(tr.testFileWeights, parallelRunners, constants.TestFilesOutputPath); err != nil {
 		return fmt.Errorf("failed to create test splits: %w", err)
 	}
 
-	slog.Info("Test execution planning completed", "parallelRunners", parallelRunners, "testFilesCount", len(weightedTestFiles))
+	slog.Info("Test execution planning completed", "parallelRunners", parallelRunners, "testFilesCount", len(tr.testFileWeights))
 
 	return nil
 }
@@ -185,7 +187,7 @@ func (tr *TestRunner) Run(ctx context.Context) error {
 
 	ciNode := settings.GetCiNode()
 	if ciNode >= 0 {
-		return runCINodeTests(ctx, framework, workerEnvMap, ciNode, tr.knownTestFileWeights())
+		return runCINodeTests(ctx, framework, workerEnvMap, ciNode, settings.GetCiNodeWorkers(), tr.testFileWeights)
 	} else if parallelRunners > 1 {
 		return runParallelTests(ctx, framework, workerEnvMap)
 	} else {

--- a/internal/runner/test_suite_durations_cache.go
+++ b/internal/runner/test_suite_durations_cache.go
@@ -1,0 +1,43 @@
+package runner
+
+import "github.com/DataDog/ddtest/internal/testoptimization"
+
+type testSuiteDurationsCache struct {
+	TestSuiteDurations map[string]map[string]testoptimization.TestSuiteDurationInfo `json:"testSuiteDurations"`
+	SuiteAggregates    map[testSuiteKey]testSuiteAggregate                          `json:"suiteAggregates"`
+	SuitesBySourceFile map[string][]testSuiteKey                                    `json:"suitesBySourceFile"`
+}
+
+func (tr *TestRunner) storeTestSuiteDurationsCache() error {
+	cache := testSuiteDurationsCache{
+		TestSuiteDurations: tr.testSuiteDurations,
+		SuiteAggregates:    tr.suiteAggregates,
+		SuitesBySourceFile: tr.suitesBySourceFile,
+	}
+
+	return testoptimization.NewCacheManager().StoreTestSuiteDurationsCache(cache)
+}
+
+func (tr *TestRunner) restoreTestSuiteDurationsCache() error {
+	var cache testSuiteDurationsCache
+	if err := testoptimization.NewCacheManager().ReadTestSuiteDurationsCache(&cache); err != nil {
+		return err
+	}
+
+	tr.testSuiteDurations = cache.TestSuiteDurations
+	if tr.testSuiteDurations == nil {
+		tr.testSuiteDurations = make(map[string]map[string]testoptimization.TestSuiteDurationInfo)
+	}
+
+	tr.suiteAggregates = cache.SuiteAggregates
+	if tr.suiteAggregates == nil {
+		tr.suiteAggregates = make(map[testSuiteKey]testSuiteAggregate)
+	}
+
+	tr.suitesBySourceFile = cache.SuitesBySourceFile
+	if tr.suitesBySourceFile == nil {
+		tr.suitesBySourceFile = indexSuitesBySourceFile(tr.suiteAggregates)
+	}
+
+	return nil
+}

--- a/internal/runner/test_suite_durations_cache.go
+++ b/internal/runner/test_suite_durations_cache.go
@@ -1,11 +1,16 @@
 package runner
 
-import "github.com/DataDog/ddtest/internal/testoptimization"
+import (
+	"log/slog"
+
+	"github.com/DataDog/ddtest/internal/testoptimization"
+)
 
 type testSuiteDurationsCache struct {
 	TestSuiteDurations map[string]map[string]testoptimization.TestSuiteDurationInfo `json:"testSuiteDurations"`
 	SuiteAggregates    map[testSuiteKey]testSuiteAggregate                          `json:"suiteAggregates"`
 	SuitesBySourceFile map[string][]testSuiteKey                                    `json:"suitesBySourceFile"`
+	TestFileWeights    map[string]int                                               `json:"testFileWeights"`
 }
 
 func (tr *TestRunner) storeTestSuiteDurationsCache() error {
@@ -13,6 +18,7 @@ func (tr *TestRunner) storeTestSuiteDurationsCache() error {
 		TestSuiteDurations: tr.testSuiteDurations,
 		SuiteAggregates:    tr.suiteAggregates,
 		SuitesBySourceFile: tr.suitesBySourceFile,
+		TestFileWeights:    tr.testFileWeights,
 	}
 
 	return testoptimization.NewCacheManager().StoreTestSuiteDurationsCache(cache)
@@ -39,5 +45,41 @@ func (tr *TestRunner) restoreTestSuiteDurationsCache() error {
 		tr.suitesBySourceFile = indexSuitesBySourceFile(tr.suiteAggregates)
 	}
 
+	tr.testFileWeights = cache.TestFileWeights
+	if tr.testFileWeights == nil {
+		tr.testFileWeights = tr.testFileWeightsFromSuites()
+	}
+
+	testSuitesCount := countTestSuites(tr.testSuiteDurations)
+	suiteAggregatesCount := len(tr.suiteAggregates)
+	suitesBySourceFileCount := len(tr.suitesBySourceFile)
+	testFileWeightsCount := len(tr.testFileWeights)
+	slog.Info("Restored test suite durations cache",
+		"objectsCount", testSuitesCount+suiteAggregatesCount+suitesBySourceFileCount+testFileWeightsCount,
+		"modulesCount", len(tr.testSuiteDurations),
+		"testSuitesCount", testSuitesCount,
+		"suiteAggregatesCount", suiteAggregatesCount,
+		"suitesBySourceFileCount", suitesBySourceFileCount,
+		"testFileWeightsCount", testFileWeightsCount)
+
 	return nil
+}
+
+func countTestSuites(testSuiteDurations map[string]map[string]testoptimization.TestSuiteDurationInfo) int {
+	totalSuites := 0
+	for _, suites := range testSuiteDurations {
+		totalSuites += len(suites)
+	}
+	return totalSuites
+}
+
+func (tr *TestRunner) testFileWeightsFromSuites() map[string]int {
+	testFileWeights := make(map[string]int, len(tr.suitesBySourceFile))
+	for testFile := range tr.suitesBySourceFile {
+		weight, ok := tr.testFileWeight(testFile)
+		if ok {
+			testFileWeights[testFile] = weight
+		}
+	}
+	return testFileWeights
 }

--- a/internal/runner/test_suite_durations_cache_test.go
+++ b/internal/runner/test_suite_durations_cache_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/DataDog/ddtest/internal/constants"
@@ -71,6 +72,9 @@ func TestTestRunner_Plan_StoresTestSuiteDurationsCache(t *testing.T) {
 	if !reflect.DeepEqual(restored.suitesBySourceFile, runner.suitesBySourceFile) {
 		t.Errorf("Expected restored suitesBySourceFile to match stored index.\nexpected: %v\nactual: %v", runner.suitesBySourceFile, restored.suitesBySourceFile)
 	}
+	if !reflect.DeepEqual(restored.testFileWeights, runner.testFileWeights) {
+		t.Errorf("Expected restored test file weights to match stored weights.\nexpected: %v\nactual: %v", runner.testFileWeights, restored.testFileWeights)
+	}
 }
 
 func TestTestRunner_StoreAndRestoreTestSuiteDurationsCache_RoundTripDurations(t *testing.T) {
@@ -107,11 +111,15 @@ func TestTestRunner_StoreAndRestoreTestSuiteDurationsCache_RoundTripDurations(t 
 	runner.suitesBySourceFile = map[string][]testSuiteKey{
 		"spec/suite1_spec.rb": {{Module: "rspec", Suite: "Suite1"}},
 	}
+	runner.testFileWeights = map[string]int{
+		"spec/suite1_spec.rb": 2500,
+	}
 
 	if err := runner.storeTestSuiteDurationsCache(); err != nil {
 		t.Fatalf("storeTestSuiteDurationsCache() should not return error, got: %v", err)
 	}
 
+	logs := captureLogs(t)
 	restored := NewWithDependencies(
 		&MockPlatformDetector{},
 		&MockTestOptimizationClient{},
@@ -130,6 +138,80 @@ func TestTestRunner_StoreAndRestoreTestSuiteDurationsCache_RoundTripDurations(t 
 	}
 	if !reflect.DeepEqual(restored.suitesBySourceFile, runner.suitesBySourceFile) {
 		t.Errorf("Expected restored suitesBySourceFile to match stored index.\nexpected: %v\nactual: %v", runner.suitesBySourceFile, restored.suitesBySourceFile)
+	}
+	if !reflect.DeepEqual(restored.testFileWeights, runner.testFileWeights) {
+		t.Errorf("Expected restored test file weights to match stored weights.\nexpected: %v\nactual: %v", runner.testFileWeights, restored.testFileWeights)
+	}
+
+	logOutput := logs.String()
+	if !strings.Contains(logOutput, "level=INFO") ||
+		!strings.Contains(logOutput, "Restored test suite durations cache") ||
+		!strings.Contains(logOutput, "objectsCount=4") ||
+		!strings.Contains(logOutput, "modulesCount=1") ||
+		!strings.Contains(logOutput, "testSuitesCount=1") ||
+		!strings.Contains(logOutput, "suiteAggregatesCount=1") ||
+		!strings.Contains(logOutput, "suitesBySourceFileCount=1") ||
+		!strings.Contains(logOutput, "testFileWeightsCount=1") {
+		t.Errorf("Expected INFO log for restored cache counts, got logs: %s", logOutput)
+	}
+}
+
+func TestTestRunner_RestoreTestSuiteDurationsCache_ComputesWeightsForLegacyCache(t *testing.T) {
+	tempDir := t.TempDir()
+	oldWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldWd) }()
+	_ = os.Chdir(tempDir)
+
+	type legacyTestSuiteDurationsCache struct {
+		TestSuiteDurations map[string]map[string]testoptimization.TestSuiteDurationInfo `json:"testSuiteDurations"`
+		SuiteAggregates    map[testSuiteKey]testSuiteAggregate                          `json:"suiteAggregates"`
+		SuitesBySourceFile map[string][]testSuiteKey                                    `json:"suitesBySourceFile"`
+	}
+
+	cache := legacyTestSuiteDurationsCache{
+		TestSuiteDurations: map[string]map[string]testoptimization.TestSuiteDurationInfo{
+			"rspec": {
+				"Suite1": {
+					SourceFile: "spec/suite1_spec.rb",
+					Duration:   testoptimization.DurationPercentiles{P50: "5000000000", P90: "7000000000"},
+				},
+			},
+		},
+		SuiteAggregates: map[testSuiteKey]testSuiteAggregate{
+			{Module: "rspec", Suite: "Suite1"}: {
+				Module:            "rspec",
+				Suite:             "Suite1",
+				SourceFile:        "spec/suite1_spec.rb",
+				TotalDuration:     5000000000,
+				EstimatedDuration: 2500000000,
+				NumTests:          2,
+				NumTestsSkipped:   1,
+			},
+		},
+		SuitesBySourceFile: map[string][]testSuiteKey{
+			"spec/suite1_spec.rb": {{Module: "rspec", Suite: "Suite1"}},
+		},
+	}
+
+	if err := testoptimization.NewCacheManager().StoreTestSuiteDurationsCache(cache); err != nil {
+		t.Fatalf("StoreTestSuiteDurationsCache() should not return error, got: %v", err)
+	}
+
+	restored := NewWithDependencies(
+		&MockPlatformDetector{},
+		&MockTestOptimizationClient{},
+		&MockTestSuiteDurationsClient{},
+		newDefaultMockCIProviderDetector(),
+	)
+	if err := restored.restoreTestSuiteDurationsCache(); err != nil {
+		t.Fatalf("restoreTestSuiteDurationsCache() should not return error, got: %v", err)
+	}
+
+	expectedWeights := map[string]int{
+		"spec/suite1_spec.rb": 2500,
+	}
+	if !reflect.DeepEqual(restored.testFileWeights, expectedWeights) {
+		t.Errorf("Expected restored legacy cache to compute test file weights.\nexpected: %v\nactual: %v", expectedWeights, restored.testFileWeights)
 	}
 }
 

--- a/internal/runner/test_suite_durations_cache_test.go
+++ b/internal/runner/test_suite_durations_cache_test.go
@@ -1,0 +1,178 @@
+package runner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/DataDog/ddtest/internal/constants"
+	"github.com/DataDog/ddtest/internal/settings"
+	"github.com/DataDog/ddtest/internal/testoptimization"
+)
+
+func TestTestRunner_Plan_StoresTestSuiteDurationsCache(t *testing.T) {
+	tempDir := t.TempDir()
+	oldWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldWd) }()
+	_ = os.Chdir(tempDir)
+
+	_ = os.Setenv("DD_TEST_OPTIMIZATION_RUNNER_MIN_PARALLELISM", "1")
+	_ = os.Setenv("DD_TEST_OPTIMIZATION_RUNNER_MAX_PARALLELISM", "1")
+	defer func() {
+		_ = os.Unsetenv("DD_TEST_OPTIMIZATION_RUNNER_MIN_PARALLELISM")
+		_ = os.Unsetenv("DD_TEST_OPTIMIZATION_RUNNER_MAX_PARALLELISM")
+		settings.Init()
+	}()
+	settings.Init()
+
+	mockFramework := &MockFramework{
+		FrameworkName: "rspec",
+		Tests: []testoptimization.Test{
+			{Module: "rspec", Suite: "Suite1", Name: "test1", SuiteSourceFile: "spec/suite1_spec.rb"},
+			{Module: "rspec", Suite: "Suite1", Name: "test2", SuiteSourceFile: "spec/suite1_spec.rb"},
+		},
+	}
+	mockPlatform := &MockPlatform{
+		PlatformName: "ruby",
+		Tags:         map[string]string{"platform": "ruby"},
+		Framework:    mockFramework,
+	}
+	runner := NewWithDependencies(
+		&MockPlatformDetector{Platform: mockPlatform},
+		&MockTestOptimizationClient{SkippableTests: map[string]bool{}},
+		&MockTestSuiteDurationsClient{},
+		newDefaultMockCIProviderDetector(),
+	)
+
+	if err := runner.Plan(context.Background()); err != nil {
+		t.Fatalf("Plan() should not return error, got: %v", err)
+	}
+
+	cachePath := filepath.Join(constants.PlanDirectory, "cache", testoptimization.TestSuiteDurationsCacheFile)
+	if _, err := os.Stat(cachePath); err != nil {
+		t.Fatalf("Expected test suite durations cache file to be written: %v", err)
+	}
+
+	restored := NewWithDependencies(
+		&MockPlatformDetector{},
+		&MockTestOptimizationClient{},
+		&MockTestSuiteDurationsClient{},
+		newDefaultMockCIProviderDetector(),
+	)
+	if err := restored.restoreTestSuiteDurationsCache(); err != nil {
+		t.Fatalf("restoreTestSuiteDurationsCache() should not return error, got: %v", err)
+	}
+
+	if !reflect.DeepEqual(restored.suiteAggregates, runner.suiteAggregates) {
+		t.Errorf("Expected restored suite aggregates to match stored aggregates.\nexpected: %v\nactual: %v", runner.suiteAggregates, restored.suiteAggregates)
+	}
+	if !reflect.DeepEqual(restored.suitesBySourceFile, runner.suitesBySourceFile) {
+		t.Errorf("Expected restored suitesBySourceFile to match stored index.\nexpected: %v\nactual: %v", runner.suitesBySourceFile, restored.suitesBySourceFile)
+	}
+}
+
+func TestTestRunner_StoreAndRestoreTestSuiteDurationsCache_RoundTripDurations(t *testing.T) {
+	tempDir := t.TempDir()
+	oldWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldWd) }()
+	_ = os.Chdir(tempDir)
+
+	runner := NewWithDependencies(
+		&MockPlatformDetector{},
+		&MockTestOptimizationClient{},
+		&MockTestSuiteDurationsClient{},
+		newDefaultMockCIProviderDetector(),
+	)
+	runner.testSuiteDurations = map[string]map[string]testoptimization.TestSuiteDurationInfo{
+		"rspec": {
+			"Suite1": {
+				SourceFile: "spec/suite1_spec.rb",
+				Duration:   testoptimization.DurationPercentiles{P50: "5000000000", P90: "7000000000"},
+			},
+		},
+	}
+	runner.suiteAggregates = map[testSuiteKey]testSuiteAggregate{
+		{Module: "rspec", Suite: "Suite1"}: {
+			Module:            "rspec",
+			Suite:             "Suite1",
+			SourceFile:        "spec/suite1_spec.rb",
+			TotalDuration:     5000000000,
+			EstimatedDuration: 2500000000,
+			NumTests:          2,
+			NumTestsSkipped:   1,
+		},
+	}
+	runner.suitesBySourceFile = map[string][]testSuiteKey{
+		"spec/suite1_spec.rb": {{Module: "rspec", Suite: "Suite1"}},
+	}
+
+	if err := runner.storeTestSuiteDurationsCache(); err != nil {
+		t.Fatalf("storeTestSuiteDurationsCache() should not return error, got: %v", err)
+	}
+
+	restored := NewWithDependencies(
+		&MockPlatformDetector{},
+		&MockTestOptimizationClient{},
+		&MockTestSuiteDurationsClient{},
+		newDefaultMockCIProviderDetector(),
+	)
+	if err := restored.restoreTestSuiteDurationsCache(); err != nil {
+		t.Fatalf("restoreTestSuiteDurationsCache() should not return error, got: %v", err)
+	}
+
+	if !reflect.DeepEqual(restored.testSuiteDurations, runner.testSuiteDurations) {
+		t.Errorf("Expected restored test suite durations to match stored durations.\nexpected: %v\nactual: %v", runner.testSuiteDurations, restored.testSuiteDurations)
+	}
+	if !reflect.DeepEqual(restored.suiteAggregates, runner.suiteAggregates) {
+		t.Errorf("Expected restored suite aggregates to match stored aggregates.\nexpected: %v\nactual: %v", runner.suiteAggregates, restored.suiteAggregates)
+	}
+	if !reflect.DeepEqual(restored.suitesBySourceFile, runner.suitesBySourceFile) {
+		t.Errorf("Expected restored suitesBySourceFile to match stored index.\nexpected: %v\nactual: %v", runner.suitesBySourceFile, restored.suitesBySourceFile)
+	}
+}
+
+func TestTestSuiteKey_JSONMapKeyRoundTrip(t *testing.T) {
+	tempDir := t.TempDir()
+	oldWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldWd) }()
+	_ = os.Chdir(tempDir)
+
+	key := testSuiteKey{Module: `rspec/module:one`, Suite: `Suite "one", with punctuation`}
+	runner := NewWithDependencies(
+		&MockPlatformDetector{},
+		&MockTestOptimizationClient{},
+		&MockTestSuiteDurationsClient{},
+		newDefaultMockCIProviderDetector(),
+	)
+	runner.suiteAggregates = map[testSuiteKey]testSuiteAggregate{
+		key: {
+			Module:            key.Module,
+			Suite:             key.Suite,
+			SourceFile:        "spec/suite1_spec.rb",
+			TotalDuration:     5000000000,
+			EstimatedDuration: 2500000000,
+			NumTests:          2,
+			NumTestsSkipped:   1,
+		},
+	}
+
+	if err := runner.storeTestSuiteDurationsCache(); err != nil {
+		t.Fatalf("storeTestSuiteDurationsCache() should not return error, got: %v", err)
+	}
+
+	restored := NewWithDependencies(
+		&MockPlatformDetector{},
+		&MockTestOptimizationClient{},
+		&MockTestSuiteDurationsClient{},
+		newDefaultMockCIProviderDetector(),
+	)
+	if err := restored.restoreTestSuiteDurationsCache(); err != nil {
+		t.Fatalf("restoreTestSuiteDurationsCache() should not return error, got: %v", err)
+	}
+
+	if !reflect.DeepEqual(restored.suiteAggregates, runner.suiteAggregates) {
+		t.Errorf("Expected restored suite aggregates to preserve text-marshaled keys.\nexpected: %v\nactual: %v", runner.suiteAggregates, restored.suiteAggregates)
+	}
+}

--- a/internal/testoptimization/cache.go
+++ b/internal/testoptimization/cache.go
@@ -19,6 +19,9 @@ type SkippableTestsCache struct {
 	SkippableTests map[string]map[string][]net.SkippableResponseDataAttributes `json:"skippableTests"`
 }
 
+// TestSuiteDurationsCacheFile is the cache file name for suite duration metadata.
+const TestSuiteDurationsCacheFile = "test_suite_durations.json"
+
 // CacheManager handles creation and storage of cache data for test runners
 type CacheManager struct{}
 
@@ -42,6 +45,20 @@ func (cm *CacheManager) writeJSONToFile(data any, filePath string) error {
 
 	if err := os.WriteFile(filePath, jsonData, 0644); err != nil {
 		return fmt.Errorf("failed to write file: %w", err)
+	}
+
+	return nil
+}
+
+// readJSONFromFile reads JSON data from the specified file path into data.
+func (cm *CacheManager) readJSONFromFile(filePath string, data any) error {
+	jsonData, err := os.ReadFile(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to read file: %w", err)
+	}
+
+	if err := json.Unmarshal(jsonData, data); err != nil {
+		return fmt.Errorf("failed to unmarshal JSON: %w", err)
 	}
 
 	return nil
@@ -118,5 +135,33 @@ func (cm *CacheManager) StoreTestManagementTestsCache(testManagementTests *net.T
 	}
 
 	slog.Debug("Test management tests written to file", "path", testManagementTestsPath)
+	return nil
+}
+
+// StoreTestSuiteDurationsCache stores test suite duration data in .testoptimization/cache/test_suite_durations.json
+func (cm *CacheManager) StoreTestSuiteDurationsCache(cache any) error {
+	if err := cm.CreateCacheDirectory(); err != nil {
+		return fmt.Errorf("failed to create cache directory: %w", err)
+	}
+
+	testSuiteDurationsPath := filepath.Join(appConstants.PlanDirectory, "cache", TestSuiteDurationsCacheFile)
+	if err := cm.writeJSONToFile(cache, testSuiteDurationsPath); err != nil {
+		slog.Error("Failed to write test suite durations to file", "error", err, "path", testSuiteDurationsPath)
+		return err
+	}
+
+	slog.Debug("Test suite durations written to file", "path", testSuiteDurationsPath)
+	return nil
+}
+
+// ReadTestSuiteDurationsCache reads test suite duration data from .testoptimization/cache/test_suite_durations.json
+func (cm *CacheManager) ReadTestSuiteDurationsCache(cache any) error {
+	testSuiteDurationsPath := filepath.Join(appConstants.PlanDirectory, "cache", TestSuiteDurationsCacheFile)
+
+	if err := cm.readJSONFromFile(testSuiteDurationsPath, cache); err != nil {
+		return err
+	}
+
+	slog.Debug("Test suite durations read from file", "path", testSuiteDurationsPath)
 	return nil
 }

--- a/internal/testoptimization/cache_test.go
+++ b/internal/testoptimization/cache_test.go
@@ -13,6 +13,7 @@ type testSuiteDurationsCacheFixture struct {
 	TestSuiteDurations map[string]map[string]TestSuiteDurationInfo `json:"testSuiteDurations"`
 	SuiteAggregates    []testSuiteAggregateCacheFixture            `json:"suiteAggregates"`
 	SuitesBySourceFile map[string][]testSuiteCacheKeyFixture       `json:"suitesBySourceFile"`
+	TestFileWeights    map[string]int                              `json:"testFileWeights"`
 }
 
 type testSuiteCacheKeyFixture struct {
@@ -58,6 +59,9 @@ func TestCacheManager_StoreAndReadTestSuiteDurationsCache(t *testing.T) {
 		},
 		SuitesBySourceFile: map[string][]testSuiteCacheKeyFixture{
 			"spec/suite1_spec.rb": {{Module: "rspec", Suite: "Suite1"}},
+		},
+		TestFileWeights: map[string]int{
+			"spec/suite1_spec.rb": 2500,
 		},
 	}
 

--- a/internal/testoptimization/cache_test.go
+++ b/internal/testoptimization/cache_test.go
@@ -1,0 +1,82 @@
+package testoptimization
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	appConstants "github.com/DataDog/ddtest/internal/constants"
+)
+
+type testSuiteDurationsCacheFixture struct {
+	TestSuiteDurations map[string]map[string]TestSuiteDurationInfo `json:"testSuiteDurations"`
+	SuiteAggregates    []testSuiteAggregateCacheFixture            `json:"suiteAggregates"`
+	SuitesBySourceFile map[string][]testSuiteCacheKeyFixture       `json:"suitesBySourceFile"`
+}
+
+type testSuiteCacheKeyFixture struct {
+	Module string `json:"module"`
+	Suite  string `json:"suite"`
+}
+
+type testSuiteAggregateCacheFixture struct {
+	Module            string  `json:"module"`
+	Suite             string  `json:"suite"`
+	SourceFile        string  `json:"sourceFile"`
+	TotalDuration     float64 `json:"totalDuration"`
+	EstimatedDuration float64 `json:"estimatedDuration"`
+	NumTests          int     `json:"numTests"`
+	NumTestsSkipped   int     `json:"numTestsSkipped"`
+}
+
+func TestCacheManager_StoreAndReadTestSuiteDurationsCache(t *testing.T) {
+	tempDir := t.TempDir()
+	oldWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldWd) }()
+	_ = os.Chdir(tempDir)
+
+	cache := testSuiteDurationsCacheFixture{
+		TestSuiteDurations: map[string]map[string]TestSuiteDurationInfo{
+			"rspec": {
+				"Suite1": {
+					SourceFile: "spec/suite1_spec.rb",
+					Duration:   DurationPercentiles{P50: "5000000000", P90: "7000000000"},
+				},
+			},
+		},
+		SuiteAggregates: []testSuiteAggregateCacheFixture{
+			{
+				Module:            "rspec",
+				Suite:             "Suite1",
+				SourceFile:        "spec/suite1_spec.rb",
+				TotalDuration:     5000000000,
+				EstimatedDuration: 2500000000,
+				NumTests:          2,
+				NumTestsSkipped:   1,
+			},
+		},
+		SuitesBySourceFile: map[string][]testSuiteCacheKeyFixture{
+			"spec/suite1_spec.rb": {{Module: "rspec", Suite: "Suite1"}},
+		},
+	}
+
+	cacheManager := NewCacheManager()
+	if err := cacheManager.StoreTestSuiteDurationsCache(cache); err != nil {
+		t.Fatalf("StoreTestSuiteDurationsCache() should not return error, got: %v", err)
+	}
+
+	cachePath := filepath.Join(appConstants.PlanDirectory, "cache", TestSuiteDurationsCacheFile)
+	if _, err := os.Stat(cachePath); err != nil {
+		t.Fatalf("Expected test suite durations cache file to be written: %v", err)
+	}
+
+	var restored testSuiteDurationsCacheFixture
+	if err := cacheManager.ReadTestSuiteDurationsCache(&restored); err != nil {
+		t.Fatalf("ReadTestSuiteDurationsCache() should not return error, got: %v", err)
+	}
+
+	if !reflect.DeepEqual(restored, cache) {
+		t.Errorf("Expected restored cache to match stored cache.\nexpected: %v\nactual: %v", cache, restored)
+	}
+}


### PR DESCRIPTION
## What

Reuse the weighted test file distribution for CI-node worker subsplitting. Planning now stores suite duration weighting data in `.testoptimization/cache/test_suite_durations.json`, and `ddtest run` restores it before splitting a CI node across local workers.

## Why

CI-node subsplitting previously used round-robin assignment, so local workers could be uneven even though the node-level split was weighted. Reusing the same weighted distribution keeps local worker assignments aligned with the existing Test Impact Analysis duration estimates.

## E2E testing

1. Run `ddtest plan` in a repo with multiple test files and suite duration data.
2. Inspect `.testoptimization/cache/test_suite_durations.json` and confirm it contains `testSuiteDurations`, `suiteAggregates`, `suitesBySourceFile`, and `testFileWeights`.
3. Confirm `testFileWeights` includes the expected runnable test files with positive duration-derived weights, and that existing cache fields are still present.
4. Inspect `.testoptimization/tests-split/runner-*` and confirm the initial node split uses the cached test file weights.
5. Run `ddtest run --ci-node=<node> --ci-node-workers=2` for one of the generated CI nodes.
6. Confirm the run restores the cache, logs the restored object counts, and splits the selected CI node across local workers using cached weights rather than round-robin order. Unknown files should fall back to the default weight.