### PR TITLE
feat: Add JS/Jest basic support

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -24,6 +24,7 @@ var HTTPCacheDir = filepath.Join(PlanDirectory, "cache", "http")
 
 // Platform specific output file paths
 var RubyEnvOutputPath = filepath.Join(PlanDirectory, "ruby_env.json")
+var JavaScriptEnvOutputPath = filepath.Join(PlanDirectory, "javascript_env.json")
 
 // Executor constants
 const (

--- a/internal/framework/framework.go
+++ b/internal/framework/framework.go
@@ -3,6 +3,7 @@ package framework
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -24,6 +25,20 @@ type Framework interface {
 	RunTests(ctx context.Context, testFiles []string, envMap map[string]string) error
 	SetPlatformEnv(platformEnv map[string]string)
 	GetPlatformEnv() map[string]string
+}
+
+var ErrFullTestDiscoveryUnsupported = errors.New("full test discovery is not supported")
+
+type FullTestDiscoverySupporter interface {
+	SupportsFullTestDiscovery() bool
+}
+
+// Asumme, by default, that every framework supports full test discovery.
+// If it implements the FullTestDiscoverySupporter interface, then
+// delegate the choice to SupportFullTestDiscovery()
+func SupportsFullTestDiscovery(f Framework) bool {
+	supporter, ok := f.(FullTestDiscoverySupporter)
+	return !ok || supporter.SupportsFullTestDiscovery()
 }
 
 // cleanupDiscoveryFile removes the discovery file, ignoring "not exists" errors

--- a/internal/framework/jest.go
+++ b/internal/framework/jest.go
@@ -1,0 +1,151 @@
+package framework
+
+import (
+	"context"
+	"log/slog"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/DataDog/ddtest/internal/ext"
+	"github.com/DataDog/ddtest/internal/settings"
+	"github.com/DataDog/ddtest/internal/testoptimization"
+)
+
+const binJestPath = "node_modules/.bin/jest"
+
+var (
+	jestTestFileExtensions = []string{"js", "jsx", "ts", "tsx", "mjs", "cjs"}
+	jestExcludedDirs       = map[string]struct{}{
+		"node_modules": {},
+		".git":         {},
+		"dist":         {},
+		"build":        {},
+		"coverage":     {},
+		".next":        {},
+	}
+)
+
+type Jest struct {
+	executor        ext.CommandExecutor
+	commandOverride []string
+	platformEnv     map[string]string
+}
+
+func NewJest() *Jest {
+	return &Jest{
+		executor:        &ext.DefaultCommandExecutor{},
+		commandOverride: loadCommandOverride(),
+		platformEnv:     make(map[string]string),
+	}
+}
+
+func (j *Jest) SetPlatformEnv(platformEnv map[string]string) {
+	j.platformEnv = platformEnv
+}
+
+func (j *Jest) GetPlatformEnv() map[string]string {
+	return j.platformEnv
+}
+
+func (j *Jest) Name() string {
+	return "jest"
+}
+
+// Makes it a FullTestDiscoverySupporter.
+// We will not be discovering tests, but test suites.
+// We'll be working outside of the Node.js process
+func (j *Jest) SupportsFullTestDiscovery() bool {
+	return false
+}
+
+func (j *Jest) DiscoverTests(ctx context.Context) ([]testoptimization.Test, error) {
+	return nil, ErrFullTestDiscoveryUnsupported
+}
+
+func (j *Jest) DiscoverTestFiles() ([]string, error) {
+	var patterns []string
+	if custom := settings.GetTestsLocation(); custom != "" {
+		patterns = []string{custom}
+	} else {
+		patterns = defaultJestTestPatterns()
+	}
+
+	// Simple glob search, taking into consideration
+	// excluded Jest test files
+	filesByPath := make(map[string]struct{})
+	for _, pattern := range patterns {
+		matches, err := globTestFiles(pattern)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, match := range matches {
+			if isJestExcludedPath(match) {
+				continue
+			}
+			filesByPath[filepath.ToSlash(match)] = struct{}{}
+		}
+	}
+
+	testFiles := make([]string, 0, len(filesByPath))
+	for testFile := range filesByPath {
+		testFiles = append(testFiles, testFile)
+	}
+	slices.Sort(testFiles)
+
+	slog.Debug("Discovered Jest test files", "count", len(testFiles))
+	return testFiles, nil
+}
+
+func (j *Jest) RunTests(ctx context.Context, testFiles []string, envMap map[string]string) error {
+	command, baseArgs := j.getJestCommand()
+	args := slices.Clone(baseArgs)
+	args = append(args, "--runTestsByPath")
+	args = append(args, testFiles...)
+
+	slog.Info("Running tests with command", "command", command, "args", args)
+
+	mergedEnv := make(map[string]string)
+	maps.Copy(mergedEnv, j.platformEnv)
+	maps.Copy(mergedEnv, envMap)
+	return j.executor.Run(ctx, command, args, mergedEnv)
+}
+
+// Decide between user custom command, local jest binary and npx jest
+func (j *Jest) getJestCommand() (string, []string) {
+	if len(j.commandOverride) > 0 {
+		return j.commandOverride[0], j.commandOverride[1:]
+	}
+
+	if info, err := os.Stat(binJestPath); err == nil && !info.IsDir() && info.Mode()&0111 != 0 {
+		slog.Debug("Using local Jest binary")
+		return binJestPath, []string{}
+	}
+
+	slog.Debug("Using npx jest for Jest commands")
+	return "npx", []string{"jest"}
+}
+
+func defaultJestTestPatterns() []string {
+	patterns := make([]string, 0, len(jestTestFileExtensions)*3)
+	for _, extension := range jestTestFileExtensions {
+		patterns = append(patterns,
+			filepath.Join("**", "__tests__", "**", "*."+extension),
+			filepath.Join("**", "*.spec."+extension),
+			filepath.Join("**", "*.test."+extension),
+		)
+	}
+	return patterns
+}
+
+func isJestExcludedPath(path string) bool {
+	for _, part := range strings.Split(filepath.ToSlash(path), "/") {
+		if _, ok := jestExcludedDirs[part]; ok {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/framework/jest_test.go
+++ b/internal/framework/jest_test.go
@@ -1,0 +1,224 @@
+package framework
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+func TestNewJest(t *testing.T) {
+	jest := NewJest()
+	if jest == nil {
+		t.Fatal("NewJest() returned nil")
+	}
+	if jest.executor == nil {
+		t.Error("NewJest() created Jest with nil executor")
+	}
+}
+
+func TestJest_Name(t *testing.T) {
+	jest := NewJest()
+	if jest.Name() != "jest" {
+		t.Errorf("expected %q, got %q", "jest", jest.Name())
+	}
+}
+
+func TestJest_DiscoverTests_Unsupported(t *testing.T) {
+	jest := NewJest()
+	tests, err := jest.DiscoverTests(context.Background())
+
+	if tests != nil {
+		t.Errorf("expected nil tests, got %v", tests)
+	}
+	if !errors.Is(err, ErrFullTestDiscoveryUnsupported) {
+		t.Fatalf("expected ErrFullTestDiscoveryUnsupported, got %v", err)
+	}
+	if SupportsFullTestDiscovery(jest) {
+		t.Error("expected Jest to report unsupported full test discovery")
+	}
+}
+
+func TestJest_DiscoverTestFiles_DefaultPatterns(t *testing.T) {
+	tempDir := t.TempDir()
+	oldWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldWd) }()
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+
+	filesToCreate := []string{
+		"src/foo.test.js",
+		"src/foo.spec.ts",
+		"src/__tests__/bar.jsx",
+		"src/not-test.js",
+		"node_modules/pkg/bad.test.js",
+		"dist/bad.spec.js",
+		"coverage/bad.test.ts",
+	}
+	for _, file := range filesToCreate {
+		if err := os.MkdirAll(filepath.Dir(file), 0755); err != nil {
+			t.Fatalf("failed to create dir for %s: %v", file, err)
+		}
+		if err := os.WriteFile(file, []byte("test"), 0644); err != nil {
+			t.Fatalf("failed to create %s: %v", file, err)
+		}
+	}
+
+	jest := NewJest()
+	files, err := jest.DiscoverTestFiles()
+	if err != nil {
+		t.Fatalf("DiscoverTestFiles failed: %v", err)
+	}
+
+	expected := []string{
+		"src/__tests__/bar.jsx",
+		"src/foo.spec.ts",
+		"src/foo.test.js",
+	}
+	if !slices.Equal(files, expected) {
+		t.Errorf("expected files %v, got %v", expected, files)
+	}
+}
+
+func TestJest_DiscoverTestFiles_WithTestsLocation(t *testing.T) {
+	tempDir := t.TempDir()
+	oldWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldWd) }()
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+
+	for _, file := range []string{"custom/a.check.js", "custom/b.check.js", "src/c.test.js"} {
+		if err := os.MkdirAll(filepath.Dir(file), 0755); err != nil {
+			t.Fatalf("failed to create dir for %s: %v", file, err)
+		}
+		if err := os.WriteFile(file, []byte("test"), 0644); err != nil {
+			t.Fatalf("failed to create %s: %v", file, err)
+		}
+	}
+
+	setTestsLocation(t, "custom/*.check.js")
+
+	jest := NewJest()
+	files, err := jest.DiscoverTestFiles()
+	if err != nil {
+		t.Fatalf("DiscoverTestFiles failed: %v", err)
+	}
+
+	expected := []string{"custom/a.check.js", "custom/b.check.js"}
+	if !slices.Equal(files, expected) {
+		t.Errorf("expected files %v, got %v", expected, files)
+	}
+}
+
+func TestJest_RunTests_UsesLocalJestBinary(t *testing.T) {
+	tempDir := t.TempDir()
+	oldWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldWd) }()
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(binJestPath), 0755); err != nil {
+		t.Fatalf("failed to create jest bin dir: %v", err)
+	}
+	if err := os.WriteFile(binJestPath, []byte("#!/usr/bin/env node\n"), 0755); err != nil {
+		t.Fatalf("failed to create jest bin: %v", err)
+	}
+
+	var capturedName string
+	var capturedArgs []string
+	mockExecutor := &mockCommandExecutor{
+		onExecution: func(name string, args []string) {
+			capturedName = name
+			capturedArgs = slices.Clone(args)
+		},
+	}
+	jest := &Jest{
+		executor:    mockExecutor,
+		platformEnv: map[string]string{"NODE_OPTIONS": "-r dd-trace/ci/init", "SHARED": "platform"},
+	}
+
+	err := jest.RunTests(context.Background(), []string{"src/a.test.js", "src/b.test.ts"}, map[string]string{"SHARED": "worker", "DD_ENV": "ci"})
+	if err != nil {
+		t.Fatalf("RunTests failed: %v", err)
+	}
+
+	if capturedName != binJestPath {
+		t.Errorf("expected command %q, got %q", binJestPath, capturedName)
+	}
+	expectedArgs := []string{"--runTestsByPath", "src/a.test.js", "src/b.test.ts"}
+	if !slices.Equal(capturedArgs, expectedArgs) {
+		t.Errorf("expected args %v, got %v", expectedArgs, capturedArgs)
+	}
+	if mockExecutor.capturedEnvMap["NODE_OPTIONS"] != "-r dd-trace/ci/init" {
+		t.Errorf("expected NODE_OPTIONS from platform env, got %q", mockExecutor.capturedEnvMap["NODE_OPTIONS"])
+	}
+	if mockExecutor.capturedEnvMap["SHARED"] != "worker" {
+		t.Errorf("expected worker env to override platform env, got %q", mockExecutor.capturedEnvMap["SHARED"])
+	}
+	if mockExecutor.capturedEnvMap["DD_ENV"] != "ci" {
+		t.Errorf("expected worker env DD_ENV, got %q", mockExecutor.capturedEnvMap["DD_ENV"])
+	}
+}
+
+func TestJest_RunTests_UsesNpxFallback(t *testing.T) {
+	tempDir := t.TempDir()
+	oldWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldWd) }()
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+
+	var capturedName string
+	var capturedArgs []string
+	mockExecutor := &mockCommandExecutor{
+		onExecution: func(name string, args []string) {
+			capturedName = name
+			capturedArgs = slices.Clone(args)
+		},
+	}
+	jest := &Jest{executor: mockExecutor, platformEnv: make(map[string]string)}
+
+	if err := jest.RunTests(context.Background(), []string{"src/a.test.js"}, nil); err != nil {
+		t.Fatalf("RunTests failed: %v", err)
+	}
+
+	if capturedName != "npx" {
+		t.Errorf("expected command %q, got %q", "npx", capturedName)
+	}
+	expectedArgs := []string{"jest", "--runTestsByPath", "src/a.test.js"}
+	if !slices.Equal(capturedArgs, expectedArgs) {
+		t.Errorf("expected args %v, got %v", expectedArgs, capturedArgs)
+	}
+}
+
+func TestJest_RunTests_WithOverride(t *testing.T) {
+	var capturedName string
+	var capturedArgs []string
+	mockExecutor := &mockCommandExecutor{
+		onExecution: func(name string, args []string) {
+			capturedName = name
+			capturedArgs = slices.Clone(args)
+		},
+	}
+	jest := &Jest{
+		executor:        mockExecutor,
+		commandOverride: []string{"pnpm", "jest", "--runInBand"},
+		platformEnv:     make(map[string]string),
+	}
+
+	if err := jest.RunTests(context.Background(), []string{"src/a.test.js"}, nil); err != nil {
+		t.Fatalf("RunTests failed: %v", err)
+	}
+
+	if capturedName != "pnpm" {
+		t.Errorf("expected command %q, got %q", "pnpm", capturedName)
+	}
+	expectedArgs := []string{"jest", "--runInBand", "--runTestsByPath", "src/a.test.js"}
+	if !slices.Equal(capturedArgs, expectedArgs) {
+		t.Errorf("expected args %v, got %v", expectedArgs, capturedArgs)
+	}
+}

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -3,6 +3,7 @@ package planner
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -16,6 +17,7 @@ import (
 	"github.com/DataDog/ddtest/civisibility/utils"
 	"github.com/DataDog/ddtest/internal/ciprovider"
 	"github.com/DataDog/ddtest/internal/constants"
+	frameworkpkg "github.com/DataDog/ddtest/internal/framework"
 	"github.com/DataDog/ddtest/internal/platform"
 	"github.com/DataDog/ddtest/internal/runmetadata"
 	"github.com/DataDog/ddtest/internal/settings"
@@ -262,6 +264,7 @@ func (tp *TestPlanner) PreparePlanningData(ctx context.Context) error {
 		return fmt.Errorf("failed to detect framework: %w", err)
 	}
 	slog.Info("Framework detected", "framework", framework.Name())
+	fullTestDiscoverySupported := frameworkpkg.SupportsFullTestDiscovery(framework)
 	tp.runInfo = runmetadata.New(utils.GetCITags())
 	tp.planInfo = NewPlanInfo(tags, detectedPlatform.Name(), framework.Name())
 
@@ -298,6 +301,11 @@ func (tp *TestPlanner) PreparePlanningData(ctx context.Context) error {
 			slog.Debug("Repository settings", "tia_enabled", repositorySettings.ItrEnabled, "tests_skipping", repositorySettings.TestsSkipping)
 			tiaSkippingEnabled = repositorySettings.ItrEnabled && repositorySettings.TestsSkipping
 
+			if tiaSkippingEnabled && !fullTestDiscoverySupported {
+				slog.Info("Framework does not support full test discovery; TIA skippables will not be applied during planning", "framework", framework.Name())
+				tiaSkippingEnabled = false
+			}
+
 			if !tiaSkippingEnabled {
 				slog.Info("TIA or test skipping disabled, cancelling full test discovery")
 				cancelDiscovery()
@@ -319,12 +327,22 @@ func (tp *TestPlanner) PreparePlanningData(ctx context.Context) error {
 
 	// Goroutine 2: Tests discovery (respects context cancellation)
 	g.Go(func() error {
+		if !fullTestDiscoverySupported {
+			fullDiscoveryErr = frameworkpkg.ErrFullTestDiscoveryUnsupported
+			slog.Info("Full test discovery is not supported by framework; using fast test file discovery fallback", "framework", framework.Name())
+			return nil
+		}
+
 		startTime := time.Now()
 		slog.Info("Discovering local tests...", "framework", framework.Name())
 		res, discErr := framework.DiscoverTests(discoveryCtx)
 		if discErr != nil {
 			fullDiscoveryErr = discErr
-			slog.Warn("Full test discovery failed or was cancelled", "error", discErr)
+			if errors.Is(discErr, frameworkpkg.ErrFullTestDiscoveryUnsupported) {
+				slog.Info("Full test discovery is not supported by framework; using fast test file discovery fallback", "framework", framework.Name())
+			} else {
+				slog.Warn("Full test discovery failed or was cancelled", "error", discErr)
+			}
 			return nil // Don't fail the entire process, we have fast discovery as fallback
 		}
 		if len(res) == 0 {

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -17,7 +17,7 @@ import (
 	"github.com/DataDog/ddtest/civisibility/utils"
 	"github.com/DataDog/ddtest/internal/ciprovider"
 	"github.com/DataDog/ddtest/internal/constants"
-	frameworkpkg "github.com/DataDog/ddtest/internal/framework"
+	"github.com/DataDog/ddtest/internal/framework"
 	"github.com/DataDog/ddtest/internal/platform"
 	"github.com/DataDog/ddtest/internal/runmetadata"
 	"github.com/DataDog/ddtest/internal/settings"
@@ -259,14 +259,14 @@ func (tp *TestPlanner) PreparePlanningData(ctx context.Context) error {
 	}
 
 	// Detect framework once to avoid duplicate work
-	framework, err := detectedPlatform.DetectFramework()
+	detectedFramework, err := detectedPlatform.DetectFramework()
 	if err != nil {
 		return fmt.Errorf("failed to detect framework: %w", err)
 	}
-	slog.Info("Framework detected", "framework", framework.Name())
-	fullTestDiscoverySupported := frameworkpkg.SupportsFullTestDiscovery(framework)
+	slog.Info("Framework detected", "framework", detectedFramework.Name())
+	fullTestDiscoverySupported := framework.SupportsFullTestDiscovery(detectedFramework)
 	tp.runInfo = runmetadata.New(utils.GetCITags())
-	tp.planInfo = NewPlanInfo(tags, detectedPlatform.Name(), framework.Name())
+	tp.planInfo = NewPlanInfo(tags, detectedPlatform.Name(), detectedFramework.Name())
 
 	// Create a cancellable context for test discovery
 	discoveryCtx, cancelDiscovery := context.WithCancel(ctx)
@@ -302,7 +302,7 @@ func (tp *TestPlanner) PreparePlanningData(ctx context.Context) error {
 			tiaSkippingEnabled = repositorySettings.ItrEnabled && repositorySettings.TestsSkipping
 
 			if tiaSkippingEnabled && !fullTestDiscoverySupported {
-				slog.Info("Framework does not support full test discovery; TIA skippables will not be applied during planning", "framework", framework.Name())
+				slog.Info("Framework does not support full test discovery; TIA skippables will not be applied during planning", "framework", detectedFramework.Name())
 				tiaSkippingEnabled = false
 			}
 
@@ -328,18 +328,18 @@ func (tp *TestPlanner) PreparePlanningData(ctx context.Context) error {
 	// Goroutine 2: Tests discovery (respects context cancellation)
 	g.Go(func() error {
 		if !fullTestDiscoverySupported {
-			fullDiscoveryErr = frameworkpkg.ErrFullTestDiscoveryUnsupported
-			slog.Info("Full test discovery is not supported by framework; using fast test file discovery fallback", "framework", framework.Name())
+			fullDiscoveryErr = framework.ErrFullTestDiscoveryUnsupported
+			slog.Info("Full test discovery is not supported by framework; using fast test file discovery fallback", "framework", detectedFramework.Name())
 			return nil
 		}
 
 		startTime := time.Now()
-		slog.Info("Discovering local tests...", "framework", framework.Name())
-		res, discErr := framework.DiscoverTests(discoveryCtx)
+		slog.Info("Discovering local tests...", "framework", detectedFramework.Name())
+		res, discErr := detectedFramework.DiscoverTests(discoveryCtx)
 		if discErr != nil {
 			fullDiscoveryErr = discErr
-			if errors.Is(discErr, frameworkpkg.ErrFullTestDiscoveryUnsupported) {
-				slog.Info("Full test discovery is not supported by framework; using fast test file discovery fallback", "framework", framework.Name())
+			if errors.Is(discErr, framework.ErrFullTestDiscoveryUnsupported) {
+				slog.Info("Full test discovery is not supported by framework; using fast test file discovery fallback", "framework", detectedFramework.Name())
 			} else {
 				slog.Warn("Full test discovery failed or was cancelled", "error", discErr)
 			}
@@ -362,8 +362,8 @@ func (tp *TestPlanner) PreparePlanningData(ctx context.Context) error {
 	// Goroutine 3: Test files discovery (fast, must always complete)
 	g.Go(func() error {
 		startTime := time.Now()
-		slog.Info("Discovering test files (fast)...", "framework", framework.Name())
-		res, discErr := framework.DiscoverTestFiles()
+		slog.Info("Discovering test files (fast)...", "framework", detectedFramework.Name())
+		res, discErr := detectedFramework.DiscoverTestFiles()
 		if discErr != nil {
 			fastDiscoveryErr = discErr
 			slog.Warn("Fast test discovery failed", "error", discErr)

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -141,16 +141,29 @@ func (m *longRunningDiscoveryFramework) DiscoverTests(ctx context.Context) ([]te
 	return nil, ctx.Err()
 }
 
+type noFullDiscoveryFramework struct {
+	MockFramework
+}
+
+func (m *noFullDiscoveryFramework) SupportsFullTestDiscovery() bool {
+	return false
+}
+
+func (m *noFullDiscoveryFramework) DiscoverTests(ctx context.Context) ([]testoptimization.Test, error) {
+	return nil, framework.ErrFullTestDiscoveryUnsupported
+}
+
 // MockTestOptimizationClient mocks the test optimization client
 type MockTestOptimizationClient struct {
-	InitializeCalled    bool
-	InitializeErr       error
-	Settings            *net.SettingsResponseData
-	SkippableTests      map[string]bool
-	KnownTests          *net.KnownTestsResponseData
-	TestManagementTests *net.TestManagementTestsResponseDataModules
-	ShutdownCalled      bool
-	Tags                map[string]string
+	InitializeCalled        bool
+	InitializeErr           error
+	Settings                *net.SettingsResponseData
+	SkippableTests          map[string]bool
+	GetSkippableTestsCalled bool
+	KnownTests              *net.KnownTestsResponseData
+	TestManagementTests     *net.TestManagementTestsResponseDataModules
+	ShutdownCalled          bool
+	Tags                    map[string]string
 }
 
 func (m *MockTestOptimizationClient) Initialize(tags map[string]string) error {
@@ -167,6 +180,7 @@ func (m *MockTestOptimizationClient) GetSettings() *net.SettingsResponseData {
 }
 
 func (m *MockTestOptimizationClient) GetSkippableTests() map[string]bool {
+	m.GetSkippableTestsCalled = true
 	return m.SkippableTests
 }
 
@@ -484,6 +498,57 @@ func TestTestPlanner_Plan_WritesManifestAndRunnerLayout(t *testing.T) {
 	assertFileContent(t, constants.ParallelRunnersOutputPath, "1")
 	assertFileContent(t, constants.SkippablePercentageOutputPath, "0.00")
 
+	assertFileContent(t, filepath.Join(constants.TestsSplitDir, "runner-0"), expectedTestFiles)
+}
+
+func TestTestPlanner_Plan_FrameworkWithoutFullDiscoveryDoesNotFetchSkippables(t *testing.T) {
+	tempDir := t.TempDir()
+	oldWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldWd) }()
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+
+	t.Cleanup(func() { settings.Init() })
+	t.Setenv("DD_TEST_OPTIMIZATION_RUNNER_MIN_PARALLELISM", "1")
+	t.Setenv("DD_TEST_OPTIMIZATION_RUNNER_MAX_PARALLELISM", "1")
+	t.Setenv("DD_TEST_OPTIMIZATION_RUNNER_REPORT_ENABLED", "false")
+	settings.Init()
+
+	mockFramework := &noFullDiscoveryFramework{
+		MockFramework: MockFramework{
+			FrameworkName: "jest",
+			TestFiles:     []string{"src/a.test.js", "src/b.test.ts"},
+		},
+	}
+	mockPlatform := &MockPlatform{
+		PlatformName: "javascript",
+		Tags:         map[string]string{"language": "javascript"},
+		Framework:    mockFramework,
+	}
+	mockOptimizationClient := &MockTestOptimizationClient{
+		Settings:       testOptimizationSettings(true, true, false),
+		SkippableTests: map[string]bool{"jest.src/a.test.js..": true},
+	}
+
+	runner := NewWithDependencies(
+		&MockPlatformDetector{Platform: mockPlatform},
+		mockOptimizationClient,
+		&MockTestSuiteDurationsClient{},
+		newDefaultMockCIProviderDetector(),
+	)
+
+	if err := runner.Plan(context.Background()); err != nil {
+		t.Fatalf("Plan() should not return error, got: %v", err)
+	}
+
+	if mockOptimizationClient.GetSkippableTestsCalled {
+		t.Fatal("expected planner not to fetch skippables when full test discovery is unsupported")
+	}
+
+	expectedTestFiles := "src/a.test.js\nsrc/b.test.ts\n"
+	assertFileContent(t, constants.TestFilesOutputPath, expectedTestFiles)
+	assertFileContent(t, constants.SkippablePercentageOutputPath, "0.00")
 	assertFileContent(t, filepath.Join(constants.TestsSplitDir, "runner-0"), expectedTestFiles)
 }
 

--- a/internal/platform/javascript.go
+++ b/internal/platform/javascript.go
@@ -1,0 +1,141 @@
+package platform
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"maps"
+	"os"
+	"strings"
+
+	"github.com/DataDog/ddtest/internal/constants"
+	"github.com/DataDog/ddtest/internal/ext"
+	"github.com/DataDog/ddtest/internal/framework"
+	"github.com/DataDog/ddtest/internal/settings"
+)
+
+//go:embed scripts/javascript_env.js
+var javascriptEnvScript string
+
+const (
+	nodeOptionsEnvVar       = "NODE_OPTIONS"
+	ddTraceCIInitModule     = "dd-trace/ci/init"
+	nodeOptionsDDTraceCIArg = "-r " + ddTraceCIInitModule
+)
+
+type JavaScript struct {
+	executor ext.CommandExecutor
+}
+
+func NewJavaScript() *JavaScript {
+	return &JavaScript{
+		executor: &ext.DefaultCommandExecutor{},
+	}
+}
+
+func (j *JavaScript) Name() string {
+	return "javascript"
+}
+
+// GetPlatformEnv returns environment variables required for JS commands.
+func (j *JavaScript) GetPlatformEnv() map[string]string {
+	// Check if the NODE_OPTIONS is set in the env, and if so,
+	// check if it contains the dd-trace init option
+	// (the minimum required to start the libary)
+	currentValue, exists := os.LookupEnv(nodeOptionsEnvVar)
+	if exists && strings.Contains(currentValue, ddTraceCIInitModule) {
+		return map[string]string{}
+	}
+
+	// If the NODE_OPTIONS contained something, prepend the dd-trace
+	// init option at the beggining
+	nodeOptions := nodeOptionsDDTraceCIArg
+	if strings.TrimSpace(currentValue) != "" {
+		nodeOptions = nodeOptionsDDTraceCIArg + " " + currentValue
+	}
+
+	// If NODE_OPTIONS is not set, just set it to '-r dd-trace/ci/init'
+	slog.Debug("Setting NODE_OPTIONS to auto-instrument with dd-trace-js", "nodeOptions", nodeOptions)
+	return map[string]string{
+		nodeOptionsEnvVar: nodeOptions,
+	}
+}
+
+func (j *JavaScript) CreateTagsMap() (map[string]string, error) {
+	tags := make(map[string]string)
+	tags["language"] = j.Name()
+
+	// Create plan directory if it doesn't exist
+	if err := os.MkdirAll(constants.PlanDirectory, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create plan directory: %w", err)
+	}
+
+	// Create a temporary file for the JavaScript script output
+	tempFile := constants.JavaScriptEnvOutputPath
+	defer func() { _ = os.Remove(tempFile) }()
+
+	// Execute the embedded JavaScript script to get runtime tags
+	if err := j.executor.Run(context.Background(), "node", []string{"-e", javascriptEnvScript, tempFile}, nil); err != nil {
+		return nil, fmt.Errorf("failed to execute JavaScript script: %w", err)
+	}
+
+	// Read the JSON output from the temp file
+	fileContent, err := os.ReadFile(tempFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read JavaScript script output file: %w", err)
+	}
+
+	// Parse the JSON output.
+	// The extracted tags from the node process are:
+	// "os.platform", "os.architecture", "os.version", "runtime.name" & "runtime.version"
+	var javascriptTags map[string]string
+	if err := json.Unmarshal(fileContent, &javascriptTags); err != nil {
+		return nil, fmt.Errorf("failed to parse runtime tags JSON: %w, tried to parse: %s", err, string(fileContent))
+	}
+
+	// Merge the tags from the JavaScript output
+	maps.Copy(tags, javascriptTags)
+
+	return tags, nil
+}
+
+func (j *JavaScript) DetectFramework() (framework.Framework, error) {
+	frameworkName := settings.GetFramework()
+	platformEnv := j.GetPlatformEnv()
+
+	var fw framework.Framework
+	switch frameworkName {
+	case "jest":
+		fw = framework.NewJest()
+	default:
+		return nil, fmt.Errorf("framework '%s' is not supported by platform 'javascript'", frameworkName)
+	}
+
+	fw.SetPlatformEnv(platformEnv)
+	return fw, nil
+}
+
+// Confirm that Node.js is installed by running 'node --version'
+// and confirm that the dd-trace package is resolvable
+func (j *JavaScript) SanityCheck() error {
+	if output, err := j.executor.CombinedOutput(context.Background(), "node", []string{"--version"}, nil); err != nil {
+		message := strings.TrimSpace(string(output))
+		if message == "" {
+			return fmt.Errorf("node --version command failed: %w", err)
+		}
+		return fmt.Errorf("node --version command failed: %s", message)
+	}
+
+	output, err := j.executor.CombinedOutput(context.Background(), "node", []string{"-e", fmt.Sprintf("require.resolve(%q)", ddTraceCIInitModule)}, nil)
+	if err != nil {
+		message := strings.TrimSpace(string(output))
+		if message == "" {
+			return fmt.Errorf("failed to resolve %s: %w", ddTraceCIInitModule, err)
+		}
+		return fmt.Errorf("failed to resolve %s: %s", ddTraceCIInitModule, message)
+	}
+
+	return nil
+}

--- a/internal/platform/javascript_test.go
+++ b/internal/platform/javascript_test.go
@@ -1,0 +1,357 @@
+package platform
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/DataDog/ddtest/internal/constants"
+	"github.com/DataDog/ddtest/internal/settings"
+	"github.com/spf13/viper"
+)
+
+// sequentialMockExecutor returns pre-configured responses in order for CombinedOutput calls.
+// Used when successive calls to SanityCheck need different return values.
+type sequentialMockExecutor struct {
+	responses []struct {
+		output []byte
+		err    error
+	}
+	index int
+}
+
+func (m *sequentialMockExecutor) CombinedOutput(_ context.Context, _ string, _ []string, _ map[string]string) ([]byte, error) {
+	if m.index >= len(m.responses) {
+		return nil, nil
+	}
+	r := m.responses[m.index]
+	m.index++
+	return r.output, r.err
+}
+
+func (m *sequentialMockExecutor) Run(_ context.Context, _ string, _ []string, _ map[string]string) error {
+	return nil
+}
+
+func TestJavaScript_Name(t *testing.T) {
+	javascript := NewJavaScript()
+	if javascript.Name() != "javascript" {
+		t.Errorf("expected %q, got %q", "javascript", javascript.Name())
+	}
+}
+
+func TestJavaScript_GetPlatformEnv_SetsNODEOPTIONS(t *testing.T) {
+	t.Setenv(nodeOptionsEnvVar, "")
+
+	javascript := NewJavaScript()
+	envMap := javascript.GetPlatformEnv()
+
+	if envMap[nodeOptionsEnvVar] != nodeOptionsDDTraceCIArg {
+		t.Errorf("expected NODE_OPTIONS to be %q, got %q", nodeOptionsDDTraceCIArg, envMap[nodeOptionsEnvVar])
+	}
+}
+
+func TestJavaScript_GetPlatformEnv_PreservesExistingNODEOPTIONS(t *testing.T) {
+	t.Setenv(nodeOptionsEnvVar, "--max-old-space-size=4096")
+
+	javascript := NewJavaScript()
+	envMap := javascript.GetPlatformEnv()
+
+	expected := nodeOptionsDDTraceCIArg + " --max-old-space-size=4096"
+	if envMap[nodeOptionsEnvVar] != expected {
+		t.Errorf("expected NODE_OPTIONS to be %q, got %q", expected, envMap[nodeOptionsEnvVar])
+	}
+}
+
+func TestJavaScript_GetPlatformEnv_DoesNotDuplicateDDTraceInit(t *testing.T) {
+	t.Setenv(nodeOptionsEnvVar, "-r dd-trace/ci/init --max-old-space-size=4096")
+
+	javascript := NewJavaScript()
+	envMap := javascript.GetPlatformEnv()
+
+	if len(envMap) != 0 {
+		t.Errorf("expected empty env map when dd-trace init is already present, got %v", envMap)
+	}
+}
+
+func TestJavaScript_CreateTagsMap_Success(t *testing.T) {
+	defer func() {
+		_ = os.RemoveAll(constants.PlanDirectory)
+	}()
+
+	expectedJavaScriptTags := map[string]string{
+		"os.platform":     "darwin",
+		"os.architecture": "arm64",
+		"os.version":      "24.5.0",
+		"runtime.name":    "node",
+		"runtime.version": "v22.16.0",
+	}
+
+	expectedOutput, err := json.Marshal(expectedJavaScriptTags)
+	if err != nil {
+		t.Fatalf("failed to marshal expected tags: %v", err)
+	}
+
+	mockExecutor := &mockCommandExecutor{
+		onRun: func(name string, args []string, envMap map[string]string) {
+			if name != "node" {
+				t.Errorf("expected command to be 'node', got %q", name)
+			}
+			if len(args) != 3 {
+				t.Errorf("expected 3 args, got %d: %v", len(args), args)
+				return
+			}
+			if args[0] != "-e" {
+				t.Errorf("expected first arg to be '-e', got %q", args[0])
+			}
+			if args[1] == "" {
+				t.Error("javascript script should not be empty")
+			}
+			if err := os.WriteFile(args[2], expectedOutput, 0644); err != nil {
+				t.Errorf("failed to write temp file: %v", err)
+			}
+		},
+	}
+
+	javascript := &JavaScript{executor: mockExecutor}
+	tags, err := javascript.CreateTagsMap()
+	if err != nil {
+		t.Fatalf("CreateTagsMap failed: %v", err)
+	}
+
+	if tags["language"] != "javascript" {
+		t.Errorf("expected language tag to be 'javascript', got %q", tags["language"])
+	}
+	for key, expectedValue := range expectedJavaScriptTags {
+		if actualValue := tags[key]; actualValue != expectedValue {
+			t.Errorf("expected tag %q to be %q, got %q", key, expectedValue, actualValue)
+		}
+	}
+}
+
+func TestJavaScript_CreateTagsMap_CommandFailure(t *testing.T) {
+	defer func() {
+		_ = os.RemoveAll(constants.PlanDirectory)
+	}()
+
+	javascript := &JavaScript{
+		executor: &mockCommandExecutor{runErr: &exec.ExitError{}},
+	}
+
+	tags, err := javascript.CreateTagsMap()
+	if err == nil {
+		t.Fatal("expected error when node command fails")
+	}
+	if tags != nil {
+		t.Error("expected nil tags when command fails")
+	}
+	if !strings.Contains(err.Error(), "failed to execute JavaScript script") {
+		t.Errorf("expected JavaScript execution error, got %v", err)
+	}
+}
+
+func TestJavaScript_CreateTagsMap_InvalidJSON(t *testing.T) {
+	defer func() {
+		_ = os.RemoveAll(constants.PlanDirectory)
+	}()
+
+	mockExecutor := &mockCommandExecutor{
+		onRun: func(name string, args []string, envMap map[string]string) {
+			if err := os.WriteFile(args[2], []byte("{invalid json}"), 0644); err != nil {
+				t.Errorf("failed to write temp file: %v", err)
+			}
+		},
+	}
+
+	javascript := &JavaScript{executor: mockExecutor}
+	tags, err := javascript.CreateTagsMap()
+	if err == nil {
+		t.Fatal("expected error when JSON is invalid")
+	}
+	if tags != nil {
+		t.Error("expected nil tags when JSON parsing fails")
+	}
+	if !strings.Contains(err.Error(), "failed to parse runtime tags JSON") {
+		t.Errorf("expected JSON parsing error, got %v", err)
+	}
+}
+
+func TestJavaScript_DetectFramework_Jest(t *testing.T) {
+	viper.Reset()
+	viper.Set("framework", "jest")
+	settings.Init()
+	defer func() {
+		viper.Reset()
+		settings.Init()
+	}()
+
+	javascript := NewJavaScript()
+	fw, err := javascript.DetectFramework()
+	if err != nil {
+		t.Fatalf("DetectFramework failed: %v", err)
+	}
+	if fw.Name() != "jest" {
+		t.Errorf("expected framework name to be 'jest', got %q", fw.Name())
+	}
+}
+
+func TestJavaScript_DetectFramework_Unsupported(t *testing.T) {
+	viper.Reset()
+	viper.Set("framework", "rspec")
+	settings.Init()
+	defer func() {
+		viper.Reset()
+		settings.Init()
+	}()
+
+	javascript := NewJavaScript()
+	fw, err := javascript.DetectFramework()
+	if err == nil {
+		t.Fatalf("expected unsupported framework error, got framework %v", fw)
+	}
+	if fw != nil {
+		t.Error("expected nil framework for unsupported framework")
+	}
+	expectedError := "framework 'rspec' is not supported by platform 'javascript'"
+	if err.Error() != expectedError {
+		t.Errorf("expected error %q, got %q", expectedError, err.Error())
+	}
+}
+
+func TestJavaScript_SanityCheck_Passes(t *testing.T) {
+	calls := 0
+	mockExecutor := &mockCommandExecutor{
+		combinedOutput: []byte("v22.16.0\n"),
+		onCombinedOutput: func(name string, args []string, envMap map[string]string) {
+			calls++
+			if name != "node" {
+				t.Fatalf("expected command 'node', got %q", name)
+			}
+			if calls == 1 && (len(args) != 1 || args[0] != "--version") {
+				t.Fatalf("expected node --version, got %v", args)
+			}
+			if calls == 2 && (len(args) != 2 || args[0] != "-e" || !strings.Contains(args[1], ddTraceCIInitModule)) {
+				t.Fatalf("expected node require.resolve command, got %v", args)
+			}
+		},
+	}
+
+	javascript := &JavaScript{executor: mockExecutor}
+	if err := javascript.SanityCheck(); err != nil {
+		t.Fatalf("SanityCheck() unexpected error: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 sanity check commands, got %d", calls)
+	}
+}
+
+func TestJavaScript_SanityCheck_FailsWhenNodeMissing(t *testing.T) {
+	javascript := &JavaScript{
+		executor: &mockCommandExecutor{
+			combinedOutput:    []byte("node: command not found"),
+			combinedOutputErr: &exec.ExitError{},
+		},
+	}
+
+	err := javascript.SanityCheck()
+	if err == nil {
+		t.Fatal("expected sanity check error")
+	}
+	if !strings.Contains(err.Error(), "node --version command failed") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestJavaScript_EmbeddedScript(t *testing.T) {
+	if javascriptEnvScript == "" {
+		t.Error("embedded JavaScript script should not be empty")
+	}
+
+	for _, expected := range []string{
+		"require(\"os\")",
+		"process.version",
+		"process.arch",
+		"process.platform",
+		"fs.writeFileSync",
+	} {
+		if !strings.Contains(javascriptEnvScript, expected) {
+			t.Errorf("expected JavaScript script to contain %q", expected)
+		}
+	}
+}
+
+func TestJavaScript_SanityCheck_FailsWhenDDTraceMissing(t *testing.T) {
+	mockExecutor := &sequentialMockExecutor{
+		responses: []struct {
+			output []byte
+			err    error
+		}{
+			{output: []byte("v22.16.0\n"), err: nil},
+			{output: []byte("Cannot find module 'dd-trace/ci/init'"), err: &exec.ExitError{}},
+		},
+	}
+
+	javascript := &JavaScript{executor: mockExecutor}
+	err := javascript.SanityCheck()
+	if err == nil {
+		t.Fatal("expected sanity check error when dd-trace is missing")
+	}
+	if !strings.Contains(err.Error(), "failed to resolve "+ddTraceCIInitModule) {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestJavaScript_DetectFramework_SetsPlatformEnv(t *testing.T) {
+	t.Setenv(nodeOptionsEnvVar, "")
+
+	viper.Reset()
+	viper.Set("framework", "jest")
+	settings.Init()
+	defer func() {
+		viper.Reset()
+		settings.Init()
+	}()
+
+	javascript := NewJavaScript()
+	fw, err := javascript.DetectFramework()
+	if err != nil {
+		t.Fatalf("DetectFramework failed: %v", err)
+	}
+	if fw == nil {
+		t.Fatal("expected framework to be non-nil")
+	}
+
+	frameworkPlatformEnv := fw.GetPlatformEnv()
+	if frameworkPlatformEnv[nodeOptionsEnvVar] != nodeOptionsDDTraceCIArg {
+		t.Errorf("expected framework platformEnv %s=%q, got %q", nodeOptionsEnvVar, nodeOptionsDDTraceCIArg, frameworkPlatformEnv[nodeOptionsEnvVar])
+	}
+}
+
+func TestDetectPlatform_JavaScript(t *testing.T) {
+	viper.Reset()
+	viper.Set("platform", "javascript")
+	settings.Init()
+	defer func() {
+		viper.Reset()
+		settings.Init()
+	}()
+
+	platform, err := DetectPlatform()
+	if err != nil {
+		// SanityCheck failed — verify the error names the javascript platform
+		if !strings.Contains(err.Error(), "javascript") {
+			t.Errorf("expected error to mention javascript platform, got: %v", err)
+		}
+		if platform != nil {
+			t.Error("expected nil platform when sanity check fails")
+		}
+	} else {
+		// SanityCheck passed (node + dd-trace available in this environment)
+		if platform.Name() != "javascript" {
+			t.Errorf("expected platform name 'javascript', got %q", platform.Name())
+		}
+	}
+}

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -32,6 +32,8 @@ func DetectPlatform() (Platform, error) {
 	switch platformName {
 	case "ruby":
 		platform = NewRuby()
+	case "javascript":
+		platform = NewJavaScript()
 	default:
 		return nil, fmt.Errorf("unsupported platform: %s", platformName)
 	}

--- a/internal/platform/scripts/javascript_env.js
+++ b/internal/platform/scripts/javascript_env.js
@@ -1,0 +1,13 @@
+const fs = require("fs")
+const os = require("os")
+
+const tagsMap = {
+  "os.platform": process.platform,
+  "os.architecture": process.arch,
+  "os.version": os.release(),
+  "runtime.name": "node",
+  "runtime.version": process.version,
+}
+
+const outputFile = process.argv[1]
+fs.writeFileSync(outputFile, JSON.stringify(tagsMap))


### PR DESCRIPTION
**What does this PR do?**
Adds JavaScript/Jest support to `ddtest`.

This includes:
- New `javascript` platform detection and sanity checks for Node.js and `dd-trace/ci/init`
- Automatic `NODE_OPTIONS=-r dd-trace/ci/init` injection for dd-trace-js instrumentation
- Runtime/OS tag collection from Node.js
- New `jest` framework integration with test-file discovery for common Jest patterns
- Jest execution through local `node_modules/.bin/jest`, custom command override, or `npx jest`
- Planner support for frameworks that do not support full test discovery, falling back to test-file discovery and avoiding TIA skippables in that mode
- Unit coverage for the new platform, Jest framework, and planner behavior

**Motivation**
`ddtest` currently supports Ruby workloads, but Test Optimization also needs JavaScript coverage. This PR starts that support by adding Jest integration, enabling `ddtest` to plan and run JavaScript test files while automatically initializing `dd-trace-js`.

**How to test the change?**
Run the focused package tests:

```bash
  go test ./internal/platform ./internal/framework ./internal/planner
```
Ran the full test suite:

```bash
  go test ./...
```