### PR TITLE
[SDTEST-2710] Unify .testoptimization layout for ddtest, make it compatible with Bazel support for Datadog

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,11 @@ The folder contents are:
     config                   # (GHA only) matrix JSON with ci_node_index entries
 ```
 
-DDTest may also write compatibility cache files for older Ruby library integrations.
-The runner files live under `.testoptimization/runner/*`. You can use
-`runner/test-files.txt` or `runner/tests-split/runner-X` files to feed them directly
-to your existing test runner.
+DDTest may also write compatibility files at legacy root paths for existing
+integrations. New integrations should read runner files from `.testoptimization/runner/*`.
+You can use `runner/test-files.txt` or `runner/tests-split/runner-X` files to feed
+them directly to your existing test runner. See [the 1.0 upgrade guide](docs/upgrade-1.0.md)
+for the planned removal of compatibility writes.
 
 Example for Knapsack Pro:
 

--- a/README.md
+++ b/README.md
@@ -91,31 +91,38 @@ The folder contents are:
 
 ```
 .testoptimization/
-  cache/                     # Datadog responses cached locally
-    settings.json
-    known_tests.json
-    skippable_tests.json
-    test_management_tests.json
+  manifest.txt               # Plan layout version
+  cache/
+    http/                    # Backend-shaped Datadog responses
+      settings.json
+      known_tests.json
+      skippable_tests.json
+      test_management.json
+  runner/                    # DDTest runner-private plan files
+    test-files.txt           # All non-skipped test files to execute
+    parallel-runners.txt     # Chosen worker count (single integer)
+    skippable-percentage.txt # % tests skipped by TIA
+    tests-split/
+      runner-0               # File list for worker 0
+      ...
+      runner-(N-1)           # File list for worker N-1
+    cache/
+      test_suite_durations.json
   tests-discovery/
     tests.json               # JSON stream of discovered tests
-  test-files.txt             # All non-skipped test files to execute
-  parallel-runners.txt       # Chosen worker count (single integer)
-  skippable-percentage.txt   # % tests skipped by TIA
-  tests-split/
-    runner-0                 # File list for worker 0
-    ...
-    runner-(N-1)             # File list for worker N-1
   github/
     config                   # (GHA only) matrix JSON with ci_node_index entries
 ```
 
-You can use `test-files.txt` or `tests-split/runner-X` files to feed them directly to
-your existing test runner.
+DDTest may also write compatibility cache files for older Ruby library integrations.
+The runner files live under `.testoptimization/runner/*`. You can use
+`runner/test-files.txt` or `runner/tests-split/runner-X` files to feed them directly
+to your existing test runner.
 
 Example for Knapsack Pro:
 
 ```bash
-KNAPSACK_PRO_TEST_FILE_LIST_SOURCE_FILE=.testoptimization/test-files.txt bundle exec rake knapsack_pro:queue:rspec
+KNAPSACK_PRO_TEST_FILE_LIST_SOURCE_FILE=.testoptimization/runner/test-files.txt bundle exec rake knapsack_pro:queue:rspec
 ```
 
 #### ddtest run
@@ -319,8 +326,8 @@ jobs:
           name: Determine parallelism
           command: |
             set -euo pipefail
-            cat .testoptimization/parallel-runners.txt
-            desired=$(cat .testoptimization/parallel-runners.txt 2>/dev/null || echo 1)
+            cat .testoptimization/runner/parallel-runners.txt
+            desired=$(cat .testoptimization/runner/parallel-runners.txt 2>/dev/null || echo 1)
             if ! echo "${desired}" | grep -Eq '^[0-9]+$'; then
               echo "Invalid parallelism value '${desired}', defaulting to 1"
               desired=1

--- a/civisibility/integrations/civisibility_features.go
+++ b/civisibility/integrations/civisibility_features.go
@@ -6,6 +6,7 @@
 package integrations
 
 import (
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
@@ -23,6 +24,13 @@ import (
 const (
 	DefaultFlakyRetryCount      = 5
 	DefaultFlakyTotalRetryCount = 1_000
+
+	// autoDetectServiceName preserves the existing public getter behavior:
+	// an empty service name makes net.NewClientWithServiceName derive the
+	// service from DD_SERVICE or repository tags. The ensure helpers are
+	// sync.Once-guarded, so raw-response getters do not repeat initialization
+	// or backend requests beyond the matching processed getter path.
+	autoDetectServiceName = ""
 )
 
 type (
@@ -314,43 +322,75 @@ func ensureAdditionalFeaturesInitialization(_ string) {
 
 // GetSettings gets the settings from the backend settings endpoint
 func GetSettings() *net.SettingsResponseData {
-	// call to ensure the settings features initialization is completed (service name can be null here)
-	ensureSettingsInitialization("")
+	// call to ensure the settings features initialization is completed
+	ensureSettingsInitialization(autoDetectServiceName)
 	return &ciVisibilitySettings
+}
+
+func GetSettingsRawResponse() json.RawMessage {
+	ensureSettingsInitialization(autoDetectServiceName)
+	if ciVisibilityClient == nil {
+		return nil
+	}
+	return ciVisibilityClient.GetSettingsRawResponse()
 }
 
 // GetKnownTests gets the known tests data
 func GetKnownTests() *net.KnownTestsResponseData {
-	// call to ensure the additional features initialization is completed (service name can be null here)
-	ensureAdditionalFeaturesInitialization("")
+	// call to ensure the additional features initialization is completed
+	ensureAdditionalFeaturesInitialization(autoDetectServiceName)
 	return &ciVisibilityKnownTests
+}
+
+func GetKnownTestsRawResponse() json.RawMessage {
+	ensureAdditionalFeaturesInitialization(autoDetectServiceName)
+	if ciVisibilityClient == nil {
+		return nil
+	}
+	return ciVisibilityClient.GetKnownTestsRawResponse()
 }
 
 // GetTestManagementTestsData gets the test management tests data
 func GetTestManagementTestsData() *net.TestManagementTestsResponseDataModules {
-	// call to ensure the additional features initialization is completed (service name can be null here)
-	ensureAdditionalFeaturesInitialization("")
+	// call to ensure the additional features initialization is completed
+	ensureAdditionalFeaturesInitialization(autoDetectServiceName)
 	return &ciVisibilityTestManagementTests
+}
+
+func GetTestManagementTestsRawResponse() json.RawMessage {
+	ensureAdditionalFeaturesInitialization(autoDetectServiceName)
+	if ciVisibilityClient == nil {
+		return nil
+	}
+	return ciVisibilityClient.GetTestManagementTestsRawResponse()
 }
 
 // GetFlakyRetriesSettings gets the flaky retries settings
 func GetFlakyRetriesSettings() *FlakyRetriesSetting {
-	// call to ensure the additional features initialization is completed (service name can be null here)
-	ensureAdditionalFeaturesInitialization("")
+	// call to ensure the additional features initialization is completed
+	ensureAdditionalFeaturesInitialization(autoDetectServiceName)
 	return &ciVisibilityFlakyRetriesSettings
 }
 
 // GetSkippableTests gets the skippable tests from the backend
 func GetSkippableTests() map[string]map[string][]net.SkippableResponseDataAttributes {
-	// call to ensure the additional features initialization is completed (service name can be null here)
-	ensureAdditionalFeaturesInitialization("")
+	// call to ensure the additional features initialization is completed
+	ensureAdditionalFeaturesInitialization(autoDetectServiceName)
 	return ciVisibilitySkippables
+}
+
+func GetSkippableTestsRawResponse() json.RawMessage {
+	ensureAdditionalFeaturesInitialization(autoDetectServiceName)
+	if ciVisibilityClient == nil {
+		return nil
+	}
+	return ciVisibilityClient.GetSkippableTestsRawResponse()
 }
 
 // GetImpactedTestsAnalyzer gets the impacted tests analyzer
 func GetImpactedTestsAnalyzer() *impactedtests.ImpactedTestAnalyzer {
-	// call to ensure the additional features initialization is completed (service name can be null here)
-	ensureAdditionalFeaturesInitialization("")
+	// call to ensure the additional features initialization is completed
+	ensureAdditionalFeaturesInitialization(autoDetectServiceName)
 	return ciVisibilityImpactedTestsAnalyzer
 }
 

--- a/civisibility/utils/net/client.go
+++ b/civisibility/utils/net/client.go
@@ -7,6 +7,7 @@ package net
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -36,11 +37,15 @@ type (
 	// Client is an interface for sending requests to the Datadog backend.
 	Client interface {
 		GetSettings() (*SettingsResponseData, error)
+		GetSettingsRawResponse() json.RawMessage
 		GetKnownTests() (*KnownTestsResponseData, error)
+		GetKnownTestsRawResponse() json.RawMessage
 		GetCommits(localCommits []string) ([]string, error)
 		SendPackFiles(commitSha string, packFiles []string) (bytes int64, err error)
 		GetSkippableTests() (correlationID string, skippables map[string]map[string][]SkippableResponseDataAttributes, err error)
+		GetSkippableTestsRawResponse() json.RawMessage
 		GetTestManagementTests() (*TestManagementTestsResponseDataModules, error)
+		GetTestManagementTestsRawResponse() json.RawMessage
 		SendLogs(logsPayload io.Reader) error
 	}
 
@@ -61,6 +66,11 @@ type (
 		testConfigurations testConfigurations
 		headers            map[string]string
 		handler            *RequestHandler
+
+		settingsRawResponse            json.RawMessage
+		knownTestsRawResponse          json.RawMessage
+		skippableTestsRawResponse      json.RawMessage
+		testManagementTestsRawResponse json.RawMessage
 	}
 
 	// testConfigurations represents the test configurations.
@@ -249,6 +259,29 @@ func NewClientWithServiceName(serviceName string) Client {
 // NewClient creates a new client with the default service name.
 func NewClient() Client {
 	return NewClientWithServiceName("")
+}
+
+func cloneRawMessage(data []byte) json.RawMessage {
+	if len(data) == 0 {
+		return nil
+	}
+	return append(json.RawMessage(nil), data...)
+}
+
+func (c *client) GetSettingsRawResponse() json.RawMessage {
+	return cloneRawMessage(c.settingsRawResponse)
+}
+
+func (c *client) GetKnownTestsRawResponse() json.RawMessage {
+	return cloneRawMessage(c.knownTestsRawResponse)
+}
+
+func (c *client) GetSkippableTestsRawResponse() json.RawMessage {
+	return cloneRawMessage(c.skippableTestsRawResponse)
+}
+
+func (c *client) GetTestManagementTestsRawResponse() json.RawMessage {
+	return cloneRawMessage(c.testManagementTestsRawResponse)
 }
 
 // getURLPath returns the full URL path for the given URL path.

--- a/civisibility/utils/net/known_tests_api.go
+++ b/civisibility/utils/net/known_tests_api.go
@@ -52,6 +52,7 @@ func (c *client) GetKnownTests() (*KnownTestsResponseData, error) {
 	if c.repositoryURL == "" || c.commitSha == "" {
 		return nil, fmt.Errorf("civisibility.GetKnownTests: repository URL and commit SHA are required")
 	}
+	c.knownTestsRawResponse = nil
 
 	body := knownTestsRequest{
 		Data: knownTestsRequestHeader{
@@ -73,6 +74,7 @@ func (c *client) GetKnownTests() (*KnownTestsResponseData, error) {
 	if err != nil {
 		return nil, fmt.Errorf("sending known tests request: %s", err)
 	}
+	c.knownTestsRawResponse = cloneRawMessage(response.Body)
 
 	var responseObject knownTestsResponse
 	err = response.Unmarshal(&responseObject)

--- a/civisibility/utils/net/raw_response_test.go
+++ b/civisibility/utils/net/raw_response_test.go
@@ -1,0 +1,158 @@
+package net
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newRawResponseTestClient(server *httptest.Server) *client {
+	return &client{
+		agentless:     true,
+		baseURL:       server.URL,
+		environment:   "ci",
+		serviceName:   "service",
+		repositoryURL: "https://github.com/DataDog/ddtest.git",
+		commitSha:     "abc123",
+		commitMessage: "commit message",
+		branchName:    "main",
+		headers:       map[string]string{},
+		handler:       NewRequestHandlerWithClient(server.Client()),
+		testConfigurations: testConfigurations{
+			OsPlatform:     "linux",
+			OsArchitecture: "amd64",
+			RuntimeName:    "ruby",
+			RuntimeVersion: "3.3.0",
+		},
+	}
+}
+
+func newRawResponseTestServer(t *testing.T, responses map[string]string) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST request, got %s", r.Method)
+		}
+
+		path := strings.TrimPrefix(r.URL.Path, "/")
+		responseBody, ok := responses[path]
+		if !ok {
+			t.Fatalf("unexpected request path %s", path)
+		}
+
+		w.Header().Set(HeaderContentType, ContentTypeJSON)
+		_, _ = w.Write([]byte(responseBody))
+	}))
+}
+
+func TestClientStoresRawBackendResponses(t *testing.T) {
+	settingsResponse := `{"data":{"id":"settings-id","type":"ci_app_test_service_libraries_settings","attributes":{"itr_enabled":true,"tests_skipping":true,"known_tests_enabled":true,"test_management":{"enabled":true,"attempt_to_fix_retries":3}}}}`
+	knownTestsResponse := `{"data":{"id":"known-tests-id","type":"ci_app_libraries_tests_request","attributes":{"tests":{"module-a":{"suite-a":["test-a"]}}}}}`
+	skippableTestsResponse := `{"meta":{"correlation_id":"correlation-id"},"data":[{"id":"skippable-id","type":"test","attributes":{"suite":"suite-a","name":"test-a","parameters":"params","configurations":{"os.platform":"linux","os.architecture":"amd64","runtime.name":"ruby","runtime.version":"3.3.0"}}}]}`
+	testManagementResponse := `{"data":{"id":"test-management-id","type":"ci_app_libraries_tests_request","attributes":{"modules":{"module-a":{"suites":{"suite-a":{"tests":{"test-a":{"properties":{"quarantined":true,"disabled":false,"attempt_to_fix":true}}}}}}}}}}`
+
+	server := newRawResponseTestServer(t, map[string]string{
+		settingsURLPath:            settingsResponse,
+		knownTestsURLPath:          knownTestsResponse,
+		skippableURLPath:           skippableTestsResponse,
+		testManagementTestsURLPath: testManagementResponse,
+	})
+	defer server.Close()
+
+	client := newRawResponseTestClient(server)
+
+	settings, err := client.GetSettings()
+	if err != nil {
+		t.Fatalf("GetSettings() returned error: %v", err)
+	}
+	if !settings.ItrEnabled || !settings.TestsSkipping {
+		t.Fatalf("GetSettings() returned unexpected processed data: %+v", settings)
+	}
+	if string(client.GetSettingsRawResponse()) != settingsResponse {
+		t.Fatalf("settings raw response mismatch:\nexpected: %s\nactual:   %s", settingsResponse, string(client.GetSettingsRawResponse()))
+	}
+
+	knownTests, err := client.GetKnownTests()
+	if err != nil {
+		t.Fatalf("GetKnownTests() returned error: %v", err)
+	}
+	if knownTests.Tests["module-a"]["suite-a"][0] != "test-a" {
+		t.Fatalf("GetKnownTests() returned unexpected processed data: %+v", knownTests)
+	}
+	if string(client.GetKnownTestsRawResponse()) != knownTestsResponse {
+		t.Fatalf("known tests raw response mismatch:\nexpected: %s\nactual:   %s", knownTestsResponse, string(client.GetKnownTestsRawResponse()))
+	}
+
+	correlationID, skippableTests, err := client.GetSkippableTests()
+	if err != nil {
+		t.Fatalf("GetSkippableTests() returned error: %v", err)
+	}
+	if correlationID != "correlation-id" || skippableTests["suite-a"]["test-a"][0].Parameters != "params" {
+		t.Fatalf("GetSkippableTests() returned unexpected processed data: correlationID=%s skippableTests=%+v", correlationID, skippableTests)
+	}
+	if string(client.GetSkippableTestsRawResponse()) != skippableTestsResponse {
+		t.Fatalf("skippable tests raw response mismatch:\nexpected: %s\nactual:   %s", skippableTestsResponse, string(client.GetSkippableTestsRawResponse()))
+	}
+
+	testManagement, err := client.GetTestManagementTests()
+	if err != nil {
+		t.Fatalf("GetTestManagementTests() returned error: %v", err)
+	}
+	testProperties := testManagement.Modules["module-a"].Suites["suite-a"].Tests["test-a"].Properties
+	if !testProperties.Quarantined || !testProperties.AttemptToFix {
+		t.Fatalf("GetTestManagementTests() returned unexpected processed data: %+v", testManagement)
+	}
+	if string(client.GetTestManagementTestsRawResponse()) != testManagementResponse {
+		t.Fatalf("test management raw response mismatch:\nexpected: %s\nactual:   %s", testManagementResponse, string(client.GetTestManagementTestsRawResponse()))
+	}
+}
+
+func TestClientRawResponseIsCloned(t *testing.T) {
+	settingsResponse := `{"data":{"id":"settings-id","type":"ci_app_test_service_libraries_settings","attributes":{"itr_enabled":true}}}`
+	server := newRawResponseTestServer(t, map[string]string{settingsURLPath: settingsResponse})
+	defer server.Close()
+
+	client := newRawResponseTestClient(server)
+	if _, err := client.GetSettings(); err != nil {
+		t.Fatalf("GetSettings() returned error: %v", err)
+	}
+
+	rawResponse := client.GetSettingsRawResponse()
+	rawResponse[0] = '['
+
+	if string(client.GetSettingsRawResponse()) != settingsResponse {
+		t.Fatalf("raw response getter should return a defensive copy")
+	}
+}
+
+func TestClientSettingsRawResponseUsesLatestResponse(t *testing.T) {
+	firstSettingsResponse := `{"data":{"id":"first","type":"ci_app_test_service_libraries_settings","attributes":{"require_git":true}}}`
+	secondSettingsResponse := `{"data":{"id":"second","type":"ci_app_test_service_libraries_settings","attributes":{"require_git":false}}}`
+	settingsResponses := []string{firstSettingsResponse, secondSettingsResponse}
+	requestCount := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/")
+		if path != settingsURLPath {
+			t.Fatalf("unexpected request path %s", path)
+		}
+		w.Header().Set(HeaderContentType, ContentTypeJSON)
+		_, _ = w.Write([]byte(settingsResponses[requestCount]))
+		requestCount++
+	}))
+	defer server.Close()
+
+	client := newRawResponseTestClient(server)
+	if _, err := client.GetSettings(); err != nil {
+		t.Fatalf("first GetSettings() returned error: %v", err)
+	}
+	if _, err := client.GetSettings(); err != nil {
+		t.Fatalf("second GetSettings() returned error: %v", err)
+	}
+
+	if string(client.GetSettingsRawResponse()) != secondSettingsResponse {
+		t.Fatalf("settings raw response should be replaced by the latest response")
+	}
+}

--- a/civisibility/utils/net/settings_api.go
+++ b/civisibility/utils/net/settings_api.go
@@ -73,6 +73,7 @@ func (c *client) GetSettings() (*SettingsResponseData, error) {
 	if c.repositoryURL == "" || c.commitSha == "" {
 		return nil, fmt.Errorf("civisibility.GetSettings: repository URL and commit SHA are required")
 	}
+	c.settingsRawResponse = nil
 
 	body := settingsRequest{
 		Data: settingsRequestHeader{
@@ -97,6 +98,7 @@ func (c *client) GetSettings() (*SettingsResponseData, error) {
 	}
 
 	slog.Debug("civisibility.settings", "responseBody", string(response.Body))
+	c.settingsRawResponse = cloneRawMessage(response.Body)
 
 	var responseObject settingsResponse
 	err = response.Unmarshal(&responseObject)

--- a/civisibility/utils/net/skippable.go
+++ b/civisibility/utils/net/skippable.go
@@ -61,6 +61,7 @@ func (c *client) GetSkippableTests() (correlationID string, skippables map[strin
 		err = fmt.Errorf("civisibility.GetSkippableTests: repository URL and commit SHA are required")
 		return
 	}
+	c.skippableTestsRawResponse = nil
 
 	body := skippableRequest{
 		Data: skippableRequestHeader{
@@ -82,6 +83,7 @@ func (c *client) GetSkippableTests() (correlationID string, skippables map[strin
 	if err != nil {
 		return "", nil, fmt.Errorf("sending skippable tests request: %s", err)
 	}
+	c.skippableTestsRawResponse = cloneRawMessage(response.Body)
 
 	var responseObject skippableResponse
 	err = response.Unmarshal(&responseObject)

--- a/civisibility/utils/net/test_management_tests_api.go
+++ b/civisibility/utils/net/test_management_tests_api.go
@@ -68,6 +68,7 @@ func (c *client) GetTestManagementTests() (*TestManagementTestsResponseDataModul
 	if c.repositoryURL == "" {
 		return nil, fmt.Errorf("civisibility.GetTestManagementTests: repository URL is required")
 	}
+	c.testManagementTestsRawResponse = nil
 
 	// we use the head commit SHA if it is set, otherwise we use the commit SHA
 	commitSha := c.commitSha
@@ -100,6 +101,7 @@ func (c *client) GetTestManagementTests() (*TestManagementTestsResponseDataModul
 	if err != nil {
 		return nil, fmt.Errorf("sending known tests request: %s", err)
 	}
+	c.testManagementTestsRawResponse = cloneRawMessage(response.Body)
 
 	var responseObject testManagementTestsResponse
 	err = response.Unmarshal(&responseObject)

--- a/docs/upgrade-1.0.md
+++ b/docs/upgrade-1.0.md
@@ -1,0 +1,53 @@
+# DDTest 1.0 Upgrade Guide
+
+DDTest 1.0 will remove compatibility writes for legacy `.testoptimization` runner files.
+Before upgrading to 1.0, update CI jobs and custom integrations to consume the new
+runner layout and upgrade the Datadog Ruby library to 1.31 or later.
+
+## Required Changes
+
+Upgrade the Datadog Ruby library to `1.31+`.
+
+Update any scripts, CI jobs, or custom test runners that read DDTest runner files:
+
+| Legacy path | New path |
+| --- | --- |
+| `.testoptimization/test-files.txt` | `.testoptimization/runner/test-files.txt` |
+| `.testoptimization/parallel-runners.txt` | `.testoptimization/runner/parallel-runners.txt` |
+| `.testoptimization/skippable-percentage.txt` | `.testoptimization/runner/skippable-percentage.txt` |
+| `.testoptimization/tests-split/runner-*` | `.testoptimization/runner/tests-split/runner-*` |
+
+Use `.testoptimization/manifest.txt` as the plan layout marker. DDTest sets
+`DD_TEST_OPTIMIZATION_MANIFEST_FILE` for worker processes to the absolute manifest
+path unless that environment variable is already provided.
+
+## Current Compatibility Window
+
+Before 1.0, DDTest writes runner files to both the legacy paths and the new
+`.testoptimization/runner/*` paths. This is write-only compatibility: DDTest itself
+reads from the new runner paths.
+
+In 1.0, DDTest will stop writing these legacy runner files:
+
+- `.testoptimization/test-files.txt`
+- `.testoptimization/parallel-runners.txt`
+- `.testoptimization/skippable-percentage.txt`
+- `.testoptimization/tests-split/runner-*`
+
+## Cache Layout
+
+Backend-shaped Datadog responses are available under `.testoptimization/cache/http/*`.
+The processed cache files under `.testoptimization/cache/*` are kept for Ruby library
+compatibility before 1.0.
+
+DDTest-private runner cache files, such as `test_suite_durations.json`, live under
+`.testoptimization/runner/cache/*` and do not cross the Ruby library compatibility
+boundary.
+
+## Validation Checklist
+
+1. Run `ddtest plan` in CI and verify `.testoptimization/manifest.txt` exists.
+2. Verify CI jobs read runner files only from `.testoptimization/runner/*`.
+3. Verify the Ruby library version is `1.31+`.
+4. Run one CI shard with `DD_TEST_OPTIMIZATION_RUNNER_CI_NODE=0 ddtest run`.
+5. Remove any references to legacy root runner paths from CI templates and custom scripts.

--- a/docs/upgrade-1.0.md
+++ b/docs/upgrade-1.0.md
@@ -18,7 +18,7 @@ Update any scripts, CI jobs, or custom test runners that read DDTest runner file
 | `.testoptimization/tests-split/runner-*` | `.testoptimization/runner/tests-split/runner-*` |
 
 Use `.testoptimization/manifest.txt` as the plan layout marker. DDTest sets
-`DD_TEST_OPTIMIZATION_MANIFEST_FILE` for worker processes to the absolute manifest
+`TEST_OPTIMIZATION_MANIFEST_FILE` for worker processes to the absolute manifest
 path unless that environment variable is already provided.
 
 ## Current Compatibility Window

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -5,11 +5,21 @@ import "path/filepath"
 // PlanDirectory is the directory where ddtest stores its output files and context data
 const PlanDirectory = ".testoptimization"
 
-// Output file paths (using filepath.Join for cross-platform compatibility)
-var TestFilesOutputPath = filepath.Join(PlanDirectory, "test-files.txt")
-var SkippablePercentageOutputPath = filepath.Join(PlanDirectory, "skippable-percentage.txt")
-var ParallelRunnersOutputPath = filepath.Join(PlanDirectory, "parallel-runners.txt")
-var TestsSplitDir = filepath.Join(PlanDirectory, "tests-split")
+const ManifestVersion = "1"
+
+var ManifestPath = filepath.Join(PlanDirectory, "manifest.txt")
+
+// Runner layout paths.
+var RunnerDirectory = filepath.Join(PlanDirectory, "runner")
+var TestFilesOutputPath = filepath.Join(RunnerDirectory, "test-files.txt")
+var SkippablePercentageOutputPath = filepath.Join(RunnerDirectory, "skippable-percentage.txt")
+var ParallelRunnersOutputPath = filepath.Join(RunnerDirectory, "parallel-runners.txt")
+var TestsSplitDir = filepath.Join(RunnerDirectory, "tests-split")
+var RunnerCacheDir = filepath.Join(RunnerDirectory, "cache")
+
+// New library-facing backend cache paths.
+var CacheDir = filepath.Join(PlanDirectory, "cache")
+var HTTPCacheDir = filepath.Join(CacheDir, "http")
 
 // Platform specific output file paths
 var RubyEnvOutputPath = filepath.Join(PlanDirectory, "ruby_env.json")

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -9,6 +9,8 @@ const ManifestVersion = "1"
 
 var ManifestPath = filepath.Join(PlanDirectory, "manifest.txt")
 
+const TestOptimizationManifestFileEnvVar = "DD_TEST_OPTIMIZATION_MANIFEST_FILE"
+
 // Runner layout paths.
 var RunnerDirectory = filepath.Join(PlanDirectory, "runner")
 var TestFilesOutputPath = filepath.Join(RunnerDirectory, "test-files.txt")

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -19,6 +19,12 @@ var ParallelRunnersOutputPath = filepath.Join(RunnerDirectory, "parallel-runners
 var TestsSplitDir = filepath.Join(RunnerDirectory, "tests-split")
 var RunnerCacheDir = filepath.Join(RunnerDirectory, "cache")
 
+// Legacy runner output paths are written for pre-1.0 compatibility only.
+var LegacyTestFilesOutputPath = filepath.Join(PlanDirectory, "test-files.txt")
+var LegacySkippablePercentageOutputPath = filepath.Join(PlanDirectory, "skippable-percentage.txt")
+var LegacyParallelRunnersOutputPath = filepath.Join(PlanDirectory, "parallel-runners.txt")
+var LegacyTestsSplitDir = filepath.Join(PlanDirectory, "tests-split")
+
 // New library-facing backend cache paths.
 var CacheDir = filepath.Join(PlanDirectory, "cache")
 var HTTPCacheDir = filepath.Join(CacheDir, "http")

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -9,7 +9,7 @@ const ManifestVersion = "1"
 
 var ManifestPath = filepath.Join(PlanDirectory, "manifest.txt")
 
-const TestOptimizationManifestFileEnvVar = "DD_TEST_OPTIMIZATION_MANIFEST_FILE"
+const TestOptimizationManifestFileEnvVar = "TEST_OPTIMIZATION_MANIFEST_FILE"
 
 // Runner layout paths.
 var RunnerDirectory = filepath.Join(PlanDirectory, "runner")

--- a/internal/runner/ci_node_executor.go
+++ b/internal/runner/ci_node_executor.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/DataDog/ddtest/internal/constants"
 	"github.com/DataDog/ddtest/internal/framework"
 	"golang.org/x/sync/errgroup"
 )
@@ -14,9 +13,11 @@ import (
 // runCINodeTests executes tests for a specific CI node (one split, not the whole tests set).
 // It further splits the node's tests among local workers based on ci_node_workers setting.
 func runCINodeTests(ctx context.Context, framework framework.Framework, workerEnvMap map[string]string, ciNode int, ciNodeWorkers int, testFileWeights map[string]int) error {
-	runnerFilePath := fmt.Sprintf("%s/runner-%d", constants.TestsSplitDir, ciNode)
+	runnerFilePath := runnerSplitPath(ciNode)
 	if _, err := os.Stat(runnerFilePath); os.IsNotExist(err) {
 		return fmt.Errorf("runner file for ci-node %d does not exist: %s", ciNode, runnerFilePath)
+	} else if err != nil {
+		return fmt.Errorf("failed to check runner file for ci-node %d at %s: %w", ciNode, runnerFilePath, err)
 	}
 
 	// Single worker mode: run all tests with nodeIndex matching ciNode.

--- a/internal/runner/ci_node_executor_test.go
+++ b/internal/runner/ci_node_executor_test.go
@@ -18,8 +18,8 @@ func TestRunCINodeTests_SingleWorker(t *testing.T) {
 	_ = os.Chdir(tempDir)
 
 	// Setup test split directory and files
-	_ = os.MkdirAll(filepath.Join(constants.PlanDirectory, "tests-split"), 0755)
-	_ = os.WriteFile(filepath.Join(constants.PlanDirectory, "tests-split", "runner-1"), []byte("test/file2_test.rb\ntest/file3_test.rb\n"), 0644)
+	_ = os.MkdirAll(constants.TestsSplitDir, 0755)
+	_ = os.WriteFile(filepath.Join(constants.TestsSplitDir, "runner-1"), []byte("test/file2_test.rb\ntest/file3_test.rb\n"), 0644)
 
 	mockFramework := &MockFramework{
 		FrameworkName: "rspec",
@@ -53,8 +53,8 @@ func TestRunCINodeTests_MultipleWorkers(t *testing.T) {
 	logs := captureLogs(t)
 
 	// Setup test split directory and files - 4 test files for ci-node 1
-	_ = os.MkdirAll(filepath.Join(constants.PlanDirectory, "tests-split"), 0755)
-	_ = os.WriteFile(filepath.Join(constants.PlanDirectory, "tests-split", "runner-1"),
+	_ = os.MkdirAll(constants.TestsSplitDir, 0755)
+	_ = os.WriteFile(filepath.Join(constants.TestsSplitDir, "runner-1"),
 		[]byte("test/file1_test.rb\ntest/file2_test.rb\ntest/file3_test.rb\ntest/file4_test.rb\n"), 0644)
 
 	mockFramework := &MockFramework{
@@ -109,8 +109,8 @@ func TestRunCINodeTests_NodeIndexMatchesCINode(t *testing.T) {
 	_ = os.Chdir(tempDir)
 
 	// Setup test split directory and files - 2 test files for ci-node 1
-	_ = os.MkdirAll(filepath.Join(constants.PlanDirectory, "tests-split"), 0755)
-	_ = os.WriteFile(filepath.Join(constants.PlanDirectory, "tests-split", "runner-1"),
+	_ = os.MkdirAll(constants.TestsSplitDir, 0755)
+	_ = os.WriteFile(filepath.Join(constants.TestsSplitDir, "runner-1"),
 		[]byte("test/file1_test.rb\ntest/file2_test.rb\n"), 0644)
 
 	mockFramework := &MockFramework{
@@ -163,8 +163,8 @@ func TestRunCINodeTests_SingleWorkerNodeIndex(t *testing.T) {
 	_ = os.Chdir(tempDir)
 
 	// Setup test split directory and files
-	_ = os.MkdirAll(filepath.Join(constants.PlanDirectory, "tests-split"), 0755)
-	_ = os.WriteFile(filepath.Join(constants.PlanDirectory, "tests-split", "runner-2"),
+	_ = os.MkdirAll(constants.TestsSplitDir, 0755)
+	_ = os.WriteFile(filepath.Join(constants.TestsSplitDir, "runner-2"),
 		[]byte("test/file1_test.rb\n"), 0644)
 
 	mockFramework := &MockFramework{
@@ -201,7 +201,7 @@ func TestRunCINodeTests_FileNotFound(t *testing.T) {
 	defer func() { _ = os.Chdir(oldWd) }()
 	_ = os.Chdir(tempDir)
 
-	_ = os.MkdirAll(filepath.Join(constants.PlanDirectory, "tests-split"), 0755)
+	_ = os.MkdirAll(constants.TestsSplitDir, 0755)
 	// Don't create runner-2 file
 
 	mockFramework := &MockFramework{FrameworkName: "rspec"}
@@ -224,8 +224,8 @@ func TestRunCINodeTests_EmptyFile(t *testing.T) {
 	_ = os.Chdir(tempDir)
 
 	// Setup test split directory with empty runner file
-	_ = os.MkdirAll(filepath.Join(constants.PlanDirectory, "tests-split"), 0755)
-	_ = os.WriteFile(filepath.Join(constants.PlanDirectory, "tests-split", "runner-0"), []byte(""), 0644)
+	_ = os.MkdirAll(constants.TestsSplitDir, 0755)
+	_ = os.WriteFile(filepath.Join(constants.TestsSplitDir, "runner-0"), []byte(""), 0644)
 
 	mockFramework := &MockFramework{FrameworkName: "rspec"}
 

--- a/internal/runner/ci_node_executor_test.go
+++ b/internal/runner/ci_node_executor_test.go
@@ -217,6 +217,28 @@ func TestRunCINodeTests_FileNotFound(t *testing.T) {
 	}
 }
 
+func TestRunCINodeTests_DoesNotReadLegacySplitFile(t *testing.T) {
+	tempDir := t.TempDir()
+	oldWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldWd) }()
+	_ = os.Chdir(tempDir)
+
+	_ = os.MkdirAll(constants.LegacyTestsSplitDir, 0755)
+	_ = os.WriteFile(filepath.Join(constants.LegacyTestsSplitDir, "runner-2"), []byte("test/file1_test.rb\n"), 0644)
+
+	mockFramework := &MockFramework{FrameworkName: "rspec"}
+
+	err := runCINodeTests(context.Background(), mockFramework, map[string]string{}, 2, 1, nil)
+	if err == nil {
+		t.Error("runCINodeTests() should return error when only the legacy runner file exists")
+	}
+
+	expectedMsg := "runner file for ci-node 2 does not exist"
+	if !strings.Contains(err.Error(), expectedMsg) {
+		t.Errorf("Error should contain '%s', got: %v", expectedMsg, err)
+	}
+}
+
 func TestRunCINodeTests_EmptyFile(t *testing.T) {
 	tempDir := t.TempDir()
 	oldWd, _ := os.Getwd()

--- a/internal/runner/distribution.go
+++ b/internal/runner/distribution.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -76,7 +77,6 @@ func DistributeTestFiles(testFiles map[string]int, parallelRunners int) [][]stri
 // For multiple runners: distributes files using bin packing and writes to separate runner files
 // For single runner: copies test-files.txt content to runner-0
 func CreateTestSplits(testFiles map[string]int, parallelRunners int, testFilesOutputPath string) error {
-	// Create tests-split directory
 	if err := os.MkdirAll(constants.TestsSplitDir, 0755); err != nil {
 		return fmt.Errorf("failed to create tests-split directory: %w", err)
 	}
@@ -92,14 +92,14 @@ func CreateTestSplits(testFiles map[string]int, parallelRunners int, testFilesOu
 				runnerContent += "\n"
 			}
 
-			runnerFilePath := fmt.Sprintf("%s/runner-%d", constants.TestsSplitDir, i)
+			runnerFilePath := filepath.Join(constants.TestsSplitDir, fmt.Sprintf("runner-%d", i))
 			if err := os.WriteFile(runnerFilePath, []byte(runnerContent), 0644); err != nil {
 				return fmt.Errorf("failed to write runner-%d files to %s: %w", i, runnerFilePath, err)
 			}
 		}
 	} else {
 		// For single runner, copy test-files.txt to runner-0
-		runnerFilePath := fmt.Sprintf("%s/runner-0", constants.TestsSplitDir)
+		runnerFilePath := filepath.Join(constants.TestsSplitDir, "runner-0")
 		testFilesData, err := os.ReadFile(testFilesOutputPath)
 		if err != nil {
 			return fmt.Errorf("failed to read test files from %s: %w", testFilesOutputPath, err)

--- a/internal/runner/distribution.go
+++ b/internal/runner/distribution.go
@@ -77,37 +77,56 @@ func DistributeTestFiles(testFiles map[string]int, parallelRunners int) [][]stri
 // For multiple runners: distributes files using bin packing and writes to separate runner files
 // For single runner: copies test-files.txt content to runner-0
 func CreateTestSplits(testFiles map[string]int, parallelRunners int, testFilesOutputPath string) error {
-	if err := os.MkdirAll(constants.TestsSplitDir, 0755); err != nil {
-		return fmt.Errorf("failed to create tests-split directory: %w", err)
-	}
+	testsSplitDirs := []string{constants.TestsSplitDir, constants.LegacyTestsSplitDir}
 
 	if parallelRunners > 1 {
 		// Distribute test files across parallel runners using bin packing
 		distribution := DistributeTestFiles(testFiles, parallelRunners)
-
-		// Save each runner's test files to separate files
-		for i, runnerFiles := range distribution {
-			runnerContent := strings.Join(runnerFiles, "\n")
-			if len(runnerFiles) > 0 {
-				runnerContent += "\n"
-			}
-
-			runnerFilePath := filepath.Join(constants.TestsSplitDir, fmt.Sprintf("runner-%d", i))
-			if err := os.WriteFile(runnerFilePath, []byte(runnerContent), 0644); err != nil {
-				return fmt.Errorf("failed to write runner-%d files to %s: %w", i, runnerFilePath, err)
+		for _, testsSplitDir := range testsSplitDirs {
+			if err := writeDistributedTestSplits(distribution, testsSplitDir); err != nil {
+				return err
 			}
 		}
 	} else {
 		// For single runner, copy test-files.txt to runner-0
-		runnerFilePath := filepath.Join(constants.TestsSplitDir, "runner-0")
 		testFilesData, err := os.ReadFile(testFilesOutputPath)
 		if err != nil {
 			return fmt.Errorf("failed to read test files from %s: %w", testFilesOutputPath, err)
 		}
 
-		if err := os.WriteFile(runnerFilePath, testFilesData, 0644); err != nil {
-			return fmt.Errorf("failed to copy test files to %s: %w", runnerFilePath, err)
+		for _, testsSplitDir := range testsSplitDirs {
+			if err := writeRunnerSplit(testsSplitDir, 0, testFilesData); err != nil {
+				return err
+			}
 		}
+	}
+
+	return nil
+}
+
+func writeDistributedTestSplits(distribution [][]string, testsSplitDir string) error {
+	for i, runnerFiles := range distribution {
+		runnerContent := strings.Join(runnerFiles, "\n")
+		if len(runnerFiles) > 0 {
+			runnerContent += "\n"
+		}
+
+		if err := writeRunnerSplit(testsSplitDir, i, []byte(runnerContent)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func writeRunnerSplit(testsSplitDir string, runnerIndex int, content []byte) error {
+	if err := os.MkdirAll(testsSplitDir, 0755); err != nil {
+		return fmt.Errorf("failed to create tests-split directory %s: %w", testsSplitDir, err)
+	}
+
+	runnerFilePath := filepath.Join(testsSplitDir, fmt.Sprintf("runner-%d", runnerIndex))
+	if err := os.WriteFile(runnerFilePath, content, 0644); err != nil {
+		return fmt.Errorf("failed to write runner-%d files to %s: %w", runnerIndex, runnerFilePath, err)
 	}
 
 	return nil

--- a/internal/runner/distribution_test.go
+++ b/internal/runner/distribution_test.go
@@ -270,11 +270,18 @@ func TestCreateTestSplits(t *testing.T) {
 		if _, err := os.Stat(constants.TestsSplitDir); os.IsNotExist(err) {
 			t.Error("Expected tests-split directory to be created")
 		}
+		if _, err := os.Stat(constants.LegacyTestsSplitDir); os.IsNotExist(err) {
+			t.Error("Expected legacy tests-split directory to be created")
+		}
 
 		// Verify runner-0 file was created
 		runnerFilePath := filepath.Join(constants.TestsSplitDir, "runner-0")
 		if _, err := os.Stat(runnerFilePath); os.IsNotExist(err) {
 			t.Error("Expected runner-0 file to be created")
+		}
+		legacyRunnerFilePath := filepath.Join(constants.LegacyTestsSplitDir, "runner-0")
+		if _, err := os.Stat(legacyRunnerFilePath); os.IsNotExist(err) {
+			t.Error("Expected legacy runner-0 file to be created")
 		}
 
 		// Verify content matches test-files.txt
@@ -285,6 +292,14 @@ func TestCreateTestSplits(t *testing.T) {
 
 		if string(runnerContent) != testContent {
 			t.Errorf("Expected runner-0 content %q, got %q", testContent, string(runnerContent))
+		}
+
+		legacyRunnerContent, err := os.ReadFile(legacyRunnerFilePath)
+		if err != nil {
+			t.Fatalf("Failed to read legacy runner-0 file: %v", err)
+		}
+		if string(legacyRunnerContent) != testContent {
+			t.Errorf("Expected legacy runner-0 content %q, got %q", testContent, string(legacyRunnerContent))
 		}
 	})
 
@@ -309,6 +324,9 @@ func TestCreateTestSplits(t *testing.T) {
 		if _, err := os.Stat(constants.TestsSplitDir); os.IsNotExist(err) {
 			t.Error("Expected tests-split directory to be created")
 		}
+		if _, err := os.Stat(constants.LegacyTestsSplitDir); os.IsNotExist(err) {
+			t.Error("Expected legacy tests-split directory to be created")
+		}
 
 		// Verify both runner files were created
 		for i := 0; i < 2; i++ {
@@ -316,12 +334,25 @@ func TestCreateTestSplits(t *testing.T) {
 			if _, err := os.Stat(runnerFilePath); os.IsNotExist(err) {
 				t.Errorf("Expected runner-%d file to be created", i)
 			}
+			legacyRunnerFilePath := filepath.Join(constants.LegacyTestsSplitDir, fmt.Sprintf("runner-%d", i))
+			if _, err := os.Stat(legacyRunnerFilePath); os.IsNotExist(err) {
+				t.Errorf("Expected legacy runner-%d file to be created", i)
+			}
 		}
 
 		// Verify content distribution
 		// With bin packing: runner-0 gets file1 (10), runner-1 gets file2+file3 (8)
 		runner0Content, _ := os.ReadFile(filepath.Join(constants.TestsSplitDir, "runner-0"))
 		runner1Content, _ := os.ReadFile(filepath.Join(constants.TestsSplitDir, "runner-1"))
+		legacyRunner0Content, _ := os.ReadFile(filepath.Join(constants.LegacyTestsSplitDir, "runner-0"))
+		legacyRunner1Content, _ := os.ReadFile(filepath.Join(constants.LegacyTestsSplitDir, "runner-1"))
+
+		if string(legacyRunner0Content) != string(runner0Content) {
+			t.Errorf("Expected legacy runner-0 content to match runner-0 content")
+		}
+		if string(legacyRunner1Content) != string(runner1Content) {
+			t.Errorf("Expected legacy runner-1 content to match runner-1 content")
+		}
 
 		runner0Files := strings.Fields(strings.TrimSpace(string(runner0Content)))
 		runner1Files := strings.Fields(strings.TrimSpace(string(runner1Content)))
@@ -361,6 +392,10 @@ func TestCreateTestSplits(t *testing.T) {
 			runnerFilePath := filepath.Join(constants.TestsSplitDir, fmt.Sprintf("runner-%d", i))
 			if _, err := os.Stat(runnerFilePath); os.IsNotExist(err) {
 				t.Errorf("Expected runner-%d file to be created", i)
+			}
+			legacyRunnerFilePath := filepath.Join(constants.LegacyTestsSplitDir, fmt.Sprintf("runner-%d", i))
+			if _, err := os.Stat(legacyRunnerFilePath); os.IsNotExist(err) {
+				t.Errorf("Expected legacy runner-%d file to be created", i)
 			}
 		}
 	})

--- a/internal/runner/distribution_test.go
+++ b/internal/runner/distribution_test.go
@@ -252,27 +252,27 @@ func TestCreateTestSplits(t *testing.T) {
 		_ = os.Chdir(tempDir)
 
 		// Create test-files.txt with content
-		_ = os.MkdirAll(constants.PlanDirectory, 0755)
+		_ = os.MkdirAll(filepath.Dir(constants.TestFilesOutputPath), 0755)
 		testContent := "test/file1_test.rb\ntest/file2_test.rb\n"
-		_ = os.WriteFile(filepath.Join(constants.PlanDirectory, "test-files.txt"), []byte(testContent), 0644)
+		_ = os.WriteFile(constants.TestFilesOutputPath, []byte(testContent), 0644)
 
 		testFiles := map[string]int{
 			"test/file1_test.rb": 2,
 			"test/file2_test.rb": 1,
 		}
 
-		err := CreateTestSplits(testFiles, 1, filepath.Join(constants.PlanDirectory, "test-files.txt"))
+		err := CreateTestSplits(testFiles, 1, constants.TestFilesOutputPath)
 		if err != nil {
 			t.Fatalf("CreateTestSplits() should not return error, got: %v", err)
 		}
 
 		// Verify tests-split directory was created
-		if _, err := os.Stat(filepath.Join(constants.PlanDirectory, "tests-split")); os.IsNotExist(err) {
+		if _, err := os.Stat(constants.TestsSplitDir); os.IsNotExist(err) {
 			t.Error("Expected tests-split directory to be created")
 		}
 
 		// Verify runner-0 file was created
-		runnerFilePath := filepath.Join(constants.PlanDirectory, "tests-split", "runner-0")
+		runnerFilePath := filepath.Join(constants.TestsSplitDir, "runner-0")
 		if _, err := os.Stat(runnerFilePath); os.IsNotExist(err) {
 			t.Error("Expected runner-0 file to be created")
 		}
@@ -300,19 +300,19 @@ func TestCreateTestSplits(t *testing.T) {
 			"test/file3_test.rb": 3,
 		}
 
-		err := CreateTestSplits(testFiles, 2, filepath.Join(constants.PlanDirectory, "test-files.txt"))
+		err := CreateTestSplits(testFiles, 2, constants.TestFilesOutputPath)
 		if err != nil {
 			t.Fatalf("CreateTestSplits() should not return error, got: %v", err)
 		}
 
 		// Verify tests-split directory was created
-		if _, err := os.Stat(filepath.Join(constants.PlanDirectory, "tests-split")); os.IsNotExist(err) {
+		if _, err := os.Stat(constants.TestsSplitDir); os.IsNotExist(err) {
 			t.Error("Expected tests-split directory to be created")
 		}
 
 		// Verify both runner files were created
 		for i := 0; i < 2; i++ {
-			runnerFilePath := filepath.Join(constants.PlanDirectory, "tests-split", fmt.Sprintf("runner-%d", i))
+			runnerFilePath := filepath.Join(constants.TestsSplitDir, fmt.Sprintf("runner-%d", i))
 			if _, err := os.Stat(runnerFilePath); os.IsNotExist(err) {
 				t.Errorf("Expected runner-%d file to be created", i)
 			}
@@ -320,8 +320,8 @@ func TestCreateTestSplits(t *testing.T) {
 
 		// Verify content distribution
 		// With bin packing: runner-0 gets file1 (10), runner-1 gets file2+file3 (8)
-		runner0Content, _ := os.ReadFile(filepath.Join(constants.PlanDirectory, "tests-split", "runner-0"))
-		runner1Content, _ := os.ReadFile(filepath.Join(constants.PlanDirectory, "tests-split", "runner-1"))
+		runner0Content, _ := os.ReadFile(filepath.Join(constants.TestsSplitDir, "runner-0"))
+		runner1Content, _ := os.ReadFile(filepath.Join(constants.TestsSplitDir, "runner-1"))
 
 		runner0Files := strings.Fields(strings.TrimSpace(string(runner0Content)))
 		runner1Files := strings.Fields(strings.TrimSpace(string(runner1Content)))
@@ -348,17 +348,17 @@ func TestCreateTestSplits(t *testing.T) {
 		_ = os.Chdir(tempDir)
 
 		// Create empty test-files.txt
-		_ = os.MkdirAll(constants.PlanDirectory, 0755)
-		_ = os.WriteFile(filepath.Join(constants.PlanDirectory, "test-files.txt"), []byte(""), 0644)
+		_ = os.MkdirAll(filepath.Dir(constants.TestFilesOutputPath), 0755)
+		_ = os.WriteFile(constants.TestFilesOutputPath, []byte(""), 0644)
 
-		err := CreateTestSplits(map[string]int{}, 2, filepath.Join(constants.PlanDirectory, "test-files.txt"))
+		err := CreateTestSplits(map[string]int{}, 2, constants.TestFilesOutputPath)
 		if err != nil {
 			t.Fatalf("CreateTestSplits() should not return error for empty files, got: %v", err)
 		}
 
 		// Verify runner files are created (even if empty)
 		for i := 0; i < 2; i++ {
-			runnerFilePath := filepath.Join(constants.PlanDirectory, "tests-split", fmt.Sprintf("runner-%d", i))
+			runnerFilePath := filepath.Join(constants.TestsSplitDir, fmt.Sprintf("runner-%d", i))
 			if _, err := os.Stat(runnerFilePath); os.IsNotExist(err) {
 				t.Errorf("Expected runner-%d file to be created", i)
 			}
@@ -374,12 +374,12 @@ func TestCreateTestSplits(t *testing.T) {
 		// Don't create test-files.txt
 		testFiles := map[string]int{"test/file1_test.rb": 1}
 
-		err := CreateTestSplits(testFiles, 1, filepath.Join(constants.PlanDirectory, "test-files.txt"))
+		err := CreateTestSplits(testFiles, 1, constants.TestFilesOutputPath)
 		if err == nil {
 			t.Error("CreateTestSplits() should return error when test-files.txt doesn't exist")
 		}
 
-		expectedMsg := "failed to read test files from " + filepath.Join(constants.PlanDirectory, "test-files.txt")
+		expectedMsg := "failed to read test files from " + constants.TestFilesOutputPath
 		if !strings.Contains(err.Error(), expectedMsg) {
 			t.Errorf("Error should contain '%s', got: %v", expectedMsg, err)
 		}

--- a/internal/runner/parallel_executor_test.go
+++ b/internal/runner/parallel_executor_test.go
@@ -17,9 +17,9 @@ func TestRunParallelTests_Success(t *testing.T) {
 	_ = os.Chdir(tempDir)
 
 	// Setup test split directory and files
-	_ = os.MkdirAll(filepath.Join(constants.PlanDirectory, "tests-split"), 0755)
-	_ = os.WriteFile(filepath.Join(constants.PlanDirectory, "tests-split", "runner-0"), []byte("test/file1_test.rb\n"), 0644)
-	_ = os.WriteFile(filepath.Join(constants.PlanDirectory, "tests-split", "runner-1"), []byte("test/file2_test.rb\n"), 0644)
+	_ = os.MkdirAll(constants.TestsSplitDir, 0755)
+	_ = os.WriteFile(filepath.Join(constants.TestsSplitDir, "runner-0"), []byte("test/file1_test.rb\n"), 0644)
+	_ = os.WriteFile(filepath.Join(constants.TestsSplitDir, "runner-1"), []byte("test/file2_test.rb\n"), 0644)
 
 	mockFramework := &MockFramework{
 		FrameworkName: "rspec",

--- a/internal/runner/plan_files.go
+++ b/internal/runner/plan_files.go
@@ -21,3 +21,12 @@ func writePlanFile(path string, data []byte) error {
 	}
 	return nil
 }
+
+func writePlanFileCopies(data []byte, paths ...string) error {
+	for _, path := range paths {
+		if err := writePlanFile(path, data); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/runner/plan_files.go
+++ b/internal/runner/plan_files.go
@@ -1,0 +1,23 @@
+package runner
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/DataDog/ddtest/internal/constants"
+)
+
+func runnerSplitPath(ciNode int) string {
+	return filepath.Join(constants.TestsSplitDir, fmt.Sprintf("runner-%d", ciNode))
+}
+
+func writePlanFile(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("failed to create output directory for %s: %w", path, err)
+	}
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("failed to write %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -95,19 +95,19 @@ func (tr *TestRunner) Plan(ctx context.Context) error {
 		content += "\n"
 	}
 
-	if err := writePlanFile(constants.TestFilesOutputPath, []byte(content)); err != nil {
+	if err := writePlanFileCopies([]byte(content), constants.TestFilesOutputPath, constants.LegacyTestFilesOutputPath); err != nil {
 		return fmt.Errorf("failed to write test files: %w", err)
 	}
 
 	percentageContent := fmt.Sprintf("%.2f", tr.skippablePercentage)
-	if err := writePlanFile(constants.SkippablePercentageOutputPath, []byte(percentageContent)); err != nil {
+	if err := writePlanFileCopies([]byte(percentageContent), constants.SkippablePercentageOutputPath, constants.LegacySkippablePercentageOutputPath); err != nil {
 		return fmt.Errorf("failed to write skippable percentage: %w", err)
 	}
 
 	// Calculate and write parallel runners count
 	parallelRunners := calculateParallelRunners(tr.skippablePercentage)
 	runnersContent := fmt.Sprintf("%d", parallelRunners)
-	if err := writePlanFile(constants.ParallelRunnersOutputPath, []byte(runnersContent)); err != nil {
+	if err := writePlanFileCopies([]byte(runnersContent), constants.ParallelRunnersOutputPath, constants.LegacyParallelRunnersOutputPath); err != nil {
 		return fmt.Errorf("failed to write parallel runners: %w", err)
 	}
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"path/filepath"
 	"slices"
 	"strings"
 
@@ -77,8 +76,8 @@ func (tr *TestRunner) Plan(ctx context.Context) error {
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Dir(constants.TestFilesOutputPath), 0755); err != nil {
-		return fmt.Errorf("failed to create output directory: %w", err)
+	if err := writePlanFile(constants.ManifestPath, []byte(constants.ManifestVersion+"\n")); err != nil {
+		return fmt.Errorf("failed to write test optimization manifest: %w", err)
 	}
 
 	if err := tr.storeTestSuiteDurationsCache(); err != nil {
@@ -96,20 +95,20 @@ func (tr *TestRunner) Plan(ctx context.Context) error {
 		content += "\n"
 	}
 
-	if err := os.WriteFile(constants.TestFilesOutputPath, []byte(content), 0644); err != nil {
-		return fmt.Errorf("failed to write test files to %s: %w", constants.TestFilesOutputPath, err)
+	if err := writePlanFile(constants.TestFilesOutputPath, []byte(content)); err != nil {
+		return fmt.Errorf("failed to write test files: %w", err)
 	}
 
 	percentageContent := fmt.Sprintf("%.2f", tr.skippablePercentage)
-	if err := os.WriteFile(constants.SkippablePercentageOutputPath, []byte(percentageContent), 0644); err != nil {
-		return fmt.Errorf("failed to write skippable percentage to %s: %w", constants.SkippablePercentageOutputPath, err)
+	if err := writePlanFile(constants.SkippablePercentageOutputPath, []byte(percentageContent)); err != nil {
+		return fmt.Errorf("failed to write skippable percentage: %w", err)
 	}
 
 	// Calculate and write parallel runners count
 	parallelRunners := calculateParallelRunners(tr.skippablePercentage)
 	runnersContent := fmt.Sprintf("%d", parallelRunners)
-	if err := os.WriteFile(constants.ParallelRunnersOutputPath, []byte(runnersContent), 0644); err != nil {
-		return fmt.Errorf("failed to write parallel runners to %s: %w", constants.ParallelRunnersOutputPath, err)
+	if err := writePlanFile(constants.ParallelRunnersOutputPath, []byte(runnersContent)); err != nil {
+		return fmt.Errorf("failed to write parallel runners: %w", err)
 	}
 
 	// Detect and configure CI provider if available
@@ -143,6 +142,8 @@ func (tr *TestRunner) Run(ctx context.Context) error {
 		if err := tr.Plan(ctx); err != nil {
 			return fmt.Errorf("failed to run planning phase: %w", err)
 		}
+	} else if err != nil {
+		return fmt.Errorf("failed to check parallel runners count at %s: %w", constants.ParallelRunnersOutputPath, err)
 	}
 
 	if err := tr.restoreTestSuiteDurationsCache(); err != nil {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -410,16 +410,15 @@ func TestTestRunner_Plan_WritesManifestAndRunnerLayout(t *testing.T) {
 
 	expectedTestFiles := "test/file1_test.rb\ntest/file2_test.rb\n"
 	assertFileContent(t, constants.TestFilesOutputPath, expectedTestFiles)
+	assertFileContent(t, constants.LegacyTestFilesOutputPath, expectedTestFiles)
 
 	assertFileContent(t, constants.ParallelRunnersOutputPath, "1")
+	assertFileContent(t, constants.LegacyParallelRunnersOutputPath, "1")
 	assertFileContent(t, constants.SkippablePercentageOutputPath, "0.00")
+	assertFileContent(t, constants.LegacySkippablePercentageOutputPath, "0.00")
 
 	assertFileContent(t, filepath.Join(constants.TestsSplitDir, "runner-0"), expectedTestFiles)
-
-	legacyTestFilesPath := filepath.Join(constants.PlanDirectory, "test-files.txt")
-	if _, err := os.Stat(legacyTestFilesPath); !os.IsNotExist(err) {
-		t.Fatalf("expected no legacy runner file at %s, got err %v", legacyTestFilesPath, err)
-	}
+	assertFileContent(t, filepath.Join(constants.LegacyTestsSplitDir, "runner-0"), expectedTestFiles)
 }
 
 func TestTestRunner_Setup_WithCIProvider(t *testing.T) {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -214,6 +214,18 @@ func newDefaultMockCIProviderDetector() *MockCIProviderDetector {
 	}
 }
 
+func assertFileContent(t *testing.T, path string, expected string) {
+	t.Helper()
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", path, err)
+	}
+	if string(content) != expected {
+		t.Fatalf("expected %s content %q, got %q", path, expected, string(content))
+	}
+}
+
 func TestNew(t *testing.T) {
 	runner := New()
 
@@ -353,6 +365,60 @@ func TestTestRunner_Setup_WithParallelRunners(t *testing.T) {
 	expected := "1"
 	if string(content) != expected {
 		t.Errorf("Expected parallel runners file content '%s', got '%s'", expected, string(content))
+	}
+}
+
+func TestTestRunner_Plan_WritesManifestAndRunnerLayout(t *testing.T) {
+	tempDir := t.TempDir()
+	oldWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldWd) }()
+	_ = os.Chdir(tempDir)
+
+	_ = os.Setenv("DD_TEST_OPTIMIZATION_RUNNER_MIN_PARALLELISM", "1")
+	_ = os.Setenv("DD_TEST_OPTIMIZATION_RUNNER_MAX_PARALLELISM", "1")
+	defer func() {
+		_ = os.Unsetenv("DD_TEST_OPTIMIZATION_RUNNER_MIN_PARALLELISM")
+		_ = os.Unsetenv("DD_TEST_OPTIMIZATION_RUNNER_MAX_PARALLELISM")
+	}()
+	settings.Init()
+
+	mockFramework := &MockFramework{
+		FrameworkName: "rspec",
+		Tests: []testoptimization.Test{
+			{Suite: "TestSuite1", Name: "test1", Parameters: "", SuiteSourceFile: "test/file1_test.rb"},
+			{Suite: "TestSuite2", Name: "test2", Parameters: "", SuiteSourceFile: "test/file2_test.rb"},
+		},
+	}
+	mockPlatform := &MockPlatform{
+		PlatformName: "ruby",
+		Tags:         map[string]string{"platform": "ruby"},
+		Framework:    mockFramework,
+	}
+
+	runner := NewWithDependencies(
+		&MockPlatformDetector{Platform: mockPlatform},
+		&MockTestOptimizationClient{SkippableTests: map[string]bool{}},
+		&MockTestSuiteDurationsClient{},
+		newDefaultMockCIProviderDetector(),
+	)
+
+	if err := runner.Plan(context.Background()); err != nil {
+		t.Fatalf("Plan() should not return error, got: %v", err)
+	}
+
+	assertFileContent(t, constants.ManifestPath, constants.ManifestVersion+"\n")
+
+	expectedTestFiles := "test/file1_test.rb\ntest/file2_test.rb\n"
+	assertFileContent(t, constants.TestFilesOutputPath, expectedTestFiles)
+
+	assertFileContent(t, constants.ParallelRunnersOutputPath, "1")
+	assertFileContent(t, constants.SkippablePercentageOutputPath, "0.00")
+
+	assertFileContent(t, filepath.Join(constants.TestsSplitDir, "runner-0"), expectedTestFiles)
+
+	legacyTestFilesPath := filepath.Join(constants.PlanDirectory, "test-files.txt")
+	if _, err := os.Stat(legacyTestFilesPath); !os.IsNotExist(err) {
+		t.Fatalf("expected no legacy runner file at %s, got err %v", legacyTestFilesPath, err)
 	}
 }
 
@@ -570,18 +636,18 @@ func TestTestRunner_Setup_WithTestSplit(t *testing.T) {
 		}
 
 		// Verify that tests-split directory was created
-		if _, err := os.Stat(filepath.Join(constants.PlanDirectory, "tests-split")); os.IsNotExist(err) {
+		if _, err := os.Stat(constants.TestsSplitDir); os.IsNotExist(err) {
 			t.Error("Expected tests-split directory to be created when parallelRunners = 1")
 		}
 
 		// Verify that runner-0 file was created
-		runnerFilePath := filepath.Join(constants.PlanDirectory, "tests-split", "runner-0")
+		runnerFilePath := filepath.Join(constants.TestsSplitDir, "runner-0")
 		if _, err := os.Stat(runnerFilePath); os.IsNotExist(err) {
 			t.Error("Expected runner-0 file to be created when parallelRunners = 1")
 		}
 
 		// Verify that runner-0 contains the same content as test-files.txt
-		testFilesContent, err := os.ReadFile(filepath.Join(constants.PlanDirectory, "test-files.txt"))
+		testFilesContent, err := os.ReadFile(constants.TestFilesOutputPath)
 		if err != nil {
 			t.Fatalf("Failed to read test-files.txt: %v", err)
 		}
@@ -658,14 +724,14 @@ func TestTestRunner_Setup_WithTestSplit(t *testing.T) {
 		}
 
 		// Verify that tests-split directory was created
-		if _, err := os.Stat(filepath.Join(constants.PlanDirectory, "tests-split")); os.IsNotExist(err) {
+		if _, err := os.Stat(constants.TestsSplitDir); os.IsNotExist(err) {
 			t.Error("Expected tests-split directory to be created")
 		}
 
 		// With min=2 and 0% skippable tests, we should get 4 parallel runners
 		// Verify runner files exist
 		for i := range expectedParallelRunnersCount {
-			runnerPath := filepath.Join(constants.PlanDirectory, "tests-split", fmt.Sprintf("runner-%d", i))
+			runnerPath := filepath.Join(constants.TestsSplitDir, fmt.Sprintf("runner-%d", i))
 			if _, err := os.Stat(runnerPath); os.IsNotExist(err) {
 				t.Errorf("Expected runner-%d file to exist", i)
 			}
@@ -674,7 +740,7 @@ func TestTestRunner_Setup_WithTestSplit(t *testing.T) {
 		// Verify content of runner files
 		// With the test distribution (file1: 2 tests, file2: 1 test, file3: 1 test)
 		// and 4 runners, expected: Runner 0 gets file1 (2 tests), others get 1 test each
-		runner0Content, err := os.ReadFile(filepath.Join(constants.PlanDirectory, "tests-split", "runner-0"))
+		runner0Content, err := os.ReadFile(filepath.Join(constants.TestsSplitDir, "runner-0"))
 		if err != nil {
 			t.Fatalf("Failed to read runner-0 file: %v", err)
 		}
@@ -688,7 +754,7 @@ func TestTestRunner_Setup_WithTestSplit(t *testing.T) {
 		// Count total files across all runners
 		totalFiles := 0
 		for i := range expectedParallelRunnersCount {
-			runnerPath := filepath.Join(constants.PlanDirectory, "tests-split", fmt.Sprintf("runner-%d", i))
+			runnerPath := filepath.Join(constants.TestsSplitDir, fmt.Sprintf("runner-%d", i))
 			content, err := os.ReadFile(runnerPath)
 			if err != nil {
 				continue

--- a/internal/runner/sequential_executor_test.go
+++ b/internal/runner/sequential_executor_test.go
@@ -17,9 +17,9 @@ func TestRunSequentialTests_Success(t *testing.T) {
 	_ = os.Chdir(tempDir)
 
 	// Setup test files
-	_ = os.MkdirAll(constants.PlanDirectory, 0755)
+	_ = os.MkdirAll(filepath.Dir(constants.TestFilesOutputPath), 0755)
 	testFiles := "test/file1_test.rb\ntest/file2_test.rb\n"
-	_ = os.WriteFile(filepath.Join(constants.PlanDirectory, "test-files.txt"), []byte(testFiles), 0644)
+	_ = os.WriteFile(constants.TestFilesOutputPath, []byte(testFiles), 0644)
 
 	mockFramework := &MockFramework{
 		FrameworkName: "rspec",

--- a/internal/runner/sequential_executor_test.go
+++ b/internal/runner/sequential_executor_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/DataDog/ddtest/internal/constants"
@@ -41,5 +42,29 @@ func TestRunSequentialTests_Success(t *testing.T) {
 	expectedFiles := []string{"test/file1_test.rb", "test/file2_test.rb"}
 	if !slices.Equal(call.TestFiles, expectedFiles) {
 		t.Errorf("Expected test files %v, got %v", expectedFiles, call.TestFiles)
+	}
+}
+
+func TestRunSequentialTests_DoesNotReadLegacyTestFiles(t *testing.T) {
+	tempDir := t.TempDir()
+	oldWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldWd) }()
+	_ = os.Chdir(tempDir)
+
+	_ = os.MkdirAll(filepath.Dir(constants.LegacyTestFilesOutputPath), 0755)
+	_ = os.WriteFile(constants.LegacyTestFilesOutputPath, []byte("test/file1_test.rb\n"), 0644)
+
+	mockFramework := &MockFramework{
+		FrameworkName: "rspec",
+		RunTestsCalls: []RunTestsCall{},
+	}
+
+	err := runSequentialTests(context.Background(), mockFramework, map[string]string{})
+	if err == nil {
+		t.Fatal("runSequentialTests() should return error when only the legacy test files list exists")
+	}
+
+	if !strings.Contains(err.Error(), constants.TestFilesOutputPath) {
+		t.Errorf("Error should reference new test files path %s, got: %v", constants.TestFilesOutputPath, err)
 	}
 }

--- a/internal/runner/test_suite_durations_cache_test.go
+++ b/internal/runner/test_suite_durations_cache_test.go
@@ -51,7 +51,7 @@ func TestTestRunner_Plan_StoresTestSuiteDurationsCache(t *testing.T) {
 		t.Fatalf("Plan() should not return error, got: %v", err)
 	}
 
-	cachePath := filepath.Join(constants.PlanDirectory, "cache", testoptimization.TestSuiteDurationsCacheFile)
+	cachePath := filepath.Join(constants.RunnerCacheDir, testoptimization.TestSuiteDurationsCacheFile)
 	if _, err := os.Stat(cachePath); err != nil {
 		t.Fatalf("Expected test suite durations cache file to be written: %v", err)
 	}

--- a/internal/runner/worker_env.go
+++ b/internal/runner/worker_env.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	ciConstants "github.com/DataDog/ddtest/civisibility/constants"
@@ -13,6 +14,7 @@ import (
 func createWorkerEnv(workerEnvMap map[string]string, nodeIndex int, workerIndex int) map[string]string {
 	workerEnv := replaceIndexPlaceholders(workerEnvMap, nodeIndex, workerIndex)
 	ensureTestSessionName(workerEnv, nodeIndex, workerIndex)
+	ensureManifestFile(workerEnv)
 	return workerEnv
 }
 
@@ -43,4 +45,21 @@ func ensureTestSessionName(workerEnv map[string]string, nodeIndex int, workerInd
 
 	service := resolveServiceName(ciUtils.GetCITags()[ciConstants.GitRepositoryURL])
 	workerEnv[ciConstants.CIVisibilityTestSessionNameEnvironmentVariable] = fmt.Sprintf("%s-node-%d-worker-%d", service, nodeIndex, workerIndex)
+}
+
+func ensureManifestFile(workerEnv map[string]string) {
+	if _, ok := workerEnv[constants.TestOptimizationManifestFileEnvVar]; ok {
+		return
+	}
+
+	if manifestFile, ok := os.LookupEnv(constants.TestOptimizationManifestFileEnvVar); ok {
+		workerEnv[constants.TestOptimizationManifestFileEnvVar] = manifestFile
+		return
+	}
+
+	manifestPath, err := filepath.Abs(constants.ManifestPath)
+	if err != nil {
+		manifestPath = constants.ManifestPath
+	}
+	workerEnv[constants.TestOptimizationManifestFileEnvVar] = manifestPath
 }

--- a/internal/runner/worker_env_test.go
+++ b/internal/runner/worker_env_test.go
@@ -3,10 +3,12 @@ package runner
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"testing"
 
 	ciConstants "github.com/DataDog/ddtest/civisibility/constants"
 	ciUtils "github.com/DataDog/ddtest/civisibility/utils"
+	"github.com/DataDog/ddtest/internal/constants"
 )
 
 func unsetEnvForTest(t *testing.T, key string) {
@@ -23,6 +25,22 @@ func unsetEnvForTest(t *testing.T, key string) {
 		} else {
 			_ = os.Unsetenv(key)
 		}
+	})
+}
+
+func chdirForTest(t *testing.T, dir string) {
+	t.Helper()
+
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current directory: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("failed to chdir to %s: %v", dir, err)
+	}
+
+	t.Cleanup(func() {
+		_ = os.Chdir(oldWd)
 	})
 }
 
@@ -118,5 +136,79 @@ func TestRunTestBatch_WorkerEnvTestSessionNameTakesPrecedence(t *testing.T) {
 	sessionName := call.EnvMap[ciConstants.CIVisibilityTestSessionNameEnvironmentVariable]
 	if sessionName != "worker-node-9-worker-1" {
 		t.Errorf("Expected worker env DD_TEST_SESSION_NAME to take precedence, got %s", sessionName)
+	}
+}
+
+func TestRunTestBatch_DefaultManifestFile(t *testing.T) {
+	chdirForTest(t, t.TempDir())
+	unsetEnvForTest(t, constants.TestOptimizationManifestFileEnvVar)
+	unsetEnvForTest(t, "DD_TEST_OPTIMIZATION_PAYLOADS_IN_FILES")
+
+	mockFramework := &MockFramework{
+		FrameworkName: "rspec",
+		RunTestsCalls: []RunTestsCall{},
+	}
+
+	err := runTestBatch(context.Background(), mockFramework, []string{"test/file1_test.rb"}, map[string]string{}, 2, 4)
+	if err != nil {
+		t.Fatalf("runTestBatch() should not return error, got: %v", err)
+	}
+
+	call := mockFramework.GetRunTestsCalls()[0]
+	expectedManifestPath, err := filepath.Abs(constants.ManifestPath)
+	if err != nil {
+		t.Fatalf("filepath.Abs() should not return error, got: %v", err)
+	}
+
+	if call.EnvMap[constants.TestOptimizationManifestFileEnvVar] != expectedManifestPath {
+		t.Errorf("Expected %s=%s, got %s",
+			constants.TestOptimizationManifestFileEnvVar,
+			expectedManifestPath,
+			call.EnvMap[constants.TestOptimizationManifestFileEnvVar])
+	}
+
+	if _, ok := call.EnvMap["DD_TEST_OPTIMIZATION_PAYLOADS_IN_FILES"]; ok {
+		t.Error("Expected DD_TEST_OPTIMIZATION_PAYLOADS_IN_FILES to not be set by ddtest run")
+	}
+}
+
+func TestRunTestBatch_ManifestFileUsesProcessEnv(t *testing.T) {
+	t.Setenv(constants.TestOptimizationManifestFileEnvVar, "/tmp/custom-manifest.txt")
+
+	mockFramework := &MockFramework{
+		FrameworkName: "rspec",
+		RunTestsCalls: []RunTestsCall{},
+	}
+
+	err := runTestBatch(context.Background(), mockFramework, []string{"test/file1_test.rb"}, map[string]string{}, 2, 4)
+	if err != nil {
+		t.Fatalf("runTestBatch() should not return error, got: %v", err)
+	}
+
+	call := mockFramework.GetRunTestsCalls()[0]
+	if call.EnvMap[constants.TestOptimizationManifestFileEnvVar] != "/tmp/custom-manifest.txt" {
+		t.Errorf("Expected process env manifest file to be preserved, got %s", call.EnvMap[constants.TestOptimizationManifestFileEnvVar])
+	}
+}
+
+func TestRunTestBatch_WorkerEnvManifestFileTakesPrecedence(t *testing.T) {
+	t.Setenv(constants.TestOptimizationManifestFileEnvVar, "/tmp/process-manifest.txt")
+
+	mockFramework := &MockFramework{
+		FrameworkName: "rspec",
+		RunTestsCalls: []RunTestsCall{},
+	}
+	workerEnvMap := map[string]string{
+		constants.TestOptimizationManifestFileEnvVar: "/tmp/worker-manifest.txt",
+	}
+
+	err := runTestBatch(context.Background(), mockFramework, []string{"test/file1_test.rb"}, workerEnvMap, 2, 4)
+	if err != nil {
+		t.Fatalf("runTestBatch() should not return error, got: %v", err)
+	}
+
+	call := mockFramework.GetRunTestsCalls()[0]
+	if call.EnvMap[constants.TestOptimizationManifestFileEnvVar] != "/tmp/worker-manifest.txt" {
+		t.Errorf("Expected worker env manifest file to take precedence, got %s", call.EnvMap[constants.TestOptimizationManifestFileEnvVar])
 	}
 }

--- a/internal/testoptimization/cache.go
+++ b/internal/testoptimization/cache.go
@@ -22,6 +22,13 @@ type SkippableTestsCache struct {
 // TestSuiteDurationsCacheFile is the cache file name for suite duration metadata.
 const TestSuiteDurationsCacheFile = "test_suite_durations.json"
 
+const (
+	httpSettingsCacheFile       = "settings.json"
+	httpKnownTestsCacheFile     = "known_tests.json"
+	httpSkippableTestsCacheFile = "skippable_tests.json"
+	httpTestManagementCacheFile = "test_management.json"
+)
+
 // CacheManager handles creation and storage of cache data for test runners
 type CacheManager struct{}
 
@@ -32,8 +39,11 @@ func NewCacheManager() *CacheManager {
 
 // CreateCacheDirectory creates the .testoptimization/cache directory for storing cache data
 func (cm *CacheManager) CreateCacheDirectory() error {
-	cacheDir := filepath.Join(appConstants.PlanDirectory, "cache")
-	return os.MkdirAll(cacheDir, 0755)
+	return os.MkdirAll(appConstants.CacheDir, 0755)
+}
+
+func (cm *CacheManager) createHTTPCacheDirectory() error {
+	return os.MkdirAll(appConstants.HTTPCacheDir, 0755)
 }
 
 // writeJSONToFile writes data as JSON to the specified file path
@@ -44,6 +54,18 @@ func (cm *CacheManager) writeJSONToFile(data any, filePath string) error {
 	}
 
 	if err := os.WriteFile(filePath, jsonData, 0644); err != nil {
+		return fmt.Errorf("failed to write file: %w", err)
+	}
+
+	return nil
+}
+
+func (cm *CacheManager) writeRawJSONToFile(data json.RawMessage, filePath string) error {
+	if len(data) == 0 {
+		return nil
+	}
+
+	if err := os.WriteFile(filePath, data, 0644); err != nil {
 		return fmt.Errorf("failed to write file: %w", err)
 	}
 
@@ -64,13 +86,47 @@ func (cm *CacheManager) readJSONFromFile(filePath string, data any) error {
 	return nil
 }
 
+func (cm *CacheManager) storeRawHTTPResponse(data json.RawMessage, fileName string) error {
+	if len(data) == 0 {
+		return nil
+	}
+	if err := cm.createHTTPCacheDirectory(); err != nil {
+		return fmt.Errorf("failed to create HTTP cache directory: %w", err)
+	}
+
+	path := filepath.Join(appConstants.HTTPCacheDir, fileName)
+	if err := cm.writeRawJSONToFile(data, path); err != nil {
+		slog.Error("Failed to write raw backend response to file", "error", err, "path", path)
+		return err
+	}
+
+	slog.Debug("Raw backend response written to file", "path", path)
+	return nil
+}
+
+func (cm *CacheManager) StoreRawRepositorySettings(data json.RawMessage) error {
+	return cm.storeRawHTTPResponse(data, httpSettingsCacheFile)
+}
+
+func (cm *CacheManager) StoreRawKnownTestsCache(data json.RawMessage) error {
+	return cm.storeRawHTTPResponse(data, httpKnownTestsCacheFile)
+}
+
+func (cm *CacheManager) StoreRawSkippableTestsCache(data json.RawMessage) error {
+	return cm.storeRawHTTPResponse(data, httpSkippableTestsCacheFile)
+}
+
+func (cm *CacheManager) StoreRawTestManagementTestsCache(data json.RawMessage) error {
+	return cm.storeRawHTTPResponse(data, httpTestManagementCacheFile)
+}
+
 // StoreRepositorySettings stores repository settings in .testoptimization/cache/settings.json
 func (cm *CacheManager) StoreRepositorySettings(repositorySettings *net.SettingsResponseData) error {
 	if err := cm.CreateCacheDirectory(); err != nil {
 		return fmt.Errorf("failed to create cache directory: %w", err)
 	}
 
-	settingsPath := filepath.Join(appConstants.PlanDirectory, "cache", "settings.json")
+	settingsPath := filepath.Join(appConstants.CacheDir, "settings.json")
 	if err := cm.writeJSONToFile(repositorySettings, settingsPath); err != nil {
 		slog.Error("Failed to write repository settings to file", "error", err, "path", settingsPath)
 		return err
@@ -96,7 +152,7 @@ func (cm *CacheManager) StoreSkippableTestsCache(skippableTests map[string]map[s
 		SkippableTests: skippableTests,
 	}
 
-	skippableTestsPath := filepath.Join(appConstants.PlanDirectory, "cache", "skippable_tests.json")
+	skippableTestsPath := filepath.Join(appConstants.CacheDir, "skippable_tests.json")
 	if err := cm.writeJSONToFile(skippableTestsCache, skippableTestsPath); err != nil {
 		slog.Error("Failed to write skippable tests to file", "error", err, "path", skippableTestsPath)
 		return err
@@ -112,7 +168,7 @@ func (cm *CacheManager) StoreKnownTestsCache(knownTests *net.KnownTestsResponseD
 		return fmt.Errorf("failed to create cache directory: %w", err)
 	}
 
-	knownTestsPath := filepath.Join(appConstants.PlanDirectory, "cache", "known_tests.json")
+	knownTestsPath := filepath.Join(appConstants.CacheDir, "known_tests.json")
 	if err := cm.writeJSONToFile(knownTests, knownTestsPath); err != nil {
 		slog.Error("Failed to write known tests to file", "error", err, "path", knownTestsPath)
 		return err
@@ -128,7 +184,7 @@ func (cm *CacheManager) StoreTestManagementTestsCache(testManagementTests *net.T
 		return fmt.Errorf("failed to create cache directory: %w", err)
 	}
 
-	testManagementTestsPath := filepath.Join(appConstants.PlanDirectory, "cache", "test_management_tests.json")
+	testManagementTestsPath := filepath.Join(appConstants.CacheDir, "test_management_tests.json")
 	if err := cm.writeJSONToFile(testManagementTests, testManagementTestsPath); err != nil {
 		slog.Error("Failed to write test management tests to file", "error", err, "path", testManagementTestsPath)
 		return err
@@ -144,7 +200,7 @@ func (cm *CacheManager) StoreTestSuiteDurationsCache(cache any) error {
 		return fmt.Errorf("failed to create cache directory: %w", err)
 	}
 
-	testSuiteDurationsPath := filepath.Join(appConstants.PlanDirectory, "cache", TestSuiteDurationsCacheFile)
+	testSuiteDurationsPath := filepath.Join(appConstants.CacheDir, TestSuiteDurationsCacheFile)
 	if err := cm.writeJSONToFile(cache, testSuiteDurationsPath); err != nil {
 		slog.Error("Failed to write test suite durations to file", "error", err, "path", testSuiteDurationsPath)
 		return err
@@ -156,7 +212,7 @@ func (cm *CacheManager) StoreTestSuiteDurationsCache(cache any) error {
 
 // ReadTestSuiteDurationsCache reads test suite duration data from .testoptimization/cache/test_suite_durations.json
 func (cm *CacheManager) ReadTestSuiteDurationsCache(cache any) error {
-	testSuiteDurationsPath := filepath.Join(appConstants.PlanDirectory, "cache", TestSuiteDurationsCacheFile)
+	testSuiteDurationsPath := filepath.Join(appConstants.CacheDir, TestSuiteDurationsCacheFile)
 
 	if err := cm.readJSONFromFile(testSuiteDurationsPath, cache); err != nil {
 		return err

--- a/internal/testoptimization/cache.go
+++ b/internal/testoptimization/cache.go
@@ -46,6 +46,10 @@ func (cm *CacheManager) createHTTPCacheDirectory() error {
 	return os.MkdirAll(appConstants.HTTPCacheDir, 0755)
 }
 
+func (cm *CacheManager) createRunnerCacheDirectory() error {
+	return os.MkdirAll(appConstants.RunnerCacheDir, 0755)
+}
+
 // writeJSONToFile writes data as JSON to the specified file path
 func (cm *CacheManager) writeJSONToFile(data any, filePath string) error {
 	jsonData, err := json.MarshalIndent(data, "", "  ")
@@ -194,30 +198,29 @@ func (cm *CacheManager) StoreTestManagementTestsCache(testManagementTests *net.T
 	return nil
 }
 
-// StoreTestSuiteDurationsCache stores test suite duration data in .testoptimization/cache/test_suite_durations.json
+// StoreTestSuiteDurationsCache stores ddtest-private duration data in the runner cache.
 func (cm *CacheManager) StoreTestSuiteDurationsCache(cache any) error {
-	if err := cm.CreateCacheDirectory(); err != nil {
-		return fmt.Errorf("failed to create cache directory: %w", err)
+	if err := cm.createRunnerCacheDirectory(); err != nil {
+		return fmt.Errorf("failed to create runner cache directory: %w", err)
 	}
 
-	testSuiteDurationsPath := filepath.Join(appConstants.CacheDir, TestSuiteDurationsCacheFile)
-	if err := cm.writeJSONToFile(cache, testSuiteDurationsPath); err != nil {
-		slog.Error("Failed to write test suite durations to file", "error", err, "path", testSuiteDurationsPath)
+	runnerPath := filepath.Join(appConstants.RunnerCacheDir, TestSuiteDurationsCacheFile)
+	if err := cm.writeJSONToFile(cache, runnerPath); err != nil {
+		slog.Error("Failed to write test suite durations to file", "error", err, "path", runnerPath)
 		return err
 	}
 
-	slog.Debug("Test suite durations written to file", "path", testSuiteDurationsPath)
+	slog.Debug("Test suite durations written to file", "path", runnerPath)
 	return nil
 }
 
-// ReadTestSuiteDurationsCache reads test suite duration data from .testoptimization/cache/test_suite_durations.json
+// ReadTestSuiteDurationsCache reads ddtest-private duration data from the runner cache.
 func (cm *CacheManager) ReadTestSuiteDurationsCache(cache any) error {
-	testSuiteDurationsPath := filepath.Join(appConstants.CacheDir, TestSuiteDurationsCacheFile)
-
-	if err := cm.readJSONFromFile(testSuiteDurationsPath, cache); err != nil {
+	runnerPath := filepath.Join(appConstants.RunnerCacheDir, TestSuiteDurationsCacheFile)
+	if err := cm.readJSONFromFile(runnerPath, cache); err != nil {
 		return err
 	}
 
-	slog.Debug("Test suite durations read from file", "path", testSuiteDurationsPath)
+	slog.Debug("Test suite durations read from file", "path", runnerPath)
 	return nil
 }

--- a/internal/testoptimization/cache_test.go
+++ b/internal/testoptimization/cache_test.go
@@ -31,17 +31,12 @@ type testSuiteAggregateCacheFixture struct {
 	NumTestsSkipped   int     `json:"numTestsSkipped"`
 }
 
-func TestCacheManager_StoreAndReadTestSuiteDurationsCache(t *testing.T) {
-	tempDir := t.TempDir()
-	oldWd, _ := os.Getwd()
-	defer func() { _ = os.Chdir(oldWd) }()
-	_ = os.Chdir(tempDir)
-
-	cache := testSuiteDurationsCacheFixture{
+func newTestSuiteDurationsCacheFixture(sourceFile string, weight int) testSuiteDurationsCacheFixture {
+	return testSuiteDurationsCacheFixture{
 		TestSuiteDurations: map[string]map[string]TestSuiteDurationInfo{
 			"rspec": {
 				"Suite1": {
-					SourceFile: "spec/suite1_spec.rb",
+					SourceFile: sourceFile,
 					Duration:   DurationPercentiles{P50: "5000000000", P90: "7000000000"},
 				},
 			},
@@ -50,7 +45,7 @@ func TestCacheManager_StoreAndReadTestSuiteDurationsCache(t *testing.T) {
 			{
 				Module:            "rspec",
 				Suite:             "Suite1",
-				SourceFile:        "spec/suite1_spec.rb",
+				SourceFile:        sourceFile,
 				TotalDuration:     5000000000,
 				EstimatedDuration: 2500000000,
 				NumTests:          2,
@@ -58,21 +53,40 @@ func TestCacheManager_StoreAndReadTestSuiteDurationsCache(t *testing.T) {
 			},
 		},
 		SuitesBySourceFile: map[string][]testSuiteCacheKeyFixture{
-			"spec/suite1_spec.rb": {{Module: "rspec", Suite: "Suite1"}},
+			sourceFile: {{Module: "rspec", Suite: "Suite1"}},
 		},
 		TestFileWeights: map[string]int{
-			"spec/suite1_spec.rb": 2500,
+			sourceFile: weight,
 		},
 	}
+}
+
+func TestCacheManager_StoreAndReadTestSuiteDurationsCache(t *testing.T) {
+	tempDir := t.TempDir()
+	oldWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldWd) }()
+	_ = os.Chdir(tempDir)
+
+	cache := newTestSuiteDurationsCacheFixture("spec/suite1_spec.rb", 2500)
 
 	cacheManager := NewCacheManager()
 	if err := cacheManager.StoreTestSuiteDurationsCache(cache); err != nil {
 		t.Fatalf("StoreTestSuiteDurationsCache() should not return error, got: %v", err)
 	}
 
-	cachePath := filepath.Join(appConstants.PlanDirectory, "cache", TestSuiteDurationsCacheFile)
-	if _, err := os.Stat(cachePath); err != nil {
-		t.Fatalf("Expected test suite durations cache file to be written: %v", err)
+	runnerCachePath := filepath.Join(appConstants.RunnerCacheDir, TestSuiteDurationsCacheFile)
+	if _, err := os.Stat(runnerCachePath); err != nil {
+		t.Fatalf("Expected runner test suite durations cache file to be written: %v", err)
+	}
+
+	legacyCachePath := filepath.Join(appConstants.CacheDir, TestSuiteDurationsCacheFile)
+	if _, err := os.Stat(legacyCachePath); !os.IsNotExist(err) {
+		t.Fatalf("Expected test suite durations cache to stay out of legacy cache dir, got error: %v", err)
+	}
+
+	httpCachePath := filepath.Join(appConstants.HTTPCacheDir, TestSuiteDurationsCacheFile)
+	if _, err := os.Stat(httpCachePath); !os.IsNotExist(err) {
+		t.Fatalf("Expected test suite durations cache to stay out of cache/http, got error: %v", err)
 	}
 
 	var restored testSuiteDurationsCacheFixture
@@ -82,5 +96,28 @@ func TestCacheManager_StoreAndReadTestSuiteDurationsCache(t *testing.T) {
 
 	if !reflect.DeepEqual(restored, cache) {
 		t.Errorf("Expected restored cache to match stored cache.\nexpected: %v\nactual: %v", cache, restored)
+	}
+}
+
+func TestCacheManager_ReadTestSuiteDurationsCache_DoesNotReadLegacyCache(t *testing.T) {
+	tempDir := t.TempDir()
+	oldWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldWd) }()
+	_ = os.Chdir(tempDir)
+
+	cacheManager := NewCacheManager()
+	if err := cacheManager.CreateCacheDirectory(); err != nil {
+		t.Fatalf("CreateCacheDirectory() should not return error, got: %v", err)
+	}
+
+	legacyCache := newTestSuiteDurationsCacheFixture("spec/legacy_spec.rb", 1000)
+	legacyCachePath := filepath.Join(appConstants.CacheDir, TestSuiteDurationsCacheFile)
+	if err := cacheManager.writeJSONToFile(legacyCache, legacyCachePath); err != nil {
+		t.Fatalf("writeJSONToFile() should not return error for legacy cache, got: %v", err)
+	}
+
+	var restored testSuiteDurationsCacheFixture
+	if err := cacheManager.ReadTestSuiteDurationsCache(&restored); err == nil {
+		t.Fatal("ReadTestSuiteDurationsCache() should not read the legacy cache path")
 	}
 }

--- a/internal/testoptimization/client.go
+++ b/internal/testoptimization/client.go
@@ -1,6 +1,7 @@
 package testoptimization
 
 import (
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"time"
@@ -23,9 +24,13 @@ type CIVisibilityIntegrations interface {
 	EnsureCiVisibilityInitialization()
 	ExitCiVisibility()
 	GetSettings() *net.SettingsResponseData
+	GetSettingsRawResponse() json.RawMessage
 	GetSkippableTests() map[string]map[string][]net.SkippableResponseDataAttributes
+	GetSkippableTestsRawResponse() json.RawMessage
 	GetKnownTests() *net.KnownTestsResponseData
+	GetKnownTestsRawResponse() json.RawMessage
 	GetTestManagementTestsData() *net.TestManagementTestsResponseDataModules
+	GetTestManagementTestsRawResponse() json.RawMessage
 }
 
 type UtilsInterface interface {
@@ -47,16 +52,32 @@ func (d *DatadogCIVisibilityIntegrations) GetSettings() *net.SettingsResponseDat
 	return integrations.GetSettings()
 }
 
+func (d *DatadogCIVisibilityIntegrations) GetSettingsRawResponse() json.RawMessage {
+	return integrations.GetSettingsRawResponse()
+}
+
 func (d *DatadogCIVisibilityIntegrations) GetSkippableTests() map[string]map[string][]net.SkippableResponseDataAttributes {
 	return integrations.GetSkippableTests()
+}
+
+func (d *DatadogCIVisibilityIntegrations) GetSkippableTestsRawResponse() json.RawMessage {
+	return integrations.GetSkippableTestsRawResponse()
 }
 
 func (d *DatadogCIVisibilityIntegrations) GetKnownTests() *net.KnownTestsResponseData {
 	return integrations.GetKnownTests()
 }
 
+func (d *DatadogCIVisibilityIntegrations) GetKnownTestsRawResponse() json.RawMessage {
+	return integrations.GetKnownTestsRawResponse()
+}
+
 func (d *DatadogCIVisibilityIntegrations) GetTestManagementTestsData() *net.TestManagementTestsResponseDataModules {
 	return integrations.GetTestManagementTestsData()
+}
+
+func (d *DatadogCIVisibilityIntegrations) GetTestManagementTestsRawResponse() json.RawMessage {
+	return integrations.GetTestManagementTestsRawResponse()
 }
 
 // DatadogUtils implements UtilsInterface using the real utils package from dd-trace-go

--- a/internal/testoptimization/client.go
+++ b/internal/testoptimization/client.go
@@ -145,6 +145,9 @@ func (c *DatadogClient) GetSkippableTests() map[string]bool {
 	if err := c.cacheManager.StoreSkippableTestsCache(skippableTests); err != nil {
 		slog.Warn("Failed to store skippable tests cache", "error", err)
 	}
+	if err := c.cacheManager.StoreRawSkippableTestsCache(c.integrations.GetSkippableTestsRawResponse()); err != nil {
+		slog.Warn("Failed to store raw skippable tests cache", "error", err)
+	}
 
 	for _, suites := range skippableTests {
 		for _, tests := range suites {
@@ -176,6 +179,9 @@ func (c *DatadogClient) StoreCacheAndExit() {
 			slog.Warn("Failed to store repository settings", "error", err)
 		}
 	}
+	if err := c.cacheManager.StoreRawRepositorySettings(c.integrations.GetSettingsRawResponse()); err != nil {
+		slog.Warn("Failed to store raw repository settings cache", "error", err)
+	}
 
 	// store known tests
 	knownTests := c.integrations.GetKnownTests()
@@ -187,6 +193,9 @@ func (c *DatadogClient) StoreCacheAndExit() {
 			slog.Warn("Failed to store known tests cache", "error", err)
 		}
 	}
+	if err := c.cacheManager.StoreRawKnownTestsCache(c.integrations.GetKnownTestsRawResponse()); err != nil {
+		slog.Warn("Failed to store raw known tests cache", "error", err)
+	}
 
 	// store test management tests
 	testManagementTests := c.integrations.GetTestManagementTestsData()
@@ -197,6 +206,9 @@ func (c *DatadogClient) StoreCacheAndExit() {
 		if err := c.cacheManager.StoreTestManagementTestsCache(testManagementTests); err != nil {
 			slog.Warn("Failed to store test management tests cache", "error", err)
 		}
+	}
+	if err := c.cacheManager.StoreRawTestManagementTestsCache(c.integrations.GetTestManagementTestsRawResponse()); err != nil {
+		slog.Warn("Failed to store raw test management tests cache", "error", err)
 	}
 
 	c.integrations.ExitCiVisibility()

--- a/internal/testoptimization/client_test.go
+++ b/internal/testoptimization/client_test.go
@@ -88,6 +88,43 @@ func (m *MockUtils) AddCITagsMap(tags map[string]string) {
 	maps.Copy(m.AddedTags, tags)
 }
 
+func cleanPlanDirectory(t *testing.T) {
+	t.Helper()
+	if err := os.RemoveAll(constants.PlanDirectory); err != nil {
+		t.Fatalf("Failed to remove plan directory: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll(constants.PlanDirectory)
+	})
+}
+
+func assertFileExists(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("Expected file to exist at %s: %v", path, err)
+	}
+}
+
+func assertFileDoesNotExist(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("Expected file to not exist at %s, got error: %v", path, err)
+	}
+}
+
+func assertRawJSONFile(t *testing.T, path string, expected json.RawMessage) {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("Failed to read raw JSON file at %s: %v", path, err)
+	}
+
+	if string(data) != string(expected) {
+		t.Fatalf("Raw JSON file mismatch at %s\nexpected: %s\nactual:   %s", path, expected, data)
+	}
+}
+
 func TestNewDatadogClient(t *testing.T) {
 	client := NewDatadogClient()
 
@@ -297,6 +334,61 @@ func TestDatadogClient_StoreCacheAndExit_WritesSettingsFile(t *testing.T) {
 	}
 }
 
+func TestDatadogClient_StoreCacheAndExit_WritesRawHTTPCaches(t *testing.T) {
+	cleanPlanDirectory(t)
+
+	settingsRaw := json.RawMessage(`{"data":{"id":"settings","type":"ci_app_test_service_settings","attributes":{"itr_enabled":true}}}`)
+	knownTestsRaw := json.RawMessage(`{"data":{"id":"known-tests","type":"ci_app_libraries_tests","attributes":{"tests":{}}}}`)
+	testManagementRaw := json.RawMessage(`{"data":{"id":"test-management","type":"test_management_tests","attributes":{"modules":{}}}}`)
+
+	mockIntegrations := &MockCIVisibilityIntegrations{
+		Settings: &net.SettingsResponseData{
+			ItrEnabled:    true,
+			TestsSkipping: false,
+		},
+		SettingsRawResponse: settingsRaw,
+		KnownTests: &net.KnownTestsResponseData{
+			Tests: net.KnownTestsResponseDataModules{},
+		},
+		KnownTestsRawResponse: knownTestsRaw,
+		TestManagementTestsData: &net.TestManagementTestsResponseDataModules{
+			Modules: map[string]net.TestManagementTestsResponseDataSuites{},
+		},
+		TestManagementTestsRawResponse: testManagementRaw,
+	}
+	mockUtils := &MockUtils{}
+	client := NewDatadogClientWithDependencies(mockIntegrations, mockUtils)
+
+	client.StoreCacheAndExit()
+
+	assertFileExists(t, filepath.Join(constants.CacheDir, "settings.json"))
+	assertFileExists(t, filepath.Join(constants.CacheDir, "known_tests.json"))
+	assertFileExists(t, filepath.Join(constants.CacheDir, "test_management_tests.json"))
+
+	assertRawJSONFile(t, filepath.Join(constants.HTTPCacheDir, "settings.json"), settingsRaw)
+	assertRawJSONFile(t, filepath.Join(constants.HTTPCacheDir, "known_tests.json"), knownTestsRaw)
+	assertRawJSONFile(t, filepath.Join(constants.HTTPCacheDir, "test_management.json"), testManagementRaw)
+}
+
+func TestDatadogClient_StoreCacheAndExit_SkipsRawHTTPCacheWithoutRawResponse(t *testing.T) {
+	cleanPlanDirectory(t)
+
+	mockIntegrations := &MockCIVisibilityIntegrations{
+		Settings: &net.SettingsResponseData{
+			ItrEnabled:    true,
+			TestsSkipping: false,
+		},
+	}
+	mockUtils := &MockUtils{}
+	client := NewDatadogClientWithDependencies(mockIntegrations, mockUtils)
+
+	client.StoreCacheAndExit()
+
+	assertFileExists(t, filepath.Join(constants.CacheDir, "settings.json"))
+	assertFileDoesNotExist(t, filepath.Join(constants.HTTPCacheDir, "settings.json"))
+	assertFileDoesNotExist(t, constants.HTTPCacheDir)
+}
+
 func TestTest_FQN(t *testing.T) {
 	testCases := []struct {
 		suite      string
@@ -454,7 +546,6 @@ func TestDatadogClient_StoreCacheAndExit_WritesKnownTestsFile(t *testing.T) {
 }
 
 func TestDatadogClient_GetSkippableTests_WritesSkippableTestsFile(t *testing.T) {
-
 	mockIntegrations := &MockCIVisibilityIntegrations{
 		Settings: &net.SettingsResponseData{
 			ItrEnabled:    true,
@@ -540,6 +631,46 @@ func TestDatadogClient_GetSkippableTests_WritesSkippableTestsFile(t *testing.T) 
 	if actualTest.Parameters != expectedTest.Parameters {
 		t.Errorf("Expected parameters to be %s, got %s", expectedTest.Parameters, actualTest.Parameters)
 	}
+}
+
+func TestDatadogClient_GetSkippableTests_WritesRawHTTPCache(t *testing.T) {
+	cleanPlanDirectory(t)
+
+	skippableTestsRaw := json.RawMessage(`{"data":[{"id":"test-id","type":"test","attributes":{"suite":"TestSuite1","name":"test_method_1"}}]}`)
+
+	mockIntegrations := &MockCIVisibilityIntegrations{
+		Settings: &net.SettingsResponseData{
+			ItrEnabled:    true,
+			TestsSkipping: true,
+		},
+		SkippableTests: map[string]map[string][]net.SkippableResponseDataAttributes{
+			"module1": {
+				"suite1": []net.SkippableResponseDataAttributes{
+					{
+						Suite:      "TestSuite1",
+						Name:       "test_method_1",
+						Parameters: "param1",
+					},
+				},
+			},
+		},
+		SkippableTestsRawResponse: skippableTestsRaw,
+	}
+	mockUtils := &MockUtils{}
+	client := NewDatadogClientWithDependencies(mockIntegrations, mockUtils)
+
+	err := client.Initialize(map[string]string{})
+	if err != nil {
+		t.Fatalf("Initialize() failed: %v", err)
+	}
+
+	result := client.GetSkippableTests()
+
+	if len(result) != 1 {
+		t.Fatalf("Expected 1 skippable test, got %d", len(result))
+	}
+	assertFileExists(t, filepath.Join(constants.CacheDir, "skippable_tests.json"))
+	assertRawJSONFile(t, filepath.Join(constants.HTTPCacheDir, "skippable_tests.json"), skippableTestsRaw)
 }
 
 func TestDatadogClient_StoreCacheAndExit_WritesTestManagementTestsFile(t *testing.T) {

--- a/internal/testoptimization/client_test.go
+++ b/internal/testoptimization/client_test.go
@@ -25,12 +25,16 @@ func TestMain(m *testing.M) {
 
 // Mock implementations for testing
 type MockCIVisibilityIntegrations struct {
-	InitializationCalled    bool
-	ShutdownCalled          bool
-	Settings                *net.SettingsResponseData
-	SkippableTests          map[string]map[string][]net.SkippableResponseDataAttributes
-	KnownTests              *net.KnownTestsResponseData
-	TestManagementTestsData *net.TestManagementTestsResponseDataModules
+	InitializationCalled           bool
+	ShutdownCalled                 bool
+	Settings                       *net.SettingsResponseData
+	SettingsRawResponse            json.RawMessage
+	SkippableTests                 map[string]map[string][]net.SkippableResponseDataAttributes
+	SkippableTestsRawResponse      json.RawMessage
+	KnownTests                     *net.KnownTestsResponseData
+	KnownTestsRawResponse          json.RawMessage
+	TestManagementTestsData        *net.TestManagementTestsResponseDataModules
+	TestManagementTestsRawResponse json.RawMessage
 }
 
 func (m *MockCIVisibilityIntegrations) EnsureCiVisibilityInitialization() {
@@ -45,16 +49,32 @@ func (m *MockCIVisibilityIntegrations) GetSettings() *net.SettingsResponseData {
 	return m.Settings
 }
 
+func (m *MockCIVisibilityIntegrations) GetSettingsRawResponse() json.RawMessage {
+	return m.SettingsRawResponse
+}
+
 func (m *MockCIVisibilityIntegrations) GetSkippableTests() map[string]map[string][]net.SkippableResponseDataAttributes {
 	return m.SkippableTests
+}
+
+func (m *MockCIVisibilityIntegrations) GetSkippableTestsRawResponse() json.RawMessage {
+	return m.SkippableTestsRawResponse
 }
 
 func (m *MockCIVisibilityIntegrations) GetKnownTests() *net.KnownTestsResponseData {
 	return m.KnownTests
 }
 
+func (m *MockCIVisibilityIntegrations) GetKnownTestsRawResponse() json.RawMessage {
+	return m.KnownTestsRawResponse
+}
+
 func (m *MockCIVisibilityIntegrations) GetTestManagementTestsData() *net.TestManagementTestsResponseDataModules {
 	return m.TestManagementTestsData
+}
+
+func (m *MockCIVisibilityIntegrations) GetTestManagementTestsRawResponse() json.RawMessage {
+	return m.TestManagementTestsRawResponse
 }
 
 type MockUtils struct {


### PR DESCRIPTION
## What

Implement the unified `.testoptimization` layout for DDTest:

- Write a plan manifest at `.testoptimization/manifest.txt`.
- Write DDTest runner artifacts under `.testoptimization/runner/*`.
- Keep pre-1.0 write-only compatibility for legacy root runner artifacts:
  - `.testoptimization/test-files.txt`
  - `.testoptimization/parallel-runners.txt`
  - `.testoptimization/skippable-percentage.txt`
  - `.testoptimization/tests-split/runner-*`
- Keep DDTest reads pointed at the new `.testoptimization/runner/*` paths.
- Capture raw backend responses and write backend-shaped cache files under `.testoptimization/cache/http/*`.
- Keep Ruby library compatibility cache writes under `.testoptimization/cache/*`.
- Move DDTest-private duration cache under `.testoptimization/runner/cache/*`.
- Set `TEST_OPTIMIZATION_MANIFEST_FILE` for worker processes unless already provided.
- Add a DDTest 1.0 upgrade guide and update README examples to use the runner layout.

## Why

This separates runner-private DDTest files from library-facing cache data while preserving compatibility for existing customers that may read legacy root runner files today. The new `cache/http` files preserve backend response envelopes exactly instead of reconstructing them after parsing, which keeps future consumers aligned with backend API shape.

For DDTest 1.0, the goal is to remove the dual runner artifact writes. Customers should upgrade the Datadog Ruby library to `1.31+` and move CI/custom integrations to the new `.testoptimization/runner/*` locations before then.

## E2E testing

1. In a Ruby test repository with Datadog Test Optimization configured, run:

   ```bash
   ddtest plan --platform ruby --framework rspec
   ```

2. Verify the new layout files are written:

   - `.testoptimization/manifest.txt`
   - `.testoptimization/runner/test-files.txt`
   - `.testoptimization/runner/parallel-runners.txt`
   - `.testoptimization/runner/skippable-percentage.txt`
   - `.testoptimization/runner/tests-split/runner-*`
   - `.testoptimization/runner/cache/test_suite_durations.json`
   - `.testoptimization/cache/http/settings.json`
   - `.testoptimization/cache/http/known_tests.json`
   - `.testoptimization/cache/http/skippable_tests.json`
   - `.testoptimization/cache/http/test_management.json`

3. Validate the format and content of the new files:

   - `manifest.txt` contains exactly `1`.
   - `runner/test-files.txt` is a newline-delimited list of non-skipped test files.
   - `runner/parallel-runners.txt` contains a positive integer.
   - `runner/skippable-percentage.txt` contains a decimal percentage value.
   - each `runner/tests-split/runner-*` file is a newline-delimited list of test files.
   - `runner/cache/test_suite_durations.json` is valid JSON with DDTest-private duration cache data.
   - each `cache/http/*.json` file is valid JSON matching the raw backend response envelope for that endpoint.

4. Verify pre-1.0 compatibility writes still exist for customers that scrape legacy runner files:

   - `.testoptimization/test-files.txt`
   - `.testoptimization/parallel-runners.txt`
   - `.testoptimization/skippable-percentage.txt`
   - `.testoptimization/tests-split/runner-*`

5. Validate the format and content of the legacy files and compare them with the new runner files:

   ```bash
   diff .testoptimization/test-files.txt .testoptimization/runner/test-files.txt
   diff .testoptimization/parallel-runners.txt .testoptimization/runner/parallel-runners.txt
   diff .testoptimization/skippable-percentage.txt .testoptimization/runner/skippable-percentage.txt
   diff .testoptimization/tests-split/runner-0 .testoptimization/runner/tests-split/runner-0
   ```

6. Share `.testoptimization/` to a CI test node and run:

   ```bash
   DD_TEST_OPTIMIZATION_RUNNER_CI_NODE=0 ddtest run --platform ruby --framework rspec
   ```

7. Confirm `ddtest run` reads from the new runner files by temporarily removing or renaming only the legacy runner files and rerunning the same command. The run should still use `.testoptimization/runner/*` successfully.

8. Confirm workers receive `TEST_OPTIMIZATION_MANIFEST_FILE` pointing to the absolute `.testoptimization/manifest.txt` path, unless the env var is explicitly provided.

9. Confirm `DD_TEST_OPTIMIZATION_PAYLOADS_IN_FILES` is not set by normal `ddtest run` execution.

Validation run locally:

- `go test ./internal/runner`
- `make test`
- `make lint`
