### PR TITLE
[python] Handle PEP 440 local prerelease versions

### DIFF
--- a/internal/platform/python.go
+++ b/internal/platform/python.go
@@ -17,15 +17,15 @@ import (
 	"github.com/DataDog/ddtest/internal/version"
 )
 
-// pep440PreReleaseRe matches PEP 440 pre-release suffixes (a/b/rc + digits) embedded
-// directly in a version component, e.g. "0rc1" or "12b3". We normalize these to
-// semver-style by inserting a hyphen so the existing parser can handle them.
-var pep440PreReleaseRe = regexp.MustCompile(`^(\d+\.\d+(?:\.\d+)*)((?:a|b|rc)\d+)$`)
+// pep440PreReleaseRe matches PEP 440 pre-release suffixes (a/b/rc + digits)
+// embedded directly in a Python package version, preserving optional local
+// version metadata, e.g. "4.12.0rc1+gabc123".
+var pep440PreReleaseRe = regexp.MustCompile(`^(\d+\.\d+(?:\.\d+)*)(a|b|rc)(\d+)(\+.*)?$`)
 
 // normalizePyVersion converts PEP 440 version strings to semver-compatible ones.
-// "4.12.0rc1" → "4.12.0-rc1", "4.10.3" → "4.10.3" (unchanged).
+// "4.12.0rc1+gabc123" -> "4.12.0-rc1+gabc123"; "4.10.3" is unchanged.
 func normalizePyVersion(v string) string {
-	return pep440PreReleaseRe.ReplaceAllString(v, "$1-$2")
+	return pep440PreReleaseRe.ReplaceAllString(v, "$1-$2$3$4")
 }
 
 //go:embed scripts/python_env.py

--- a/internal/platform/python_test.go
+++ b/internal/platform/python_test.go
@@ -22,8 +22,11 @@ func TestPython_Name(t *testing.T) {
 func TestNormalizePyVersion(t *testing.T) {
 	cases := []struct{ in, want string }{
 		{"4.12.0rc1", "4.12.0-rc1"},
+		{"4.12.0rc1+g0e3e598", "4.12.0-rc1+g0e3e598"},
 		{"4.12.0b2", "4.12.0-b2"},
+		{"4.12.0b2+gabc123", "4.12.0-b2+gabc123"},
 		{"4.12.0a1", "4.12.0-a1"},
+		{"4.12.0a1+local.build", "4.12.0-a1+local.build"},
 		{"4.10.3", "4.10.3"},
 		{"1.2.3.4", "1.2.3.4"},
 	}
@@ -36,7 +39,7 @@ func TestNormalizePyVersion(t *testing.T) {
 
 func TestPython_SanityCheck_SuccessWithPreRelease(t *testing.T) {
 	mockExecutor := &mockCommandExecutor{
-		combinedOutput: []byte("4.12.0rc1\n"),
+		combinedOutput: []byte("4.12.0rc1+g0e3e598\n"),
 	}
 	python := NewPython()
 	python.executor = mockExecutor


### PR DESCRIPTION
**What does this PR do?**

Normalizes Python package versions returned by `importlib.metadata.version("ddtrace")` before ddtest's Python sanity check parses them.

`dd-trace-py` can publish PEP 440 prerelease/local versions like `4.12.0rc1+g0e3e598`. ddtest's internal version parser expects semver-style prerelease syntax, so this PR converts those Python forms to parser-compatible values such as `4.12.0-rc1+g0e3e598` while leaving normal versions like `4.10.3` unchanged.

**Motivation**

When running the new Pytest/ddtest e2e flow from Shepherd against `dd-trace-py@main`, ddtest failed during platform sanity checking before planning tests:

```text
invalid version component "0rc1"
```

That happened because the previous normalization handled `4.12.0rc1`, but not the real source-build form with local metadata: `4.12.0rc1+g...`.

**Additional Notes**

The normalization stays in the Python platform layer instead of changing the shared version parser. This keeps the PEP 440 compatibility behavior scoped to Python package versions and avoids changing Ruby/JS/ddtest version semantics.

**How to test the change?**

Automated coverage was added for alpha, beta, rc, and local metadata cases, including the observed `4.12.0rc1+g0e3e598` shape.

Validated locally with:

```bash
go test ./internal/platform ./internal/version
go test ./...
```
