### PR TITLE
Preserve coverage_report_upload_enabled in cached settings

### DIFF
--- a/civisibility/utils/net/settings_api.go
+++ b/civisibility/utils/net/settings_api.go
@@ -65,7 +65,8 @@ type (
 			Enabled             bool `json:"enabled"`
 			AttemptToFixRetries int  `json:"attempt_to_fix_retries"`
 		} `json:"test_management"`
-		SubtestFeaturesEnabled bool `json:"-"`
+		CoverageReportUploadEnabled bool `json:"coverage_report_upload_enabled"`
+		SubtestFeaturesEnabled      bool `json:"-"`
 	}
 )
 

--- a/civisibility/utils/net/settings_api_test.go
+++ b/civisibility/utils/net/settings_api_test.go
@@ -1,0 +1,39 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+package net
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestSettingsResponseDataPreservesCoverageReportUploadEnabled verifies that
+// coverage_report_upload_enabled returned by the settings API is preserved
+// through the SettingsResponseData round-trip. Without a matching struct
+// field, encoding/json would silently drop the key when ddtest re-serializes
+// the settings into its cache file, disabling coverage upload in downstream
+// consumers such as datadog-ci.
+func TestSettingsResponseDataPreservesCoverageReportUploadEnabled(t *testing.T) {
+	payload := `{"data":{"id":"settings-id","type":"ci_app_test_service_libraries_settings","attributes":{"itr_enabled":true,"tests_skipping":true,"coverage_report_upload_enabled":true}}}`
+
+	var resp settingsResponse
+	if err := json.Unmarshal([]byte(payload), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if !resp.Data.Attributes.CoverageReportUploadEnabled {
+		t.Fatalf("CoverageReportUploadEnabled = false; want true after unmarshalling %q", payload)
+	}
+
+	out, err := json.Marshal(resp.Data.Attributes)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(out), `"coverage_report_upload_enabled":true`) {
+		t.Fatalf("marshalled JSON does not preserve coverage_report_upload_enabled=true: %s", out)
+	}
+}


### PR DESCRIPTION
Closes #67.

## Problem

`SettingsResponseData` in `civisibility/utils/net/settings_api.go` did not declare a field for `coverage_report_upload_enabled`. Since Go's `encoding/json` only marshals declared struct fields, the value returned by the Datadog settings API was dropped when `ddtest` re-serialized the response into `.testoptimization/cache/settings.json`.

The Ruby `datadog-ci` gem then read the cache, did not find the key, and defaulted it to `false` — silently disabling Code Coverage report upload. There was no error or warning; coverage simply stopped being uploaded.

For reference, in `datadog-ci` v1.28.0:

- `lib/datadog/ci/remote/library_settings.rb` reads the key with `payload.fetch("coverage_report_upload_enabled", false)`.
- `lib/datadog/ci/code_coverage/component.rb` gates upload on the resulting value.

See #67 for full repro details and the workaround we currently rely on (a `jq` patch of the cache file between `plan` and `run`).

## Change

Add the field with the matching `json` tag so the value round-trips through `ddtest` and reaches downstream consumers unchanged:

```go
CoverageReportUploadEnabled bool `json:"coverage_report_upload_enabled"`
```

Placed alongside the other API-derived bool fields, just before the Go-internal `SubtestFeaturesEnabled` field (which uses `json:"-"`).

Also adds `civisibility/utils/net/settings_api_test.go` with a round-trip test that asserts the key is preserved through both `json.Unmarshal` and `json.Marshal`. Without the struct field, this test fails — with it, it passes.

## Verification

- `gofmt -d` reports no diff.
- `go build ./...` and `go vet ./...` pass.
- `go test ./civisibility/utils/net/...` passes, including the new `TestSettingsResponseDataPreservesCoverageReportUploadEnabled`.
- After this change, downstream consumers (`datadog-ci`) see the key in the cached settings without the workaround.