### PR TITLE
Datadog Flaky Test Management: Keep attempt-to-fix tests runnable

### DIFF
--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -1379,6 +1379,7 @@ func TestTestPlanner_PreparePlanningData_DisabledTestManagementTestsAreSkipped(t
 			{Module: "rspec", Suite: "Suite1", Name: "test2", Parameters: "", SuiteSourceFile: "spec/file1_spec.rb"},
 			{Module: "rspec", Suite: "Suite2", Name: "test3", Parameters: `{"arguments":{},"metadata":{"scoped_id":"1:2"}}`, SuiteSourceFile: "spec/file2_spec.rb"},
 			{Module: "rspec", Suite: "Suite3", Name: "test4", Parameters: "", SuiteSourceFile: "spec/file3_spec.rb"},
+			{Module: "rspec", Suite: "Suite4", Name: "test5", Parameters: "", SuiteSourceFile: "spec/file4_spec.rb"},
 		},
 	}
 	mockPlatform := &MockPlatform{
@@ -1403,6 +1404,11 @@ func TestTestPlanner_PreparePlanningData_DisabledTestManagementTestsAreSkipped(t
 						"Suite3": {
 							Tests: map[string]api.TestManagementTestsResponseDataTestProperties{
 								"test4": {Properties: api.TestManagementTestsResponseDataTestPropertiesAttributes{Quarantined: true}},
+							},
+						},
+						"Suite4": {
+							Tests: map[string]api.TestManagementTestsResponseDataTestProperties{
+								"test5": {Properties: api.TestManagementTestsResponseDataTestPropertiesAttributes{Disabled: true, AttemptToFix: true}},
 							},
 						},
 					},
@@ -1434,6 +1440,15 @@ func TestTestPlanner_PreparePlanningData_DisabledTestManagementTestsAreSkipped(t
 	suite3 := runner.suiteAggregates[testSuiteKey{Module: "rspec", Suite: "Suite3"}]
 	if suite3.NumTests != 1 || suite3.NumTestsSkipped != 0 {
 		t.Errorf("Expected Suite3 quarantined test to remain runnable, got %+v", suite3)
+	}
+
+	suite4 := runner.suiteAggregates[testSuiteKey{Module: "rspec", Suite: "Suite4"}]
+	if suite4.NumTests != 1 || suite4.NumTestsSkipped != 0 {
+		t.Errorf("Expected Suite4 attempt-to-fix test to remain runnable, got %+v", suite4)
+	}
+
+	if _, ok := runner.testFileWeights["spec/file4_spec.rb"]; !ok {
+		t.Errorf("Expected attempt-to-fix file to be scheduled, got %v", runner.testFileWeights)
 	}
 
 	if runner.planReport.SkippableTestsCount != 2 {

--- a/internal/testoptimization/test_management.go
+++ b/internal/testoptimization/test_management.go
@@ -11,7 +11,7 @@ func DisabledTestsFromTestManagementData(testManagementTests *api.TestManagement
 	for module, suites := range testManagementTests.Modules {
 		for suite, tests := range suites.Suites {
 			for name, test := range tests.Tests {
-				if !test.Properties.Disabled {
+				if !test.Properties.Disabled || test.Properties.AttemptToFix {
 					continue
 				}
 				disabledTest := Test{

--- a/internal/testoptimization/testoptimization_test.go
+++ b/internal/testoptimization/testoptimization_test.go
@@ -417,8 +417,9 @@ func TestDisabledTestsFromTestManagementData(t *testing.T) {
 				Suites: map[string]api.TestManagementTestsResponseDataTests{
 					"suite-a": {
 						Tests: map[string]api.TestManagementTestsResponseDataTestProperties{
-							"disabled":    {Properties: api.TestManagementTestsResponseDataTestPropertiesAttributes{Disabled: true}},
-							"quarantined": {Properties: api.TestManagementTestsResponseDataTestPropertiesAttributes{Quarantined: true}},
+							"disabled":                {Properties: api.TestManagementTestsResponseDataTestPropertiesAttributes{Disabled: true}},
+							"disabled attempt-to-fix": {Properties: api.TestManagementTestsResponseDataTestPropertiesAttributes{Disabled: true, AttemptToFix: true}},
+							"quarantined":             {Properties: api.TestManagementTestsResponseDataTestPropertiesAttributes{Quarantined: true}},
 						},
 					},
 				},


### PR DESCRIPTION
## What
Keep Test Management tests marked `attempt_to_fix` out of the planner disabled-test skip set, even when they also have `disabled: true`. Added focused coverage for the Test Management helper and the planner path that produces scheduled test files.

## Why
Disabled-flake fix PRs rely on the matching `DD_<attempt_to_fix_id>` token making the target test runnable so the tracer can emit `is_attempt_to_fix` events and FTM can evaluate `attempt_to_fix_passed:true`. PR #74 started treating every disabled managed test as planner-skipped, so those files disappeared from `test-files.txt` before the runner could execute the attempt-to-fix workflow.

## E2E testing
Run `ddtest plan` in a repo where Test Management returns a test with `disabled: true` and `attempt_to_fix: true` for a head commit containing the matching `DD_<attempt_to_fix_id>` token. Confirm the target spec appears in `.testoptimization/runner/test-files.txt`, then run the planned shard and confirm Datadog receives `is_attempt_to_fix` events. Automated checks run: `go test ./internal/testoptimization ./internal/planner`, `make test`, and `make lint`.