### PR TITLE
Truncate discovery command log

### DIFF
--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -12,6 +12,7 @@ import (
 	"path"
 	"path/filepath"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/DataDog/ddtest/internal/constants"
@@ -23,7 +24,11 @@ import (
 
 var TestsFilePath = filepath.Join(".", constants.PlanDirectory, "tests-discovery/tests.json")
 
-const MaxExplicitTestFiles = 8_000
+const (
+	MaxExplicitTestFiles           = 8_000
+	discoveryCommandLogMaxLength   = 300
+	discoveryCommandLogTruncSuffix = "..."
+)
 
 type Excluder struct {
 	pattern string
@@ -179,7 +184,7 @@ func DiscoverTests(
 	maps.Copy(discoveryEnv, envMap)
 	maps.Copy(discoveryEnv, BaseEnv())
 
-	slog.Info("Discovering tests with command", "command", executable, "args", args)
+	slog.Info("Discovering tests with command", "command", discoveryCommandLogValue(executable, args))
 	if err := executeCommand(ctx, executor, executable, args, discoveryEnv); err != nil {
 		return nil, err
 	}
@@ -192,6 +197,19 @@ func DiscoverTests(
 
 	slog.Debug("Parsed test discovery report", "tests", len(tests))
 	return tests, nil
+}
+
+func discoveryCommandLogValue(executable string, args []string) string {
+	parts := make([]string, 0, len(args)+1)
+	parts = append(parts, executable)
+	parts = append(parts, args...)
+
+	command := strings.Join(parts, " ")
+	if len(command) <= discoveryCommandLogMaxLength {
+		return command
+	}
+
+	return command[:discoveryCommandLogMaxLength-len(discoveryCommandLogTruncSuffix)] + discoveryCommandLogTruncSuffix
 }
 
 func executeCommand(ctx context.Context, executor ext.CommandExecutor, executable string, args []string, envMap map[string]string) error {

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -131,6 +131,45 @@ func TestDiscoverTestFilesWithInvalidExcludePattern(t *testing.T) {
 	}
 }
 
+func TestDiscoverTestsLogsTruncatedCommand(t *testing.T) {
+	logs := captureDiscoveryLogs(t)
+	root := t.TempDir()
+	t.Chdir(root)
+
+	if err := os.MkdirAll(filepath.Dir(TestsFilePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(TestsFilePath, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	longArg := strings.Repeat("a", discoveryCommandLogMaxLength)
+	args := []string{"exec", "rspec", "spec/example_spec.rb", longArg}
+	_, err := DiscoverTests(context.Background(), successfulDiscoveryExecutor{}, "bundle", args, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	loggedCommand := discoveryCommandLogValue("bundle", args)
+	if len(loggedCommand) != discoveryCommandLogMaxLength {
+		t.Fatalf("expected logged command to be %d characters, got %d", discoveryCommandLogMaxLength, len(loggedCommand))
+	}
+	if !strings.HasSuffix(loggedCommand, discoveryCommandLogTruncSuffix) {
+		t.Fatalf("expected logged command to have truncation suffix, got %q", loggedCommand)
+	}
+
+	output := logs.String()
+	if !strings.Contains(output, "Discovering tests with command") || !strings.Contains(output, loggedCommand) {
+		t.Fatalf("expected discovery command to be logged, got: %s", output)
+	}
+	if strings.Contains(output, "args=") {
+		t.Fatalf("expected discovery args not to be logged separately, got: %s", output)
+	}
+	if strings.Contains(output, longArg) {
+		t.Fatalf("expected full long arg not to appear in logs, got: %s", output)
+	}
+}
+
 func TestExecuteCommandLogsCancelledDiscoveryAtDebug(t *testing.T) {
 	logs := captureDiscoveryLogs(t)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -264,6 +303,16 @@ func createDiscoveryFixture(tb testing.TB) string {
 type failingDiscoveryExecutor struct {
 	output []byte
 	err    error
+}
+
+type successfulDiscoveryExecutor struct{}
+
+func (successfulDiscoveryExecutor) CombinedOutput(context.Context, string, []string, map[string]string) ([]byte, error) {
+	return nil, nil
+}
+
+func (successfulDiscoveryExecutor) Run(context.Context, string, []string, map[string]string) error {
+	return nil
 }
 
 func (e failingDiscoveryExecutor) CombinedOutput(context.Context, string, []string, map[string]string) ([]byte, error) {


### PR DESCRIPTION
## What

Truncate the test discovery command log value to 300 characters and log it as a single `command` field.

## Why

When test discovery receives many explicit files, the logged argument list can become very long and noisy. Capping the logged command keeps the discovery log readable without changing the command that is actually executed.

## E2E testing

Run `ddtest plan` in a project where the test discovery exclude pattern leaves many explicit test files, then verify the `Discovering tests with command` log line is capped at 300 characters and discovery still completes.

Validation run:

- `go test ./internal/discovery`
- `make test`
- `make lint`