### PR TITLE
Downgrade cancelled test discovery log from WARN to DEBUG

### DIFF
--- a/internal/framework/framework.go
+++ b/internal/framework/framework.go
@@ -40,7 +40,11 @@ func executeDiscoveryCommand(ctx context.Context, executor ext.CommandExecutor, 
 
 	output, err := executor.CombinedOutput(ctx, name, args, envMap)
 	if err != nil {
-		slog.Warn("Failed to run test discovery", "framework", frameworkName, "output", string(output), "error", err)
+		if ctx.Err() != nil {
+			slog.Debug("Test discovery was cancelled", "framework", frameworkName)
+		} else {
+			slog.Warn("Failed to run test discovery", "framework", frameworkName, "output", string(output), "error", err)
+		}
 		return nil, err
 	}
 

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -324,7 +324,11 @@ func (tp *TestPlanner) PreparePlanningData(ctx context.Context) error {
 		res, discErr := framework.DiscoverTests(discoveryCtx)
 		if discErr != nil {
 			fullDiscoveryErr = discErr
-			slog.Warn("Full test discovery failed or was cancelled", "error", discErr)
+			if discoveryCtx.Err() != nil {
+				slog.Debug("Full test discovery was cancelled")
+			} else {
+				slog.Warn("Full test discovery failed", "error", discErr)
+			}
 			return nil // Don't fail the entire process, we have fast discovery as fallback
 		}
 		if len(res) == 0 {


### PR DESCRIPTION
## What

When full test discovery is intentionally cancelled (TIA disabled, or the Datadog API returns 0 skippable tests), the killed subprocess now logs at DEBUG instead of WARN. Unexpected subprocess failures still log at WARN.

## Why

During `ddtest plan`, two goroutines race:
- **Goroutine 1** fetches TIA settings from the Datadog API, then calls `cancelDiscovery()` if full discovery is not needed
- **Goroutine 2** runs the framework's full test discovery (`pytest --collect-only`, `rspec --dry-run`, etc.) under a cancellable context

When Goroutine 1 wins and cancels the context, `exec.CommandContext` sends SIGKILL to the subprocess. It exits with `signal: killed` — a non-zero exit code — which previously triggered unconditional `WARN` logs at both call sites. This implied something had gone wrong, when in fact the kill was deliberate.

The fix checks `ctx.Err() != nil` to distinguish the two cases. `errors.Is(err, context.Canceled)` is not usable here: `exec.CommandContext` only wraps `ctx.Err()` into the returned error when `cmd.WaitDelay` is set; without it the error is a plain `*exec.ExitError` with no reference to the context.

## E2E testing

Run `ddtest plan --platform python --framework pytest` (or ruby/rspec) on a repo where the Datadog API returns 0 skippable tests (e.g. first run). Previously produced:
```
WARN Failed to run test discovery framework=pytest output="" error="signal: killed"
WARN Full test discovery failed or was cancelled error="signal: killed"
```
After this change those lines are gone from WARN-level output entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)