### PR TITLE
[SDTEST-3864] Add suite-level TIA skipping support

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -71,6 +71,7 @@ var rootPersistentFlagBindings = []persistentFlagBinding{
 	{configKey: "tests_location", flagName: "tests-location"},
 	{configKey: "tests_exclude_pattern", flagName: "tests-exclude-pattern"},
 	{configKey: "test_discovery_cache", flagName: "test-discovery-cache"},
+	{configKey: "test_skipping_mode", flagName: "test-skipping-mode"},
 	{configKey: "runtime_tags", flagName: "runtime-tags"},
 }
 
@@ -89,6 +90,7 @@ func init() {
 	rootCmd.PersistentFlags().String("tests-location", "", "Glob pattern used to discover test files")
 	rootCmd.PersistentFlags().String("tests-exclude-pattern", "", "Glob pattern used to exclude test files from discovery")
 	rootCmd.PersistentFlags().String("test-discovery-cache", "", "Path to a restored test discovery cache file to import before planning")
+	rootCmd.PersistentFlags().String("test-skipping-mode", "test", `TIA skipping granularity for Ruby ("test" or "suite"; invalid values fall back to "test")`)
 	rootCmd.PersistentFlags().String("runtime-tags", "", "JSON string to override runtime tags (e.g. '{\"os.platform\":\"linux\",\"runtime.version\":\"3.2.0\"}')")
 	if err := bindPersistentFlags(rootCmd, rootPersistentFlagBindings); err != nil {
 		fmt.Fprintf(os.Stderr, "Error binding CLI flags: %v\n", err)

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -56,6 +56,12 @@ func TestRootCommandFlags(t *testing.T) {
 		return
 	}
 
+	testSkippingModeFlag := rootCmd.PersistentFlags().Lookup("test-skipping-mode")
+	if testSkippingModeFlag == nil {
+		t.Error("test-skipping-mode flag should be defined")
+		return
+	}
+
 	ciNodeWorkersFlag := rootCmd.PersistentFlags().Lookup("ci-node-workers")
 	if ciNodeWorkersFlag == nil {
 		t.Error("ci-node-workers flag should be defined")
@@ -97,6 +103,10 @@ func TestRootCommandFlags(t *testing.T) {
 
 	if testDiscoveryCacheFlag.DefValue != "" {
 		t.Errorf("expected test-discovery-cache default to be empty, got %q", testDiscoveryCacheFlag.DefValue)
+	}
+
+	if testSkippingModeFlag.DefValue != "test" {
+		t.Errorf("expected test-skipping-mode default to be 'test', got %q", testSkippingModeFlag.DefValue)
 	}
 
 	if ciNodeWorkersFlag.DefValue != "1" {
@@ -332,6 +342,9 @@ func TestFlagBinding(t *testing.T) {
 	if err := rootCmd.PersistentFlags().Set("test-discovery-cache", "/tmp/ddtest-tests.json"); err != nil {
 		t.Fatalf("Error setting test-discovery-cache flag: %v", err)
 	}
+	if err := rootCmd.PersistentFlags().Set("test-skipping-mode", "suite"); err != nil {
+		t.Fatalf("Error setting test-skipping-mode flag: %v", err)
+	}
 	if err := rootCmd.PersistentFlags().Set("ci-node-workers", "ncpu"); err != nil {
 		t.Fatalf("Error setting ci-node-workers flag: %v", err)
 	}
@@ -360,6 +373,9 @@ func TestFlagBinding(t *testing.T) {
 	}
 	if viper.GetString("test_discovery_cache") != "/tmp/ddtest-tests.json" {
 		t.Errorf("expected viper test_discovery_cache to be '/tmp/ddtest-tests.json', got %q", viper.GetString("test_discovery_cache"))
+	}
+	if viper.GetString("test_skipping_mode") != "suite" {
+		t.Errorf("expected viper test_skipping_mode to be 'suite', got %q", viper.GetString("test_skipping_mode"))
 	}
 	if viper.GetString("ci_node_workers") != "ncpu" {
 		t.Errorf("expected viper ci_node_workers to be 'ncpu', got %q", viper.GetString("ci_node_workers"))

--- a/internal/framework/framework.go
+++ b/internal/framework/framework.go
@@ -15,4 +15,6 @@ type Framework interface {
 	SetPlatformEnv(platformEnv map[string]string)
 	GetPlatformEnv() map[string]string
 	SupportsFullTestDiscovery() bool
+	SourceFileForSuite(suite string) (string, bool)
+	HasUnskippableMarker(testFile string) bool
 }

--- a/internal/framework/jest.go
+++ b/internal/framework/jest.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/ddtest/internal/ext"
 	"github.com/DataDog/ddtest/internal/settings"
 	"github.com/DataDog/ddtest/internal/testoptimization"
+	"github.com/DataDog/ddtest/internal/utils"
 )
 
 const binJestPath = "node_modules/.bin/jest"
@@ -52,6 +53,18 @@ func (j *Jest) Name() string {
 // We'll be working outside of the Node.js process
 func (j *Jest) SupportsFullTestDiscovery() bool {
 	return false
+}
+
+func (j *Jest) SourceFileForSuite(suite string) (string, bool) {
+	suite = strings.TrimSpace(suite)
+	if suite == "" {
+		return "", false
+	}
+	return suite, true
+}
+
+func (j *Jest) HasUnskippableMarker(testFile string) bool {
+	return utils.FileContainsAll(testFile, "@datadog", "unskippable")
 }
 
 func (j *Jest) TestPattern() string {

--- a/internal/framework/jest_test.go
+++ b/internal/framework/jest_test.go
@@ -43,6 +43,42 @@ func TestJest_DiscoverTests_Unsupported(t *testing.T) {
 	}
 }
 
+func TestJest_SourceFileForSuite(t *testing.T) {
+	jest := NewJest()
+
+	sourceFile, ok := jest.SourceFileForSuite("src/example.test.js")
+	if !ok || sourceFile != "src/example.test.js" {
+		t.Fatalf("SourceFileForSuite() = %q, %v; want suite path", sourceFile, ok)
+	}
+
+	if sourceFile, ok := jest.SourceFileForSuite(" "); ok || sourceFile != "" {
+		t.Fatalf("SourceFileForSuite(blank) = %q, %v; want unresolved", sourceFile, ok)
+	}
+}
+
+func TestJest_HasUnskippableMarker(t *testing.T) {
+	tempDir := t.TempDir()
+	markedFile := filepath.Join(tempDir, "marked.test.js")
+	if err := os.WriteFile(markedFile, []byte("// @datadog\n// unskippable"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	unmarkedFile := filepath.Join(tempDir, "unmarked.test.js")
+	if err := os.WriteFile(unmarkedFile, []byte("// unskippable"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	jest := NewJest()
+	if !jest.HasUnskippableMarker(markedFile) {
+		t.Fatal("expected marker when @datadog and unskippable are present")
+	}
+	if jest.HasUnskippableMarker(unmarkedFile) {
+		t.Fatal("expected no marker without @datadog")
+	}
+	if !jest.HasUnskippableMarker(filepath.Join(tempDir, "missing.test.js")) {
+		t.Fatal("expected missing file to be treated as guarded")
+	}
+}
+
 func TestJest_DiscoverTestFiles_DefaultPatterns(t *testing.T) {
 	tempDir := t.TempDir()
 	oldWd, _ := os.Getwd()

--- a/internal/framework/minitest.go
+++ b/internal/framework/minitest.go
@@ -12,6 +12,7 @@ import (
 	"github.com/DataDog/ddtest/internal/ext"
 	"github.com/DataDog/ddtest/internal/settings"
 	"github.com/DataDog/ddtest/internal/testoptimization"
+	"github.com/DataDog/ddtest/internal/utils"
 )
 
 const (
@@ -166,4 +167,12 @@ func (m *Minitest) getMinitestCommand() (string, []string, bool) {
 
 func (m *Minitest) SupportsFullTestDiscovery() bool {
 	return true
+}
+
+func (m *Minitest) SourceFileForSuite(suite string) (string, bool) {
+	return trailingRubySuiteSourceFile(suite)
+}
+
+func (m *Minitest) HasUnskippableMarker(testFile string) bool {
+	return utils.FileContainsAll(testFile, "datadog_itr_unskippable")
 }

--- a/internal/framework/minitest_test.go
+++ b/internal/framework/minitest_test.go
@@ -1720,3 +1720,28 @@ func TestMinitest_SupportsFullTestDiscovery(t *testing.T) {
 		t.Error("expected Minitest to support full test discovery")
 	}
 }
+
+func TestMinitest_SourceFileForSuite(t *testing.T) {
+	minitest := NewMinitest()
+
+	sourceFile, ok := minitest.SourceFileForSuite("UserTest at test/models/user_test.rb")
+	if !ok || sourceFile != "test/models/user_test.rb" {
+		t.Fatalf("SourceFileForSuite() = %q, %v; want Ruby trailing path", sourceFile, ok)
+	}
+}
+
+func TestMinitest_HasUnskippableMarker(t *testing.T) {
+	tempDir := t.TempDir()
+	markedFile := filepath.Join(tempDir, "marked_test.rb")
+	if err := os.WriteFile(markedFile, []byte("datadog_itr_unskippable"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	minitest := NewMinitest()
+	if !minitest.HasUnskippableMarker(markedFile) {
+		t.Fatal("expected Ruby unskippable marker")
+	}
+	if !minitest.HasUnskippableMarker(filepath.Join(tempDir, "missing_test.rb")) {
+		t.Fatal("expected missing file to be treated as guarded")
+	}
+}

--- a/internal/framework/pytest.go
+++ b/internal/framework/pytest.go
@@ -107,6 +107,14 @@ func (p *PyTest) SupportsFullTestDiscovery() bool {
 	return true
 }
 
+func (p *PyTest) SourceFileForSuite(suite string) (string, bool) {
+	return "", false
+}
+
+func (p *PyTest) HasUnskippableMarker(testFile string) bool {
+	return false
+}
+
 func (p *PyTest) RunTests(ctx context.Context, testFiles []string, envMap map[string]string) error {
 	command := "python"
 	args := []string{"-m", "pytest"}

--- a/internal/framework/pytest_test.go
+++ b/internal/framework/pytest_test.go
@@ -199,6 +199,9 @@ func TestPyTest_SupportsFullTestDiscovery(t *testing.T) {
 	if !pytest.SupportsFullTestDiscovery() {
 		t.Error("expected PyTest to support full test discovery")
 	}
+	if sourceFile, ok := pytest.SourceFileForSuite("tests/test_user.py"); ok || sourceFile != "" {
+		t.Fatalf("SourceFileForSuite() = %q, %v; want unsupported", sourceFile, ok)
+	}
 }
 
 func TestPyTest_RunTests(t *testing.T) {

--- a/internal/framework/rspec.go
+++ b/internal/framework/rspec.go
@@ -6,17 +6,21 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/DataDog/ddtest/internal/discovery"
 	"github.com/DataDog/ddtest/internal/ext"
 	"github.com/DataDog/ddtest/internal/settings"
 	"github.com/DataDog/ddtest/internal/testoptimization"
+	"github.com/DataDog/ddtest/internal/utils"
 )
 
 const (
-	binRSpecPath         = "bin/rspec"
-	rspecTestFilePattern = "*_spec.rb"
-	rspecRootDir         = "spec"
+	binRSpecPath                 = "bin/rspec"
+	rspecTestFilePattern         = "*_spec.rb"
+	rspecRootDir                 = "spec"
+	rubySuiteSourceFileSeparator = " at "
+	rubyCIQueueSuiteSuffix       = " (ci-queue running example "
 )
 
 type RSpec struct {
@@ -103,4 +107,28 @@ func (r *RSpec) getRSpecCommand() (string, []string) {
 
 func (r *RSpec) SupportsFullTestDiscovery() bool {
 	return true
+}
+
+func (r *RSpec) SourceFileForSuite(suite string) (string, bool) {
+	return trailingRubySuiteSourceFile(suite)
+}
+
+func (r *RSpec) HasUnskippableMarker(testFile string) bool {
+	return utils.FileContainsAll(testFile, "datadog_itr_unskippable")
+}
+
+func trailingRubySuiteSourceFile(suite string) (string, bool) {
+	separatorIndex := strings.LastIndex(suite, rubySuiteSourceFileSeparator)
+	if separatorIndex < 0 {
+		return "", false
+	}
+
+	sourceFile := strings.TrimSpace(suite[separatorIndex+len(rubySuiteSourceFileSeparator):])
+	if suffixIndex := strings.Index(sourceFile, rubyCIQueueSuiteSuffix); suffixIndex >= 0 {
+		sourceFile = strings.TrimSpace(sourceFile[:suffixIndex])
+	}
+	if sourceFile == "" {
+		return "", false
+	}
+	return sourceFile, true
 }

--- a/internal/framework/rspec_test.go
+++ b/internal/framework/rspec_test.go
@@ -1321,3 +1321,44 @@ func TestRSpec_SupportsFullTestDiscovery(t *testing.T) {
 		t.Error("expected RSpec to support full test discovery")
 	}
 }
+
+func TestRSpec_SourceFileForSuite(t *testing.T) {
+	rspec := NewRSpec()
+
+	sourceFile, ok := rspec.SourceFileForSuite("User model at spec/models/user_spec.rb")
+	if !ok || sourceFile != "spec/models/user_spec.rb" {
+		t.Fatalf("SourceFileForSuite() = %q, %v; want Ruby trailing path", sourceFile, ok)
+	}
+
+	sourceFile, ok = rspec.SourceFileForSuite("SomeTest at ./spec/some_test_rspec.rb (ci-queue running example [nested foo])")
+	if !ok || sourceFile != "./spec/some_test_rspec.rb" {
+		t.Fatalf("SourceFileForSuite(ci queue) = %q, %v; want Ruby path without ci-queue suffix", sourceFile, ok)
+	}
+
+	if sourceFile, ok := rspec.SourceFileForSuite("User model"); ok || sourceFile != "" {
+		t.Fatalf("SourceFileForSuite(no path) = %q, %v; want unresolved", sourceFile, ok)
+	}
+}
+
+func TestRSpec_HasUnskippableMarker(t *testing.T) {
+	tempDir := t.TempDir()
+	markedFile := filepath.Join(tempDir, "marked_spec.rb")
+	if err := os.WriteFile(markedFile, []byte("datadog_itr_unskippable"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	unmarkedFile := filepath.Join(tempDir, "unmarked_spec.rb")
+	if err := os.WriteFile(unmarkedFile, []byte("describe 'user'"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	rspec := NewRSpec()
+	if !rspec.HasUnskippableMarker(markedFile) {
+		t.Fatal("expected Ruby unskippable marker")
+	}
+	if rspec.HasUnskippableMarker(unmarkedFile) {
+		t.Fatal("expected no Ruby unskippable marker")
+	}
+	if !rspec.HasUnskippableMarker(filepath.Join(tempDir, "missing_spec.rb")) {
+		t.Fatal("expected missing file to be treated as guarded")
+	}
+}

--- a/internal/planner/discovered_tests.go
+++ b/internal/planner/discovered_tests.go
@@ -3,10 +3,13 @@ package planner
 import (
 	"context"
 	"log/slog"
+	"time"
 
 	"github.com/DataDog/ddtest/internal/discovery"
+	"github.com/DataDog/ddtest/internal/framework"
 	"github.com/DataDog/ddtest/internal/settings"
 	"github.com/DataDog/ddtest/internal/testoptimization"
+	"github.com/DataDog/ddtest/internal/testoptimization/api"
 	"github.com/DataDog/ddtest/internal/utils"
 )
 
@@ -18,7 +21,7 @@ func (tp *TestPlanner) resetDiscoveryResults() {
 
 func (tp *TestPlanner) recordFullDiscoveryResults(
 	discoveredTests []testoptimization.Test,
-	skippableTests testSkipper,
+	skippableMatcher skippableMatcher,
 ) error {
 	excluder, err := discovery.NewExcluder(settings.GetTestsExcludePattern())
 	if err != nil {
@@ -43,7 +46,7 @@ func (tp *TestPlanner) recordFullDiscoveryResults(
 				break
 			}
 		}
-		slog.Debug("Skippable tests map size for matching", "size", skippableTests.Count())
+		slog.Debug("Skippable matcher size", "size", skippableMatcher.Count())
 	}
 
 	skippableTestsCount := 0
@@ -62,7 +65,7 @@ func (tp *TestPlanner) recordFullDiscoveryResults(
 			tp.testFiles[normalizedSourceFile] = struct{}{}
 		}
 
-		if !skippableTests.Contains(test) {
+		if !skippableMatcher.Contains(test) {
 			slog.Debug("Test is not skipped", "test", test.DatadogTestId(), "sourceFile", test.SuiteSourceFile)
 			recordRunnableTest(tp.suiteAggregates, test, normalizedSourceFile)
 		} else {
@@ -79,24 +82,43 @@ func (tp *TestPlanner) recordFullDiscoveryResults(
 	return nil
 }
 
-type testSkipper struct {
-	tiaSkippableTests map[string]bool
-	disabledTests     map[string]bool
+type skippableMatcher struct {
+	tiaSkippableTests  map[string]bool
+	tiaSkippableSuites api.SkippableSuites
+	disabledTests      map[string]bool
 }
 
-func newTestSkipper(tiaSkippableTests, disabledTests map[string]bool) testSkipper {
-	return testSkipper{
-		tiaSkippableTests: tiaSkippableTests,
-		disabledTests:     disabledTests,
+func newSkippableMatcher(skippables api.Skippables, disabledTests map[string]bool) skippableMatcher {
+	if skippables.Tests == nil {
+		skippables.Tests = api.SkippableTests{}
+	}
+	if skippables.Suites == nil {
+		skippables.Suites = api.SkippableSuites{}
+	}
+	if disabledTests == nil {
+		disabledTests = map[string]bool{}
+	}
+
+	return skippableMatcher{
+		tiaSkippableTests:  skippables.Tests,
+		tiaSkippableSuites: skippables.Suites,
+		disabledTests:      disabledTests,
 	}
 }
 
-func (s testSkipper) Contains(test testoptimization.Test) bool {
-	return s.tiaSkippableTests[test.DatadogTestId()] || s.disabledTests[test.FQN()]
+func (s skippableMatcher) Contains(test testoptimization.Test) bool {
+	suite := api.SkippableSuite{Module: test.Module, Suite: test.Suite}
+	return s.tiaSkippableTests[test.DatadogTestId()] ||
+		s.tiaSkippableSuites[suite] ||
+		s.disabledTests[test.FQN()]
 }
 
-func (s testSkipper) Count() int {
-	return len(s.tiaSkippableTests) + len(s.disabledTests)
+func (s skippableMatcher) Count() int {
+	return s.TIASkippablesCount() + len(s.disabledTests)
+}
+
+func (s skippableMatcher) TIASkippablesCount() int {
+	return len(s.tiaSkippableTests) + len(s.tiaSkippableSuites)
 }
 
 func (tp *TestPlanner) recordFastDiscoveryFallbackFiles(discoveredTestFiles []string) error {
@@ -112,6 +134,78 @@ func (tp *TestPlanner) recordFastDiscoveryFallbackFiles(discoveredTestFiles []st
 		}
 	}
 	return nil
+}
+
+func (tp *TestPlanner) recordSuiteLevelSkippables(skippableMatcher skippableMatcher, testFramework framework.Framework) {
+	if len(skippableMatcher.tiaSkippableSuites) == 0 {
+		return
+	}
+
+	for suite := range skippableMatcher.tiaSkippableSuites {
+		key := testSuiteKey{Module: suite.Module, Suite: suite.Suite}
+		sourceFile, ok := tp.sourceFileForSuite(key, testFramework)
+		if !ok {
+			slog.Debug("Could not resolve source file for skippable suite; keeping file runnable", "module", suite.Module, "suite", suite.Suite)
+			continue
+		}
+		if _, ok := tp.testFiles[sourceFile]; !ok {
+			slog.Debug("Skippable suite source file was not discovered or was excluded; ignoring suite", "module", suite.Module, "suite", suite.Suite, "sourceFile", sourceFile)
+			continue
+		}
+		if testFramework.HasUnskippableMarker(sourceFile) {
+			slog.Info("Skippable suite source file contains an unskippable marker; keeping file runnable", "sourceFile", sourceFile)
+			continue
+		}
+
+		duration := float64(time.Second)
+		durationSource := testFileDurationSourceDefault
+		if suiteInfo, ok := getTestSuiteDuration(tp.testSuiteDurations, key); ok {
+			if p50, ok := parseDurationP50(suiteInfo); ok {
+				duration = p50
+				durationSource = testFileDurationSourceKnown
+			}
+		}
+
+		aggregate := tp.suiteAggregates[key]
+		aggregate.Module = key.Module
+		aggregate.Suite = key.Suite
+		aggregate.SourceFile = sourceFile
+		if aggregate.TotalDuration <= 0 {
+			aggregate.TotalDuration = duration
+		}
+		aggregate.EstimatedDuration = 0
+		if aggregate.DurationSource == "" {
+			aggregate.DurationSource = durationSource
+		}
+		if aggregate.NumTests == 0 {
+			aggregate.NumTests = 1
+		}
+		aggregate.NumTestsSkipped = aggregate.NumTests
+		tp.suiteAggregates[key] = aggregate
+	}
+}
+
+func (tp *TestPlanner) sourceFileForSuite(key testSuiteKey, testFramework framework.Framework) (string, bool) {
+	if suiteInfo, ok := getTestSuiteDuration(tp.testSuiteDurations, key); ok {
+		if sourceFile := normalizeSuiteSourceFile(suiteInfo.SourceFile); sourceFile != "" {
+			return sourceFile, true
+		}
+	}
+
+	sourceFile, ok := testFramework.SourceFileForSuite(key.Suite)
+	if !ok {
+		return "", false
+	}
+	sourceFile = normalizeSuiteSourceFile(sourceFile)
+	if sourceFile == "" {
+		return "", false
+	}
+	return sourceFile, true
+}
+
+func normalizeSuiteSourceFile(sourceFile string) string {
+	sourceFile = utils.StripCwdSubdirPrefix(sourceFile)
+	return utils.NormalizePath(sourceFile)
 }
 
 func recordRunnableTest(suiteAggregates map[testSuiteKey]testSuiteAggregate, test testoptimization.Test, sourceFile string) {

--- a/internal/planner/discovery_cache_test.go
+++ b/internal/planner/discovery_cache_test.go
@@ -176,9 +176,9 @@ func TestDiscoveryCacheHitUsesCachedTests(t *testing.T) {
 	}
 	mockOptimizationClient := &MockTestOptimizationClient{
 		Settings: testOptimizationSettings(true, true, false),
-		SkippableTests: map[string]bool{
+		Skippables: testSkippables(map[string]bool{
 			cachedTest.DatadogTestId(): true,
-		},
+		}),
 	}
 	runner := NewWithDependencies(
 		&MockPlatformDetector{Platform: mockPlatform},
@@ -221,9 +221,9 @@ func TestDiscoveryCacheMissRunsFullDiscoveryAndStoresMetadata(t *testing.T) {
 	}
 	mockOptimizationClient := &MockTestOptimizationClient{
 		Settings: testOptimizationSettings(true, true, false),
-		SkippableTests: map[string]bool{
+		Skippables: testSkippables(map[string]bool{
 			discoveredTest.DatadogTestId(): true,
-		},
+		}),
 	}
 	runner := NewWithDependencies(
 		&MockPlatformDetector{Platform: mockPlatform},
@@ -274,9 +274,9 @@ func TestDiscoveryCacheImportsExternalCacheBeforeValidation(t *testing.T) {
 	}
 	mockOptimizationClient := &MockTestOptimizationClient{
 		Settings: testOptimizationSettings(true, true, false),
-		SkippableTests: map[string]bool{
+		Skippables: testSkippables(map[string]bool{
 			cachedTest.DatadogTestId(): true,
-		},
+		}),
 	}
 	runner := NewWithDependencies(
 		&MockPlatformDetector{Platform: mockPlatform},

--- a/internal/planner/high_skippable_integration_test.go
+++ b/internal/planner/high_skippable_integration_test.go
@@ -81,9 +81,9 @@ func TestTestPlanner_Plan_HighSkippableIntegrationSelectsExpectedRunnerCountAndR
 	runner := NewWithDependencies(
 		&MockPlatformDetector{Platform: mockPlatform},
 		&MockTestOptimizationClient{
-			Settings:       testOptimizationSettings(true, true, false),
-			SkippableTests: fixture.skippableTestSet(),
-			Durations:      fixture.TestSuiteDurations,
+			Settings:   testOptimizationSettings(true, true, false),
+			Skippables: testSkippables(fixture.skippableTestSet()),
+			Durations:  fixture.TestSuiteDurations,
 		},
 		newDefaultMockCIProviderDetector(),
 	)

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -34,7 +34,7 @@ type Planner interface {
 type testOptimizationClient interface {
 	Initialize(tags map[string]string) error
 	GetSettings() *api.SettingsResponseData
-	GetSkippableTests() map[string]bool
+	GetSkippables() api.Skippables
 	GetKnownTests() *api.KnownTestsResponseData
 	GetTestManagementTestsData() *api.TestManagementTestsResponseDataModules
 	GetDisabledTests() map[string]bool
@@ -43,24 +43,27 @@ type testOptimizationClient interface {
 }
 
 type PlanInfo struct {
-	Platform    string            `json:"platform"`
-	Framework   string            `json:"framework"`
-	OSTags      map[string]string `json:"osTags"`
-	RuntimeTags map[string]string `json:"runtimeTags"`
+	Platform          string            `json:"platform"`
+	Framework         string            `json:"framework"`
+	TestSkippingLevel string            `json:"testSkippingLevel,omitempty"`
+	OSTags            map[string]string `json:"osTags"`
+	RuntimeTags       map[string]string `json:"runtimeTags"`
 }
 
-func NewPlanInfo(tags map[string]string, platformName, frameworkName string) PlanInfo {
+func NewPlanInfo(tags map[string]string, platformName, frameworkName string, testSkippingLevel settings.TestSkippingLevel) PlanInfo {
 	return PlanInfo{
-		Platform:    platformName,
-		Framework:   frameworkName,
-		OSTags:      selectTags(tags, constants.OSPlatform, constants.OSArchitecture, constants.OSVersion),
-		RuntimeTags: selectTags(tags, constants.RuntimeName, constants.RuntimeVersion),
+		Platform:          platformName,
+		Framework:         frameworkName,
+		TestSkippingLevel: testSkippingLevel.String(),
+		OSTags:            selectTags(tags, constants.OSPlatform, constants.OSArchitecture, constants.OSVersion),
+		RuntimeTags:       selectTags(tags, constants.RuntimeName, constants.RuntimeVersion),
 	}
 }
 
 func (p PlanInfo) IsZero() bool {
 	return p.Platform == "" &&
 		p.Framework == "" &&
+		p.TestSkippingLevel == "" &&
 		len(p.OSTags) == 0 &&
 		len(p.RuntimeTags) == 0
 }
@@ -79,6 +82,7 @@ type TestPlanner struct {
 	planInfo                PlanInfo
 	platformDetector        platform.PlatformDetector
 	optimizationClient      testOptimizationClient
+	newOptimizationClient   func(testSkippingLevel settings.TestSkippingLevel) testOptimizationClient
 	ciProviderDetector      environment.CIProviderDetector
 	reportWriter            io.Writer
 }
@@ -147,7 +151,9 @@ func Plan(ctx context.Context) error {
 func New() *TestPlanner {
 	planner := newTestPlannerWithDefaults()
 	planner.platformDetector = platform.NewPlatformDetector()
-	planner.optimizationClient = testoptimization.NewTestOptimizationClient()
+	planner.newOptimizationClient = func(testSkippingLevel settings.TestSkippingLevel) testOptimizationClient {
+		return testoptimization.NewTestOptimizationClientWithTestSkippingLevel(testSkippingLevel)
+	}
 	planner.ciProviderDetector = environment.NewCIProviderDetector()
 	return planner
 }
@@ -273,16 +279,26 @@ func (tp *TestPlanner) PreparePlanningData(ctx context.Context) error {
 		return fmt.Errorf("failed to detect framework: %w", err)
 	}
 	slog.Info("Framework detected", "framework", testFramework.Name())
+	testSkippingLevel := detectedPlatform.TestSkippingLevel()
+	isSuiteLevelSkipping := testSkippingLevel == settings.TestSkippingLevelSuite
+	isTestLevelSkipping := testSkippingLevel == settings.TestSkippingLevelTest
 	fullTestDiscoverySupported := testFramework.SupportsFullTestDiscovery()
+	fullDiscoveryNeeded := isTestLevelSkipping && fullTestDiscoverySupported
 	tp.runInfo = runmetadata.New(environment.GetCITags())
-	tp.planInfo = NewPlanInfo(tags, detectedPlatform.Name(), testFramework.Name())
+	tp.planInfo = NewPlanInfo(tags, detectedPlatform.Name(), testFramework.Name(), testSkippingLevel)
+	if tp.optimizationClient == nil {
+		if tp.newOptimizationClient == nil {
+			return fmt.Errorf("failed to create optimization client: missing client factory")
+		}
+		tp.optimizationClient = tp.newOptimizationClient(testSkippingLevel)
+	}
 
 	resolvedTestFiles, err := discovery.ResolveTestFiles(testFramework.TestPattern(), settings.GetTestsExcludePattern())
 	if err != nil {
 		return err
 	}
 
-	var skippedTests testSkipper
+	var skipMatcher skippableMatcher
 	var discoveredTestFiles []string
 	var discoveredTests []testoptimization.Test
 	var fullDiscoverySucceeded bool
@@ -318,7 +334,7 @@ func (tp *TestPlanner) PreparePlanningData(ctx context.Context) error {
 			slog.Debug("Repository settings", "tia_enabled", repositorySettings.ItrEnabled, "tests_skipping", repositorySettings.TestsSkipping)
 			tiaSkippingEnabled = repositorySettings.ItrEnabled && repositorySettings.TestsSkipping
 
-			if tiaSkippingEnabled && !fullTestDiscoverySupported {
+			if tiaSkippingEnabled && isTestLevelSkipping && !fullTestDiscoverySupported {
 				slog.Info("Framework does not support full test discovery; TIA skippables will not be applied during planning", "framework", testFramework.Name())
 				tiaSkippingEnabled = false
 			}
@@ -329,11 +345,11 @@ func (tp *TestPlanner) PreparePlanningData(ctx context.Context) error {
 			}
 		}
 
-		skippedTests = tp.fetchTestsToSkip(tiaSkippingEnabled)
-		tp.planReport.SkippableTestsCount = skippedTests.Count()
+		skipMatcher = tp.fetchSkippables(tiaSkippingEnabled)
+		tp.planReport.SkippableTestsCount = skipMatcher.Count()
 
-		if tiaSkippingEnabled && len(skippedTests.tiaSkippableTests) == 0 {
-			slog.Info("No TIA-skippable tests found for this run, cancelling full test discovery")
+		if tiaSkippingEnabled && skipMatcher.TIASkippablesCount() == 0 {
+			slog.Info("No TIA-skippable tests or suites found for this run, cancelling full test discovery")
 			cancelDiscovery()
 		}
 
@@ -346,7 +362,11 @@ func (tp *TestPlanner) PreparePlanningData(ctx context.Context) error {
 
 	// Goroutine 2: Tests discovery (respects context cancellation)
 	g.Go(func() error {
-		if !fullTestDiscoverySupported {
+		if !fullDiscoveryNeeded {
+			if isSuiteLevelSkipping {
+				slog.Info("Suite-level skipping does not require full test discovery; using fast test file discovery fallback", "framework", testFramework.Name())
+				return nil
+			}
 			slog.Info("Full test discovery is not supported by framework; using fast test file discovery fallback", "framework", testFramework.Name())
 			return nil
 		}
@@ -398,7 +418,7 @@ func (tp *TestPlanner) PreparePlanningData(ctx context.Context) error {
 	// backend data cancels it, use it even when TIA has no skips: full discovery
 	// is more precise than fast file discovery.
 	if fullDiscoverySucceeded {
-		if err := tp.recordFullDiscoveryResults(discoveredTests, skippedTests); err != nil {
+		if err := tp.recordFullDiscoveryResults(discoveredTests, skipMatcher); err != nil {
 			return err
 		}
 		// if we have data on which tests exist in the local repository, we will aggregate them
@@ -416,6 +436,9 @@ func (tp *TestPlanner) PreparePlanningData(ctx context.Context) error {
 			return err
 		}
 		tp.addDurationDataForFastDiscoveryFallback()
+		if isSuiteLevelSkipping && tiaSkippingEnabled {
+			tp.recordSuiteLevelSkippables(skipMatcher, testFramework)
+		}
 
 		slog.Info("Full test discovery did not run or failed; using fast test file discovery fallback",
 			"fastDiscoveredTestFilesCount", len(discoveredTestFiles))
@@ -457,25 +480,27 @@ func discoverLocalTests(ctx context.Context, testFramework framework.Framework, 
 	return tests, nil
 }
 
-func (tp *TestPlanner) fetchTestsToSkip(tiaSkippingEnabled bool) testSkipper {
+func (tp *TestPlanner) fetchSkippables(tiaSkippingEnabled bool) skippableMatcher {
 	startTime := time.Now()
-	slog.Info("Fetching tests to skip from Datadog...")
+	slog.Info("Fetching skippables from Datadog...")
 
-	tiaSkippableTests := map[string]bool{}
+	skippables := api.NewSkippables()
 	if tiaSkippingEnabled {
-		tiaSkippableTests = tp.optimizationClient.GetSkippableTests()
+		skippables = tp.optimizationClient.GetSkippables()
 	}
 
 	tp.planReport.KnownTests = newKnownTestsReport(tp.optimizationClient.GetKnownTests())
-	tp.planReport.ManagedFlakyTests = newManagedFlakyTestsReport(tp.optimizationClient.GetTestManagementTestsData())
+	testManagementTestsData := tp.optimizationClient.GetTestManagementTestsData()
+	tp.planReport.ManagedFlakyTests = newManagedFlakyTestsReport(testManagementTestsData)
 
 	disabledTests := tp.optimizationClient.GetDisabledTests()
-	slog.Info("Fetched tests to skip",
+	slog.Info("Fetched skippables",
 		"duration", time.Since(startTime),
-		"tiaSkippableTestsCount", len(tiaSkippableTests),
+		"tiaSkippableTestsCount", len(skippables.Tests),
+		"tiaSkippableSuitesCount", len(skippables.Suites),
 		"disabledTestsCount", len(disabledTests))
 
-	return newTestSkipper(tiaSkippableTests, disabledTests)
+	return newSkippableMatcher(skippables, disabledTests)
 }
 
 func (tp *TestPlanner) estimateDiscoveredSuiteDurations() {
@@ -524,8 +549,9 @@ func (tp *TestPlanner) addDurationDataForFastDiscoveryFallback() {
 				continue
 			}
 
-			// Backend durations can contain duplicate suite names for the same source file.
-			// Fast discovery only tells us the file exists, so keep one backend fallback row per file.
+			// Fast discovery only sees files, not test cases. For suite-level TIA we
+			// assume a single backend suite maps to a single source file, so one
+			// duration-backed aggregate per source file is enough and avoids double-counting.
 			if _, ok := seenSourceFiles[sourceFile]; ok {
 				continue
 			}

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -49,6 +49,7 @@ type MockPlatform struct {
 	Framework    framework.Framework
 	FrameworkErr error
 	SanityErr    error
+	TestLevel    settings.TestSkippingLevel
 }
 
 func (m *MockPlatform) Name() string {
@@ -67,6 +68,13 @@ func (m *MockPlatform) SanityCheck() error {
 	return m.SanityErr
 }
 
+func (m *MockPlatform) TestSkippingLevel() settings.TestSkippingLevel {
+	if m.TestLevel == "" {
+		return settings.TestSkippingLevelTest
+	}
+	return m.TestLevel
+}
+
 // MockFramework mocks a testing framework
 type MockFramework struct {
 	FrameworkName            string
@@ -79,6 +87,8 @@ type MockFramework struct {
 	RunTestsCalls            []RunTestsCall
 	DiscoverTestsFiles       []discovery.TestFileSet
 	FullDiscoveryUnsupported bool
+	SuiteSourceFiles         map[string]string
+	UnskippableFiles         map[string]bool
 	mu                       sync.Mutex
 }
 
@@ -292,6 +302,21 @@ func (m *MockFramework) SupportsFullTestDiscovery() bool {
 	return !m.FullDiscoveryUnsupported
 }
 
+func (m *MockFramework) SourceFileForSuite(suite string) (string, bool) {
+	if m.SuiteSourceFiles != nil {
+		sourceFile, ok := m.SuiteSourceFiles[suite]
+		return sourceFile, ok
+	}
+	if suite == "" {
+		return "", false
+	}
+	return suite, true
+}
+
+func (m *MockFramework) HasUnskippableMarker(testFile string) bool {
+	return m.UnskippableFiles[testFile]
+}
+
 func (m *MockFramework) GetRunTestsCallsCount() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -315,18 +340,26 @@ func (m *longRunningDiscoveryFramework) DiscoverTests(ctx context.Context, testF
 
 // MockTestOptimizationClient mocks the test optimization client
 type MockTestOptimizationClient struct {
-	InitializeCalled        bool
-	InitializeErr           error
-	Settings                *api.SettingsResponseData
-	SkippableTests          map[string]bool
-	GetSkippableTestsCalled bool
-	KnownTests              *api.KnownTestsResponseData
-	TestManagementTests     *api.TestManagementTestsResponseDataModules
-	DisabledTests           map[string]bool
-	Durations               map[string]map[string]api.TestSuiteDurationInfo
-	DurationsCalled         bool
-	ShutdownCalled          bool
-	Tags                    map[string]string
+	InitializeCalled    bool
+	InitializeErr       error
+	Settings            *api.SettingsResponseData
+	Skippables          api.Skippables
+	GetSkippablesCalled bool
+	KnownTests          *api.KnownTestsResponseData
+	TestManagementTests *api.TestManagementTestsResponseDataModules
+	DisabledTests       map[string]bool
+	Durations           map[string]map[string]api.TestSuiteDurationInfo
+	DurationsCalled     bool
+	ShutdownCalled      bool
+	Tags                map[string]string
+}
+
+func testSkippables(tests map[string]bool) api.Skippables {
+	skippables := api.NewSkippables()
+	if tests != nil {
+		skippables.Tests = api.SkippableTests(tests)
+	}
+	return skippables
 }
 
 func (m *MockTestOptimizationClient) Initialize(tags map[string]string) error {
@@ -342,9 +375,16 @@ func (m *MockTestOptimizationClient) GetSettings() *api.SettingsResponseData {
 	return m.Settings
 }
 
-func (m *MockTestOptimizationClient) GetSkippableTests() map[string]bool {
-	m.GetSkippableTestsCalled = true
-	return m.SkippableTests
+func (m *MockTestOptimizationClient) GetSkippables() api.Skippables {
+	m.GetSkippablesCalled = true
+	skippables := m.Skippables
+	if skippables.Tests == nil {
+		skippables.Tests = api.SkippableTests{}
+	}
+	if skippables.Suites == nil {
+		skippables.Suites = api.SkippableSuites{}
+	}
+	return skippables
 }
 
 func (m *MockTestOptimizationClient) GetKnownTests() *api.KnownTestsResponseData {
@@ -494,9 +534,9 @@ func testOptimizationClientRequiringFullDiscovery() *MockTestOptimizationClient 
 	}
 	return &MockTestOptimizationClient{
 		Settings: testOptimizationSettings(true, true, false),
-		SkippableTests: map[string]bool{
+		Skippables: testSkippables(map[string]bool{
 			unmatchedSkippableTest.DatadogTestId(): true,
-		},
+		}),
 	}
 }
 
@@ -528,8 +568,8 @@ func TestNew(t *testing.T) {
 		t.Error("New() should initialize platformDetector")
 	}
 
-	if runner.optimizationClient == nil {
-		t.Error("New() should initialize optimizationClient")
+	if runner.newOptimizationClient == nil {
+		t.Error("New() should initialize optimization client factory")
 	}
 }
 
@@ -563,6 +603,53 @@ func TestNewWithDependencies(t *testing.T) {
 
 	if len(runner.suitesBySourceFile) != 0 {
 		t.Error("NewWithDependencies() should initialize suitesBySourceFile to empty map")
+	}
+}
+
+func TestTestPlanner_PreparePlanningData_CreatesOptimizationClientWithDetectedTestSkippingLevel(t *testing.T) {
+	tempDir := t.TempDir()
+	oldWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldWd) }()
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+	if err := os.MkdirAll("src", 0o755); err != nil {
+		t.Fatalf("failed to create test directory: %v", err)
+	}
+	if err := os.WriteFile("src/a.test.js", []byte("test('a', () => {})"), 0o644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	mockOptimizationClient := &MockTestOptimizationClient{
+		Settings: testOptimizationSettings(false, false, false),
+	}
+	var capturedLevel settings.TestSkippingLevel
+	runner := newTestPlannerWithDefaults()
+	runner.platformDetector = &MockPlatformDetector{Platform: &MockPlatform{
+		PlatformName: "javascript",
+		Tags:         map[string]string{},
+		Framework: &MockFramework{
+			FrameworkName:            "jest",
+			TestFiles:                []string{"src/a.test.js"},
+			FullDiscoveryUnsupported: true,
+			SuiteSourceFiles: map[string]string{
+				"src/a.test.js": "src/a.test.js",
+			},
+		},
+		TestLevel: settings.TestSkippingLevelSuite,
+	}}
+	runner.newOptimizationClient = func(testSkippingLevel settings.TestSkippingLevel) testOptimizationClient {
+		capturedLevel = testSkippingLevel
+		return mockOptimizationClient
+	}
+	runner.ciProviderDetector = newDefaultMockCIProviderDetector()
+
+	if err := runner.PreparePlanningData(context.Background()); err != nil {
+		t.Fatalf("PreparePlanningData() should not return error, got: %v", err)
+	}
+
+	if capturedLevel != settings.TestSkippingLevelSuite {
+		t.Fatalf("optimization client test skipping level = %q, want %q", capturedLevel, settings.TestSkippingLevelSuite)
 	}
 }
 
@@ -609,10 +696,10 @@ func TestTestPlanner_Setup_WithParallelRunners(t *testing.T) {
 	mockPlatformDetector := &MockPlatformDetector{Platform: mockPlatform}
 	mockOptimizationClient := &MockTestOptimizationClient{
 		Settings: testOptimizationSettings(true, true, false),
-		SkippableTests: map[string]bool{
+		Skippables: testSkippables(map[string]bool{
 			(&testoptimization.Test{Module: "rspec", Suite: "TestSuite1", Name: "test2"}).DatadogTestId(): true, // Skip test2
 			(&testoptimization.Test{Module: "rspec", Suite: "TestSuite4", Name: "test5"}).DatadogTestId(): true, // Skip test5
-		},
+		}),
 	}
 
 	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, newDefaultMockCIProviderDetector())
@@ -685,7 +772,7 @@ func TestTestPlanner_Plan_WritesManifestAndRunnerLayout(t *testing.T) {
 
 	runner := NewWithDependencies(
 		&MockPlatformDetector{Platform: mockPlatform},
-		&MockTestOptimizationClient{SkippableTests: map[string]bool{}},
+		&MockTestOptimizationClient{Skippables: testSkippables(map[string]bool{})},
 		newDefaultMockCIProviderDetector(),
 	)
 
@@ -704,7 +791,7 @@ func TestTestPlanner_Plan_WritesManifestAndRunnerLayout(t *testing.T) {
 	assertFileContent(t, filepath.Join(constants.TestsSplitDir, "runner-0"), expectedTestFiles)
 }
 
-func TestTestPlanner_Plan_FrameworkWithoutFullDiscoveryDoesNotFetchSkippables(t *testing.T) {
+func TestTestPlanner_Plan_JestSuiteSkippingFetchesSkippablesWithoutFullDiscovery(t *testing.T) {
 	tempDir := t.TempDir()
 	oldWd, _ := os.Getwd()
 	defer func() { _ = os.Chdir(oldWd) }()
@@ -727,10 +814,21 @@ func TestTestPlanner_Plan_FrameworkWithoutFullDiscoveryDoesNotFetchSkippables(t 
 		PlatformName: "javascript",
 		Tags:         map[string]string{"language": "javascript"},
 		Framework:    mockFramework,
+		TestLevel:    settings.TestSkippingLevelSuite,
 	}
 	mockOptimizationClient := &MockTestOptimizationClient{
-		Settings:       testOptimizationSettings(true, true, false),
-		SkippableTests: map[string]bool{"jest.src/a.test.js..": true},
+		Settings: testOptimizationSettings(true, true, false),
+		Skippables: api.Skippables{
+			Suites: api.SkippableSuites{
+				{Module: "jest", Suite: "src/a.test.js"}: true,
+			},
+		},
+		Durations: map[string]map[string]api.TestSuiteDurationInfo{
+			"jest": {
+				"src/a.test.js": {SourceFile: "src/a.test.js", Duration: api.DurationPercentiles{P50: "1000000000"}},
+				"src/b.test.ts": {SourceFile: "src/b.test.ts", Duration: api.DurationPercentiles{P50: "1000000000"}},
+			},
+		},
 	}
 
 	runner := NewWithDependencies(
@@ -743,14 +841,182 @@ func TestTestPlanner_Plan_FrameworkWithoutFullDiscoveryDoesNotFetchSkippables(t 
 		t.Fatalf("Plan() should not return error, got: %v", err)
 	}
 
-	if mockOptimizationClient.GetSkippableTestsCalled {
-		t.Fatal("expected planner not to fetch skippables when full test discovery is unsupported")
+	if !mockOptimizationClient.GetSkippablesCalled {
+		t.Fatal("expected planner to fetch suite skippables when full test discovery is unsupported")
 	}
 
-	expectedTestFiles := "src/a.test.js\nsrc/b.test.ts\n"
+	expectedTestFiles := "src/b.test.ts\n"
 	assertFileContent(t, constants.TestFilesOutputPath, expectedTestFiles)
-	assertFileContent(t, constants.SkippablePercentageOutputPath, "0.00")
+	assertFileContent(t, constants.SkippablePercentageOutputPath, "50.00")
 	assertFileContent(t, filepath.Join(constants.TestsSplitDir, "runner-0"), expectedTestFiles)
+}
+
+func TestTestPlanner_PreparePlanningData_RubySuiteModeSkipsFullDiscoveryAndSkipsFile(t *testing.T) {
+	tempDir := t.TempDir()
+	oldWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldWd) }()
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+
+	t.Cleanup(func() { settings.Init() })
+	t.Setenv("DD_TEST_OPTIMIZATION_RUNNER_REPORT_ENABLED", "false")
+	settings.Init()
+
+	skippedSuite := "Order at spec/models/order_spec.rb"
+	runnableSuite := "Payment at spec/models/payment_spec.rb"
+	mockFramework := &MockFramework{
+		FrameworkName: "rspec",
+		TestFiles:     []string{"spec/models/order_spec.rb", "spec/models/payment_spec.rb"},
+		SuiteSourceFiles: map[string]string{
+			skippedSuite:  "spec/models/order_spec.rb",
+			runnableSuite: "spec/models/payment_spec.rb",
+		},
+		OnDiscoverTests: func() {
+			t.Fatal("full discovery should not run in suite skipping mode")
+		},
+	}
+	mockPlatform := &MockPlatform{
+		PlatformName: "ruby",
+		Tags:         map[string]string{"language": "ruby"},
+		Framework:    mockFramework,
+		TestLevel:    settings.TestSkippingLevelSuite,
+	}
+	mockOptimizationClient := &MockTestOptimizationClient{
+		Settings: testOptimizationSettings(true, true, false),
+		Skippables: api.Skippables{
+			Suites: api.SkippableSuites{
+				{Module: "rspec", Suite: skippedSuite}: true,
+			},
+		},
+		Durations: map[string]map[string]api.TestSuiteDurationInfo{
+			"rspec": {
+				skippedSuite:  {SourceFile: "spec/models/order_spec.rb", Duration: api.DurationPercentiles{P50: "1000000000"}},
+				runnableSuite: {SourceFile: "spec/models/payment_spec.rb", Duration: api.DurationPercentiles{P50: "1000000000"}},
+			},
+		},
+	}
+
+	runner := NewWithDependencies(
+		&MockPlatformDetector{Platform: mockPlatform},
+		mockOptimizationClient,
+		newDefaultMockCIProviderDetector(),
+	)
+
+	if err := runner.PreparePlanningData(context.Background()); err != nil {
+		t.Fatalf("PreparePlanningData() should not return error, got: %v", err)
+	}
+
+	if len(mockFramework.DiscoverTestsFiles) != 0 {
+		t.Fatalf("expected full discovery not to run, got calls: %+v", mockFramework.DiscoverTestsFiles)
+	}
+	if _, ok := runner.testFileWeights["spec/models/order_spec.rb"]; ok {
+		t.Fatalf("expected skipped suite file to be omitted, got weights: %+v", runner.testFileWeights)
+	}
+	if _, ok := runner.testFileWeights["spec/models/payment_spec.rb"]; !ok {
+		t.Fatalf("expected runnable suite file to remain, got weights: %+v", runner.testFileWeights)
+	}
+	if runner.planInfo.TestSkippingLevel != settings.TestSkippingLevelSuite.String() {
+		t.Fatalf("plan test skipping level = %q, want suite", runner.planInfo.TestSkippingLevel)
+	}
+}
+
+func TestTestPlanner_RecordFullDiscoveryResults_SuiteSkippablesSkipDiscoveredTests(t *testing.T) {
+	runner := newTestPlannerWithDefaults()
+	tests := []testoptimization.Test{
+		{Module: "rspec", Suite: "Order", Name: "first", SuiteSourceFile: "spec/models/order_spec.rb"},
+		{Module: "rspec", Suite: "Order", Name: "second", SuiteSourceFile: "spec/models/order_spec.rb"},
+	}
+	skippables := api.Skippables{
+		Suites: api.SkippableSuites{
+			{Module: "rspec", Suite: "Order"}: true,
+		},
+	}
+
+	if err := runner.recordFullDiscoveryResults(tests, newSkippableMatcher(skippables, nil)); err != nil {
+		t.Fatalf("recordFullDiscoveryResults() should not fail, got: %v", err)
+	}
+
+	aggregate := runner.suiteAggregates[testSuiteKey{Module: "rspec", Suite: "Order"}]
+	if aggregate.NumTests != 2 || aggregate.NumTestsSkipped != 2 {
+		t.Fatalf("expected whole suite to be skipped, got %+v", aggregate)
+	}
+}
+
+func TestTestPlanner_RecordSuiteLevelSkippables_SafetyGuardsKeepFilesRunnable(t *testing.T) {
+	tests := []struct {
+		name         string
+		testFiles    map[string]struct{}
+		durations    map[string]map[string]api.TestSuiteDurationInfo
+		framework    *MockFramework
+		expectedFile string
+	}{
+		{
+			name:      "unskippable marker",
+			testFiles: map[string]struct{}{"spec/models/order_spec.rb": {}},
+			durations: map[string]map[string]api.TestSuiteDurationInfo{
+				"rspec": {
+					"Order at spec/models/order_spec.rb": {SourceFile: "spec/models/order_spec.rb", Duration: api.DurationPercentiles{P50: "1000000000"}},
+				},
+			},
+			framework: &MockFramework{
+				UnskippableFiles: map[string]bool{"spec/models/order_spec.rb": true},
+			},
+			expectedFile: "spec/models/order_spec.rb",
+		},
+		{
+			name:      "unresolved suite source",
+			testFiles: map[string]struct{}{"spec/models/order_spec.rb": {}},
+			framework: &MockFramework{
+				SuiteSourceFiles: map[string]string{},
+			},
+			expectedFile: "spec/models/order_spec.rb",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := newTestPlannerWithDefaults()
+			runner.testFiles = tt.testFiles
+			runner.testSuiteDurations = tt.durations
+			runner.addDurationDataForFastDiscoveryFallback()
+			skippables := api.Skippables{
+				Suites: api.SkippableSuites{
+					{Module: "rspec", Suite: "Order at spec/models/order_spec.rb"}:   true,
+					{Module: "rspec", Suite: "Skipped at spec/models/order_spec.rb"}: true,
+				},
+			}
+
+			runner.recordSuiteLevelSkippables(newSkippableMatcher(skippables, nil), tt.framework)
+			runner.suitesBySourceFile = indexSuitesBySourceFile(runner.suiteAggregates)
+			weights := runner.calculateFileWeights()
+
+			if _, ok := weights[tt.expectedFile]; !ok {
+				t.Fatalf("expected %s to remain runnable, got weights %+v and aggregates %+v", tt.expectedFile, weights, runner.suiteAggregates)
+			}
+		})
+	}
+}
+
+func TestTestPlanner_RecordSuiteLevelSkippables_IgnoresExcludedOrUndiscoveredFile(t *testing.T) {
+	runner := newTestPlannerWithDefaults()
+	runner.testFiles = map[string]struct{}{"spec/models/payment_spec.rb": {}}
+	skippables := api.Skippables{
+		Suites: api.SkippableSuites{
+			{Module: "rspec", Suite: "Order at spec/models/order_spec.rb"}: true,
+		},
+	}
+	framework := &MockFramework{
+		SuiteSourceFiles: map[string]string{
+			"Order at spec/models/order_spec.rb": "spec/models/order_spec.rb",
+		},
+	}
+
+	runner.recordSuiteLevelSkippables(newSkippableMatcher(skippables, nil), framework)
+
+	if len(runner.suiteAggregates) != 0 {
+		t.Fatalf("expected suite for undiscovered file to be ignored, got %+v", runner.suiteAggregates)
+	}
 }
 
 func TestTestPlanner_Plan_DoesNotPrintReportWhenDisabled(t *testing.T) {
@@ -784,7 +1050,7 @@ func TestTestPlanner_Plan_DoesNotPrintReportWhenDisabled(t *testing.T) {
 
 	runner := NewWithDependencies(
 		&MockPlatformDetector{Platform: mockPlatform},
-		&MockTestOptimizationClient{SkippableTests: map[string]bool{}},
+		&MockTestOptimizationClient{Skippables: testSkippables(map[string]bool{})},
 		newDefaultMockCIProviderDetector(),
 	)
 	var output strings.Builder
@@ -846,8 +1112,8 @@ func TestTestPlanner_Plan_ChoosesParallelismFromFanoutAdjustedSplit(t *testing.T
 	runner := NewWithDependencies(
 		&MockPlatformDetector{Platform: mockPlatform},
 		&MockTestOptimizationClient{
-			Settings:       testOptimizationSettings(true, true, false),
-			SkippableTests: skippableTests,
+			Settings:   testOptimizationSettings(true, true, false),
+			Skippables: testSkippables(skippableTests),
 		},
 		newDefaultMockCIProviderDetector(),
 	)
@@ -898,9 +1164,9 @@ func TestTestPlanner_Setup_WithCIProvider(t *testing.T) {
 	mockPlatformDetector := &MockPlatformDetector{Platform: mockPlatform}
 	mockOptimizationClient := &MockTestOptimizationClient{
 		Settings: testOptimizationSettings(true, true, false),
-		SkippableTests: map[string]bool{
+		Skippables: testSkippables(map[string]bool{
 			(&testoptimization.Test{Module: "rspec", Suite: "TestSuite1", Name: "test1"}).DatadogTestId(): true, // Skip test1 = 50% skippable
-		},
+		}),
 	}
 
 	// Mock CI provider that should be called
@@ -958,7 +1224,7 @@ func TestTestPlanner_Setup_CIProviderDetectionFailure(t *testing.T) {
 	}
 
 	mockPlatformDetector := &MockPlatformDetector{Platform: mockPlatform}
-	mockOptimizationClient := &MockTestOptimizationClient{SkippableTests: map[string]bool{}}
+	mockOptimizationClient := &MockTestOptimizationClient{Skippables: testSkippables(map[string]bool{})}
 
 	// Mock CI provider detector that fails
 	mockCIProviderDetector := &MockCIProviderDetector{
@@ -999,7 +1265,7 @@ func TestTestPlanner_Setup_CIProviderConfigureFailure(t *testing.T) {
 	}
 
 	mockPlatformDetector := &MockPlatformDetector{Platform: mockPlatform}
-	mockOptimizationClient := &MockTestOptimizationClient{SkippableTests: map[string]bool{}}
+	mockOptimizationClient := &MockTestOptimizationClient{Skippables: testSkippables(map[string]bool{})}
 
 	// Mock CI provider that fails during configuration
 	mockCIProvider := &MockCIProvider{
@@ -1064,7 +1330,7 @@ func TestTestPlanner_Setup_WithTestSplit(t *testing.T) {
 
 		mockPlatformDetector := &MockPlatformDetector{Platform: mockPlatform}
 		mockOptimizationClient := &MockTestOptimizationClient{
-			SkippableTests: map[string]bool{}, // No tests skipped
+			Skippables: testSkippables(map[string]bool{}), // No tests skipped
 		}
 
 		runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, newDefaultMockCIProviderDetector())
@@ -1141,7 +1407,7 @@ func TestTestPlanner_Setup_WithTestSplit(t *testing.T) {
 
 		mockPlatformDetector := &MockPlatformDetector{Platform: mockPlatform}
 		mockOptimizationClient := &MockTestOptimizationClient{
-			SkippableTests: map[string]bool{}, // No tests skipped
+			Skippables: testSkippables(map[string]bool{}), // No tests skipped
 		}
 
 		expectedParallelRunnersCount := 2
@@ -1357,10 +1623,10 @@ func TestTestPlanner_PreparePlanningData_Success(t *testing.T) {
 
 	mockOptimizationClient := &MockTestOptimizationClient{
 		Settings: testOptimizationSettings(true, true, false),
-		SkippableTests: map[string]bool{
+		Skippables: testSkippables(map[string]bool{
 			(&testoptimization.Test{Module: "rspec", Suite: "TestSuite1", Name: "test2"}).DatadogTestId(): true, // Skip test2
 			(&testoptimization.Test{Module: "rspec", Suite: "TestSuite3", Name: "test4"}).DatadogTestId(): true, // Skip test4
-		},
+		}),
 		Durations: map[string]map[string]api.TestSuiteDurationInfo{
 			"rspec": {
 				"TestSuite1": {
@@ -1477,9 +1743,9 @@ func TestTestPlanner_PreparePlanningData_DisabledTestManagementTestsAreSkipped(t
 	}
 	mockOptimizationClient := &MockTestOptimizationClient{
 		Settings: testOptimizationSettings(true, true, true),
-		SkippableTests: map[string]bool{
+		Skippables: testSkippables(map[string]bool{
 			(&testoptimization.Test{Module: "rspec", Suite: "Suite1", Name: "test2"}).DatadogTestId(): true,
-		},
+		}),
 		TestManagementTests: &api.TestManagementTestsResponseDataModules{
 			Modules: map[string]api.TestManagementTestsResponseDataSuites{
 				"rspec": {
@@ -1577,10 +1843,10 @@ func TestTestPlanner_PreparePlanningData_TIASkipsRequireParametersMatch(t *testi
 	}
 	mockOptimizationClient := &MockTestOptimizationClient{
 		Settings: testOptimizationSettings(true, true, false),
-		SkippableTests: map[string]bool{
+		Skippables: testSkippables(map[string]bool{
 			(&testoptimization.Test{Module: "rspec", Suite: "Suite1", Name: "same name"}).DatadogTestId(): true,
 			parameterizedSkippedTest.DatadogTestId():                                                      true,
-		},
+		}),
 	}
 
 	runner := NewWithDependencies(
@@ -1620,9 +1886,9 @@ func TestTestPlanner_PreparePlanningData_ModuleQualifiedSkipsDoNotCrossModules(t
 	}
 	mockOptimizationClient := &MockTestOptimizationClient{
 		Settings: testOptimizationSettings(true, true, true),
-		SkippableTests: map[string]bool{
+		Skippables: testSkippables(map[string]bool{
 			(&testoptimization.Test{Module: "module-a", Suite: "SharedSuite", Name: "same name"}).DatadogTestId(): true,
-		},
+		}),
 		TestManagementTests: &api.TestManagementTestsResponseDataModules{
 			Modules: map[string]api.TestManagementTestsResponseDataSuites{
 				"module-c": {
@@ -1686,9 +1952,9 @@ func TestTestPlanner_PreparePlanningData_TestManagementDoesNotKeepFullDiscoveryW
 	}
 	mockOptimizationClient := &MockTestOptimizationClient{
 		Settings: testOptimizationSettings(false, false, true),
-		SkippableTests: map[string]bool{
+		Skippables: testSkippables(map[string]bool{
 			(&testoptimization.Test{Module: "rspec", Suite: "Suite2", Name: "not_applied"}).DatadogTestId(): true,
-		},
+		}),
 		TestManagementTests: &api.TestManagementTestsResponseDataModules{
 			Modules: map[string]api.TestManagementTestsResponseDataSuites{
 				"rspec": {
@@ -1755,8 +2021,8 @@ func TestTestPlanner_PreparePlanningData_CancelsFullDiscoveryWhenNoTIASkippableT
 		Framework:    mockFramework,
 	}
 	mockOptimizationClient := &MockTestOptimizationClient{
-		Settings:       testOptimizationSettings(true, true, false),
-		SkippableTests: map[string]bool{},
+		Settings:   testOptimizationSettings(true, true, false),
+		Skippables: testSkippables(map[string]bool{}),
 	}
 
 	runner := NewWithDependencies(
@@ -1778,7 +2044,7 @@ func TestTestPlanner_PreparePlanningData_CancelsFullDiscoveryWhenNoTIASkippableT
 	if runner.skippablePercentage != 0 {
 		t.Errorf("Expected zero skippable percentage without full discovery data, got %.2f", runner.skippablePercentage)
 	}
-	if !strings.Contains(logs.String(), "No TIA-skippable tests found for this run, cancelling full test discovery") {
+	if !strings.Contains(logs.String(), "No TIA-skippable tests or suites found for this run, cancelling full test discovery") {
 		t.Errorf("Expected log about skipping full discovery when no TIA-skippable tests exist, got: %s", logs.String())
 	}
 }
@@ -1815,9 +2081,9 @@ func TestTestPlanner_PreparePlanningData_RunsFullDiscoveryInParallelWithBackend(
 	mockOptimizationClient := &waitForDiscoveryOptimizationClient{
 		MockTestOptimizationClient: MockTestOptimizationClient{
 			Settings: testOptimizationSettings(true, true, false),
-			SkippableTests: map[string]bool{
+			Skippables: testSkippables(map[string]bool{
 				discoveredTest.DatadogTestId(): true,
-			},
+			}),
 		},
 		discoveryStarted: discoveryStarted,
 	}
@@ -1861,8 +2127,8 @@ func TestTestPlanner_PreparePlanningData_UsesCompletedFullDiscoveryWhenNoTIASkip
 		Framework:    mockFramework,
 	}
 	mockOptimizationClient := &MockTestOptimizationClient{
-		Settings:       testOptimizationSettings(true, true, false),
-		SkippableTests: map[string]bool{},
+		Settings:   testOptimizationSettings(true, true, false),
+		Skippables: testSkippables(map[string]bool{}),
 	}
 
 	runner := NewWithDependencies(
@@ -2010,8 +2276,8 @@ func TestTestPlanner_PreparePlanningData_SkippablePercentageUsesDurations(t *tes
 	}
 	skippedTest := mockFramework.Tests[0]
 	mockOptimizationClient := &MockTestOptimizationClient{
-		Settings:       testOptimizationSettings(true, true, false),
-		SkippableTests: map[string]bool{skippedTest.DatadogTestId(): true},
+		Settings:   testOptimizationSettings(true, true, false),
+		Skippables: testSkippables(map[string]bool{skippedTest.DatadogTestId(): true}),
 		Durations: map[string]map[string]api.TestSuiteDurationInfo{
 			"rspec": {
 				"SlowSuite": {
@@ -2710,8 +2976,8 @@ func TestTestPlanner_PreparePlanningData_BackendDoesNotReintroduceFullySkippedSu
 		Framework: mockFramework,
 	}
 	mockOptimizationClient := &MockTestOptimizationClient{
-		Settings:       testOptimizationSettings(true, true, false),
-		SkippableTests: map[string]bool{skippedTest.DatadogTestId(): true},
+		Settings:   testOptimizationSettings(true, true, false),
+		Skippables: testSkippables(map[string]bool{skippedTest.DatadogTestId(): true}),
 		Durations: map[string]map[string]api.TestSuiteDurationInfo{
 			"rspec": {
 				"SkippedSuite": {
@@ -2764,8 +3030,8 @@ func TestTestPlanner_PreparePlanningData_BackendDoesNotDuplicateDiscoveredSource
 		Framework: mockFramework,
 	}
 	mockOptimizationClient := &MockTestOptimizationClient{
-		Settings:       testOptimizationSettings(true, true, false),
-		SkippableTests: map[string]bool{skippedTest.DatadogTestId(): true},
+		Settings:   testOptimizationSettings(true, true, false),
+		Skippables: testSkippables(map[string]bool{skippedTest.DatadogTestId(): true}),
 		Durations: map[string]map[string]api.TestSuiteDurationInfo{
 			"rspec": {
 				"BackendDuplicateSuite": {
@@ -2821,7 +3087,7 @@ func TestTestPlanner_RecordFullDiscoveryResults_AppliesExcludeAfterSubdirNormali
 		},
 	}
 
-	err := runner.recordFullDiscoveryResults(tests, newTestSkipper(nil, nil))
+	err := runner.recordFullDiscoveryResults(tests, newSkippableMatcher(api.NewSkippables(), nil))
 	if err != nil {
 		t.Fatalf("recordFullDiscoveryResults() should not fail, got: %v", err)
 	}
@@ -2912,9 +3178,9 @@ func TestTestPlanner_PreparePlanningData_ResolvesFilteredTestFilesOnce(t *testin
 	}
 	mockOptimizationClient := &MockTestOptimizationClient{
 		Settings: testOptimizationSettings(true, true, false),
-		SkippableTests: map[string]bool{
+		Skippables: testSkippables(map[string]bool{
 			(&testoptimization.Test{Module: "rspec", Suite: "User", Name: "test1"}).DatadogTestId(): true,
-		},
+		}),
 	}
 	runner := NewWithDependencies(
 		&MockPlatformDetector{Platform: mockPlatform},
@@ -3227,9 +3493,9 @@ func TestTestPlanner_PreparePlanningData_EmptyTests(t *testing.T) {
 	mockPlatformDetector := &MockPlatformDetector{Platform: mockPlatform}
 	mockOptimizationClient := &MockTestOptimizationClient{
 		Settings: testOptimizationSettings(true, true, false),
-		SkippableTests: map[string]bool{
+		Skippables: testSkippables(map[string]bool{
 			(&testoptimization.Test{Module: "rspec", Suite: "Suite", Name: "test1"}).DatadogTestId(): true,
-		},
+		}),
 	}
 
 	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, newDefaultMockCIProviderDetector())
@@ -3278,10 +3544,10 @@ func TestTestPlanner_PreparePlanningData_AllTestsSkipped(t *testing.T) {
 	mockPlatformDetector := &MockPlatformDetector{Platform: mockPlatform}
 	mockOptimizationClient := &MockTestOptimizationClient{
 		Settings: testOptimizationSettings(true, true, false),
-		SkippableTests: map[string]bool{
+		Skippables: testSkippables(map[string]bool{
 			(&testoptimization.Test{Module: "rspec", Suite: "Suite1", Name: "test1"}).DatadogTestId(): true,
 			(&testoptimization.Test{Module: "rspec", Suite: "Suite2", Name: "test2"}).DatadogTestId(): true,
-		},
+		}),
 	}
 
 	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, newDefaultMockCIProviderDetector())
@@ -3336,7 +3602,7 @@ func TestTestPlanner_PreparePlanningData_RuntimeTagsOverride(t *testing.T) {
 	}
 
 	mockOptimizationClient := &MockTestOptimizationClient{
-		SkippableTests: map[string]bool{},
+		Skippables: testSkippables(map[string]bool{}),
 	}
 
 	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, newDefaultMockCIProviderDetector())
@@ -3446,7 +3712,7 @@ func TestTestPlanner_PreparePlanningData_NoRuntimeTagsOverride(t *testing.T) {
 	}
 
 	mockOptimizationClient := &MockTestOptimizationClient{
-		SkippableTests: map[string]bool{},
+		Skippables: testSkippables(map[string]bool{}),
 	}
 
 	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, newDefaultMockCIProviderDetector())
@@ -3779,10 +4045,10 @@ func TestPreparePlanningData_ITRSubdir_SkipMatching_WithSuitePathsMatchingCwd(t 
 	}
 	mockOptimizationClient := &MockTestOptimizationClient{
 		Settings: testOptimizationSettings(true, true, false),
-		SkippableTests: map[string]bool{
+		Skippables: testSkippables(map[string]bool{
 			roleTest1.DatadogTestId(): true,
 			roleTest2.DatadogTestId(): true,
-		},
+		}),
 	}
 
 	runner := NewWithDependencies(mockPlatformDetector, mockOptimizationClient, newDefaultMockCIProviderDetector())

--- a/internal/planner/test_optimization_plan_cache_test.go
+++ b/internal/planner/test_optimization_plan_cache_test.go
@@ -43,7 +43,7 @@ func TestTestPlanner_Plan_StoresTestOptimizationPlanCache(t *testing.T) {
 	}
 	runner := NewWithDependencies(
 		&MockPlatformDetector{Platform: mockPlatform},
-		&MockTestOptimizationClient{SkippableTests: map[string]bool{}},
+		&MockTestOptimizationClient{Skippables: testSkippables(map[string]bool{})},
 		newDefaultMockCIProviderDetector(),
 	)
 

--- a/internal/platform/javascript.go
+++ b/internal/platform/javascript.go
@@ -39,6 +39,10 @@ func (j *JavaScript) Name() string {
 	return "javascript"
 }
 
+func (j *JavaScript) TestSkippingLevel() settings.TestSkippingLevel {
+	return settings.TestSkippingLevelSuite
+}
+
 // GetPlatformEnv returns environment variables required for JS commands.
 func (j *JavaScript) GetPlatformEnv() map[string]string {
 	// Check if the NODE_OPTIONS is set in the env, and if so,

--- a/internal/platform/javascript_test.go
+++ b/internal/platform/javascript_test.go
@@ -43,6 +43,12 @@ func TestJavaScript_Name(t *testing.T) {
 	}
 }
 
+func TestJavaScript_TestSkippingLevel(t *testing.T) {
+	if got := NewJavaScript().TestSkippingLevel(); got != settings.TestSkippingLevelSuite {
+		t.Fatalf("TestSkippingLevel() = %q, want %q", got, settings.TestSkippingLevelSuite)
+	}
+}
+
 func TestJavaScript_GetPlatformEnv_SetsNODEOPTIONS(t *testing.T) {
 	t.Setenv(nodeOptionsEnvVar, "")
 

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -12,6 +12,7 @@ type Platform interface {
 	CreateTagsMap() (map[string]string, error)
 	DetectFramework() (framework.Framework, error)
 	SanityCheck() error
+	TestSkippingLevel() settings.TestSkippingLevel
 }
 
 // PlatformDetector defines interface for detecting platforms - needed to allow mocking in tests
@@ -31,7 +32,7 @@ func DetectPlatform() (Platform, error) {
 	var platform Platform
 	switch platformName {
 	case "ruby":
-		platform = NewRuby()
+		platform = NewRuby(settings.GetTestSkippingLevel())
 	case "javascript":
 		platform = NewJavaScript()
 	case "python":

--- a/internal/platform/python.go
+++ b/internal/platform/python.go
@@ -52,6 +52,10 @@ func (p *Python) Name() string {
 	return "python"
 }
 
+func (p *Python) TestSkippingLevel() settings.TestSkippingLevel {
+	return settings.TestSkippingLevelTest
+}
+
 // GetPlatformEnv returns environment variables required for Python commands.
 // It appends --ddtrace to PYTEST_ADDOPTS to load the ddtrace pytest plugin.
 func (p *Python) GetPlatformEnv() map[string]string {

--- a/internal/platform/python_test.go
+++ b/internal/platform/python_test.go
@@ -19,6 +19,12 @@ func TestPython_Name(t *testing.T) {
 	}
 }
 
+func TestPython_TestSkippingLevel(t *testing.T) {
+	if got := NewPython().TestSkippingLevel(); got != settings.TestSkippingLevelTest {
+		t.Fatalf("TestSkippingLevel() = %q, want %q", got, settings.TestSkippingLevelTest)
+	}
+}
+
 func TestNormalizePyVersion(t *testing.T) {
 	cases := []struct{ in, want string }{
 		{"4.12.0rc1", "4.12.0-rc1"},

--- a/internal/platform/ruby.go
+++ b/internal/platform/ruby.go
@@ -29,17 +29,23 @@ const (
 )
 
 type Ruby struct {
-	executor ext.CommandExecutor
+	executor          ext.CommandExecutor
+	testSkippingLevel settings.TestSkippingLevel
 }
 
-func NewRuby() *Ruby {
+func NewRuby(testSkippingLevel settings.TestSkippingLevel) *Ruby {
 	return &Ruby{
-		executor: &ext.DefaultCommandExecutor{},
+		executor:          &ext.DefaultCommandExecutor{},
+		testSkippingLevel: testSkippingLevel,
 	}
 }
 
 func (r *Ruby) Name() string {
 	return "ruby"
+}
+
+func (r *Ruby) TestSkippingLevel() settings.TestSkippingLevel {
+	return r.testSkippingLevel
 }
 
 // GetPlatformEnv returns environment variables required for Ruby commands.

--- a/internal/platform/ruby_test.go
+++ b/internal/platform/ruby_test.go
@@ -35,13 +35,36 @@ func (m *mockCommandExecutor) Run(ctx context.Context, name string, args []strin
 	return m.runErr
 }
 
+func newTestRuby() *Ruby {
+	return NewRuby(settings.TestSkippingLevelTest)
+}
+
 func TestRuby_Name(t *testing.T) {
-	ruby := NewRuby()
+	ruby := newTestRuby()
 	expected := "ruby"
 	actual := ruby.Name()
 
 	if actual != expected {
 		t.Errorf("expected %q, got %q", expected, actual)
+	}
+}
+
+func TestRuby_TestSkippingLevel(t *testing.T) {
+	tests := []struct {
+		name  string
+		value settings.TestSkippingLevel
+		want  settings.TestSkippingLevel
+	}{
+		{name: "test", value: "test", want: settings.TestSkippingLevelTest},
+		{name: "suite", value: "suite", want: settings.TestSkippingLevelSuite},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewRuby(tt.value).TestSkippingLevel(); got != tt.want {
+				t.Fatalf("TestSkippingLevel() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -58,7 +81,7 @@ func TestRuby_SanityCheck_Passes(t *testing.T) {
 		},
 	}
 
-	ruby := NewRuby()
+	ruby := newTestRuby()
 	ruby.executor = mockExecutor
 	if err := ruby.SanityCheck(); err != nil {
 		t.Fatalf("SanityCheck() unexpected error: %v", err)
@@ -71,7 +94,7 @@ func TestRuby_SanityCheck_FailsWhenBundleInfoFails(t *testing.T) {
 		combinedOutputErr: &exec.ExitError{},
 	}
 
-	ruby := NewRuby()
+	ruby := newTestRuby()
 	ruby.executor = mockExecutor
 	err := ruby.SanityCheck()
 	if err == nil {
@@ -88,7 +111,7 @@ func TestRuby_SanityCheck_FailsWhenVersionTooLow(t *testing.T) {
 		combinedOutput: []byte("  * datadog-ci (1.30.9)\n"),
 	}
 
-	ruby := NewRuby()
+	ruby := newTestRuby()
 	ruby.executor = mockExecutor
 	err := ruby.SanityCheck()
 	if err == nil {
@@ -108,7 +131,7 @@ func TestRuby_SanityCheck_FailsWhenVersionNotFound(t *testing.T) {
 		combinedOutput: []byte("  * datadog-ci\n    Summary: Datadog Test Optimization for your ruby application\n"),
 	}
 
-	ruby := NewRuby()
+	ruby := newTestRuby()
 	ruby.executor = mockExecutor
 	err := ruby.SanityCheck()
 	if err == nil {
@@ -133,7 +156,7 @@ func TestRuby_SanityCheck_SucceedsWithDebugLogs(t *testing.T) {
 		combinedOutput: []byte(output),
 	}
 
-	ruby := NewRuby()
+	ruby := newTestRuby()
 	ruby.executor = mockExecutor
 	if err := ruby.SanityCheck(); err != nil {
 		t.Fatalf("SanityCheck() unexpected error: %v", err)
@@ -145,7 +168,7 @@ func TestRuby_DetectFramework_RSpec(t *testing.T) {
 	viper.Set("framework", "rspec")
 	defer viper.Reset()
 
-	ruby := NewRuby()
+	ruby := newTestRuby()
 	fw, err := ruby.DetectFramework()
 
 	if err != nil {
@@ -174,7 +197,7 @@ func TestRuby_DetectFramework_Minitest(t *testing.T) {
 		settings.Init()
 	}()
 
-	ruby := NewRuby()
+	ruby := newTestRuby()
 	fw, err := ruby.DetectFramework()
 
 	if err != nil {
@@ -199,7 +222,7 @@ func TestRuby_DetectFramework_Unsupported(t *testing.T) {
 		settings.Init()
 	}()
 
-	ruby := NewRuby()
+	ruby := newTestRuby()
 	fw, err := ruby.DetectFramework()
 
 	if err == nil {
@@ -444,7 +467,7 @@ func TestRuby_GetPlatformEnv_SetsRUBYOPT_WhenNotSet(t *testing.T) {
 		defer func() { _ = os.Setenv("RUBYOPT", originalValue) }()
 	}
 
-	ruby := NewRuby()
+	ruby := newTestRuby()
 	envMap := ruby.GetPlatformEnv()
 
 	expectedValue := "-rbundler/setup -rdatadog/ci/auto_instrument"
@@ -466,7 +489,7 @@ func TestRuby_GetPlatformEnv_DoesNotOverride_WhenAlreadySet(t *testing.T) {
 		}
 	}()
 
-	ruby := NewRuby()
+	ruby := newTestRuby()
 	envMap := ruby.GetPlatformEnv()
 
 	// When RUBYOPT is already set, GetPlatformEnv should not include it
@@ -487,7 +510,7 @@ func TestRuby_DetectFramework_SetsPlatformEnv(t *testing.T) {
 	viper.Set("framework", "rspec")
 	defer viper.Reset()
 
-	ruby := NewRuby()
+	ruby := newTestRuby()
 	fw, err := ruby.DetectFramework()
 
 	if err != nil {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -97,7 +97,7 @@ func (tr *TestRunner) Run(ctx context.Context) error {
 	slog.Info("Framework detected", "framework", framework.Name())
 	runInfo := runmetadata.New(ciUtils.GetCITags())
 	if planInfo.IsZero() {
-		planInfo = planner.NewPlanInfo(nil, detectedPlatform.Name(), framework.Name())
+		planInfo = planner.NewPlanInfo(nil, detectedPlatform.Name(), framework.Name(), detectedPlatform.TestSkippingLevel())
 	}
 
 	ciNode := settings.GetCiNode()

--- a/internal/runner/test_helpers_test.go
+++ b/internal/runner/test_helpers_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/DataDog/ddtest/internal/discovery"
 	"github.com/DataDog/ddtest/internal/framework"
 	"github.com/DataDog/ddtest/internal/platform"
+	"github.com/DataDog/ddtest/internal/settings"
 	"github.com/DataDog/ddtest/internal/testoptimization"
 )
 
@@ -43,6 +44,7 @@ type MockPlatform struct {
 	Framework    framework.Framework
 	FrameworkErr error
 	SanityErr    error
+	TestLevel    settings.TestSkippingLevel
 }
 
 func (m *MockPlatform) Name() string {
@@ -61,6 +63,13 @@ func (m *MockPlatform) SanityCheck() error {
 	return m.SanityErr
 }
 
+func (m *MockPlatform) TestSkippingLevel() settings.TestSkippingLevel {
+	if m.TestLevel == "" {
+		return settings.TestSkippingLevelTest
+	}
+	return m.TestLevel
+}
+
 type MockFramework struct {
 	FrameworkName            string
 	TestPatternValue         string
@@ -69,6 +78,8 @@ type MockFramework struct {
 	DiscoverTestsErr         error
 	RunTestsCalls            []RunTestsCall
 	FullDiscoveryUnsupported bool
+	SuiteSourceFiles         map[string]string
+	UnskippableFiles         map[string]bool
 	mu                       sync.Mutex
 }
 
@@ -111,6 +122,21 @@ func (m *MockFramework) GetPlatformEnv() map[string]string {
 
 func (m *MockFramework) SupportsFullTestDiscovery() bool {
 	return !m.FullDiscoveryUnsupported
+}
+
+func (m *MockFramework) SourceFileForSuite(suite string) (string, bool) {
+	if m.SuiteSourceFiles != nil {
+		sourceFile, ok := m.SuiteSourceFiles[suite]
+		return sourceFile, ok
+	}
+	if suite == "" {
+		return "", false
+	}
+	return suite, true
+}
+
+func (m *MockFramework) HasUnskippableMarker(testFile string) bool {
+	return m.UnskippableFiles[testFile]
 }
 
 func (m *MockFramework) GetRunTestsCallsCount() int {

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -21,8 +21,16 @@ const (
 	testsLocationEnv              = "DD_TEST_OPTIMIZATION_RUNNER_TESTS_LOCATION"
 	testsExcludePatternEnv        = "DD_TEST_OPTIMIZATION_RUNNER_TESTS_EXCLUDE_PATTERN"
 	testDiscoveryCacheEnv         = "DD_TEST_OPTIMIZATION_RUNNER_TEST_DISCOVERY_CACHE"
+	testSkippingModeEnv           = "DD_TESTOPTIMIZATION_TIA_TEST_SKIPPING_MODE"
 	knapsackTestFilePatternEnv    = "KNAPSACK_PRO_TEST_FILE_PATTERN"
 	knapsackTestFileExcludeEnv    = "KNAPSACK_PRO_TEST_FILE_EXCLUDE_PATTERN"
+)
+
+type TestSkippingLevel string
+
+const (
+	TestSkippingLevelTest  TestSkippingLevel = "test"
+	TestSkippingLevelSuite TestSkippingLevel = "suite"
 )
 
 // DefaultParallelism returns the default parallelism value.
@@ -85,20 +93,21 @@ func ceilDiv(numerator, denominator int) int {
 }
 
 type Config struct {
-	Platform               string        `mapstructure:"platform"`
-	Framework              string        `mapstructure:"framework"`
-	MinParallelism         int           `mapstructure:"min_parallelism"`
-	MaxParallelism         int           `mapstructure:"max_parallelism"`
-	ParallelRunnerOverhead time.Duration `mapstructure:"parallel_runner_overhead"`
-	WorkerEnv              string        `mapstructure:"worker_env"`
-	CiNode                 int           `mapstructure:"ci_node"`
-	CiNodeWorkers          int           `mapstructure:"ci_node_workers"`
-	Command                string        `mapstructure:"command"`
-	TestsLocation          string        `mapstructure:"tests_location"`
-	TestsExcludePattern    string        `mapstructure:"tests_exclude_pattern"`
-	TestDiscoveryCache     string        `mapstructure:"test_discovery_cache"`
-	RuntimeTags            string        `mapstructure:"runtime_tags"`
-	ReportEnabled          bool          `mapstructure:"report_enabled"`
+	Platform               string            `mapstructure:"platform"`
+	Framework              string            `mapstructure:"framework"`
+	MinParallelism         int               `mapstructure:"min_parallelism"`
+	MaxParallelism         int               `mapstructure:"max_parallelism"`
+	ParallelRunnerOverhead time.Duration     `mapstructure:"parallel_runner_overhead"`
+	WorkerEnv              string            `mapstructure:"worker_env"`
+	CiNode                 int               `mapstructure:"ci_node"`
+	CiNodeWorkers          int               `mapstructure:"ci_node_workers"`
+	Command                string            `mapstructure:"command"`
+	TestsLocation          string            `mapstructure:"tests_location"`
+	TestsExcludePattern    string            `mapstructure:"tests_exclude_pattern"`
+	TestDiscoveryCache     string            `mapstructure:"test_discovery_cache"`
+	TestSkippingLevel      TestSkippingLevel `mapstructure:"test_skipping_mode"`
+	RuntimeTags            string            `mapstructure:"runtime_tags"`
+	ReportEnabled          bool              `mapstructure:"report_enabled"`
 }
 
 var (
@@ -125,6 +134,10 @@ func Init() {
 		fmt.Fprintf(os.Stderr, "Error binding test discovery cache env: %v\n", err)
 		os.Exit(1)
 	}
+	if err := viper.BindEnv("test_skipping_mode", testSkippingModeEnv); err != nil {
+		fmt.Fprintf(os.Stderr, "Error binding test skipping mode env: %v\n", err)
+		os.Exit(1)
+	}
 
 	setDefaults()
 
@@ -140,6 +153,7 @@ func Init() {
 		os.Exit(1)
 	}
 	viper.Set("parallel_runner_overhead", parallelRunnerOverhead)
+	viper.Set("test_skipping_mode", NormalizeTestSkippingLevel(TestSkippingLevel(viper.GetString("test_skipping_mode"))))
 
 	config = &Config{}
 	if err := viper.Unmarshal(config); err != nil {
@@ -161,8 +175,24 @@ func setDefaults() {
 	viper.SetDefault("tests_location", "")
 	viper.SetDefault("tests_exclude_pattern", "")
 	viper.SetDefault("test_discovery_cache", "")
+	viper.SetDefault("test_skipping_mode", TestSkippingLevelTest)
 	viper.SetDefault("runtime_tags", "")
 	viper.SetDefault("report_enabled", true)
+}
+
+// NormalizeTestSkippingLevel accepts only the backend-supported TIA skipping modes.
+// Invalid or empty values fall back to test-level skipping.
+func NormalizeTestSkippingLevel(level TestSkippingLevel) TestSkippingLevel {
+	switch TestSkippingLevel(strings.TrimSpace(string(level))) {
+	case TestSkippingLevelSuite:
+		return TestSkippingLevelSuite
+	default:
+		return TestSkippingLevelTest
+	}
+}
+
+func (level TestSkippingLevel) String() string {
+	return string(level)
 }
 
 // ParseParallelRunnerOverhead resolves the modeled overhead for adding another
@@ -258,6 +288,10 @@ func GetTestsExcludePattern() string {
 
 func GetTestDiscoveryCache() string {
 	return Get().TestDiscoveryCache
+}
+
+func GetTestSkippingLevel() TestSkippingLevel {
+	return Get().TestSkippingLevel
 }
 
 func GetRuntimeTags() string {

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -152,6 +152,9 @@ func TestInit(t *testing.T) {
 	if config.TestDiscoveryCache != "" {
 		t.Errorf("expected default test_discovery_cache to be empty, got %q", config.TestDiscoveryCache)
 	}
+	if config.TestSkippingLevel != "test" {
+		t.Errorf("expected default test_skipping_mode to be 'test', got %q", config.TestSkippingLevel)
+	}
 	if config.RuntimeTags != "" {
 		t.Errorf("expected default runtime_tags to be empty, got %q", config.RuntimeTags)
 	}
@@ -201,6 +204,9 @@ func TestSetDefaults(t *testing.T) {
 	}
 	if viper.GetString("test_discovery_cache") != "" {
 		t.Errorf("expected default test_discovery_cache to be empty, got %q", viper.GetString("test_discovery_cache"))
+	}
+	if viper.GetString("test_skipping_mode") != "test" {
+		t.Errorf("expected default test_skipping_mode to be 'test', got %q", viper.GetString("test_skipping_mode"))
 	}
 	if viper.GetString("runtime_tags") != "" {
 		t.Errorf("expected default runtime_tags to be empty, got %q", viper.GetString("runtime_tags"))
@@ -282,6 +288,7 @@ func TestEnvironmentVariables(t *testing.T) {
 	_ = os.Setenv("DD_TEST_OPTIMIZATION_RUNNER_TESTS_LOCATION", "spec/**/*_spec.rb")
 	_ = os.Setenv("DD_TEST_OPTIMIZATION_RUNNER_TESTS_EXCLUDE_PATTERN", "spec/system/**/*_spec.rb")
 	_ = os.Setenv("DD_TEST_OPTIMIZATION_RUNNER_TEST_DISCOVERY_CACHE", "/tmp/ddtest-tests.json")
+	_ = os.Setenv("DD_TESTOPTIMIZATION_TIA_TEST_SKIPPING_MODE", "suite")
 	_ = os.Setenv("DD_TEST_OPTIMIZATION_RUNNER_RUNTIME_TAGS", `{"os.platform":"linux","runtime.version":"3.2.0"}`)
 	_ = os.Setenv("DD_TEST_OPTIMIZATION_RUNNER_REPORT_ENABLED", "false")
 	defer func() {
@@ -297,6 +304,7 @@ func TestEnvironmentVariables(t *testing.T) {
 		_ = os.Unsetenv("DD_TEST_OPTIMIZATION_RUNNER_TESTS_LOCATION")
 		_ = os.Unsetenv("DD_TEST_OPTIMIZATION_RUNNER_TESTS_EXCLUDE_PATTERN")
 		_ = os.Unsetenv("DD_TEST_OPTIMIZATION_RUNNER_TEST_DISCOVERY_CACHE")
+		_ = os.Unsetenv("DD_TESTOPTIMIZATION_TIA_TEST_SKIPPING_MODE")
 		_ = os.Unsetenv("DD_TEST_OPTIMIZATION_RUNNER_RUNTIME_TAGS")
 		_ = os.Unsetenv("DD_TEST_OPTIMIZATION_RUNNER_REPORT_ENABLED")
 	}()
@@ -338,6 +346,9 @@ func TestEnvironmentVariables(t *testing.T) {
 	}
 	if config.TestDiscoveryCache != "/tmp/ddtest-tests.json" {
 		t.Errorf("expected test_discovery_cache from env var to be '/tmp/ddtest-tests.json', got %q", config.TestDiscoveryCache)
+	}
+	if config.TestSkippingLevel != "suite" {
+		t.Errorf("expected test_skipping_mode from env var to be 'suite', got %q", config.TestSkippingLevel)
 	}
 	if config.RuntimeTags != `{"os.platform":"linux","runtime.version":"3.2.0"}` {
 		t.Errorf("expected runtime_tags from env var to be JSON string, got %q", config.RuntimeTags)
@@ -480,6 +491,68 @@ func TestGetTestDiscoveryCache(t *testing.T) {
 	cachePath = GetTestDiscoveryCache()
 	if cachePath != "/tmp/ddtest-tests.json" {
 		t.Errorf("expected test_discovery_cache to be '/tmp/ddtest-tests.json', got %q", cachePath)
+	}
+}
+
+func TestNormalizeTestSkippingLevel(t *testing.T) {
+	tests := []struct {
+		name  string
+		value TestSkippingLevel
+		want  TestSkippingLevel
+	}{
+		{name: "test", value: "test", want: "test"},
+		{name: "suite", value: "suite", want: "suite"},
+		{name: "invalid", value: "file", want: "test"},
+		{name: "empty", value: "", want: "test"},
+		{name: "trimmed suite", value: " suite ", want: "suite"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NormalizeTestSkippingLevel(tt.value); got != tt.want {
+				t.Fatalf("NormalizeTestSkippingLevel(%q) = %q, want %q", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetTestSkippingLevel(t *testing.T) {
+	config = nil
+	viper.Reset()
+
+	if got := GetTestSkippingLevel(); got != "test" {
+		t.Fatalf("GetTestSkippingLevel() default = %q, want test", got)
+	}
+
+	config = nil
+	viper.Reset()
+	viper.Set("test_skipping_mode", "suite")
+	if got := GetTestSkippingLevel(); got != "suite" {
+		t.Fatalf("GetTestSkippingLevel() configured = %q, want suite", got)
+	}
+}
+
+func TestTestSkippingLevelRubyEnv(t *testing.T) {
+	config = nil
+	viper.Reset()
+	t.Setenv(testSkippingModeEnv, "suite")
+
+	Init()
+
+	if config.TestSkippingLevel != "suite" {
+		t.Fatalf("test_skipping_mode from Ruby env = %q, want suite", config.TestSkippingLevel)
+	}
+}
+
+func TestTestSkippingLevelInvalidFallsBackToTest(t *testing.T) {
+	config = nil
+	viper.Reset()
+	t.Setenv(testSkippingModeEnv, "invalid")
+
+	Init()
+
+	if config.TestSkippingLevel != "test" {
+		t.Fatalf("test_skipping_mode from invalid env = %q, want test", config.TestSkippingLevel)
 	}
 }
 

--- a/internal/testoptimization/api/raw_response_test.go
+++ b/internal/testoptimization/api/raw_response_test.go
@@ -9,20 +9,26 @@ import (
 	"testing"
 
 	"github.com/DataDog/ddtest/internal/constants"
+	"github.com/DataDog/ddtest/internal/settings"
 )
 
 func newRawResponseTestClient(server *httptest.Server) *transport {
+	return newRawResponseTestClientWithTestSkippingLevel(server, settings.TestSkippingLevelTest)
+}
+
+func newRawResponseTestClientWithTestSkippingLevel(server *httptest.Server, testSkippingLevel settings.TestSkippingLevel) *transport {
 	return &transport{
-		agentless:     true,
-		baseURL:       server.URL,
-		environment:   "ci",
-		serviceName:   "service",
-		repositoryURL: "https://github.com/DataDog/ddtest.git",
-		commitSha:     "abc123",
-		commitMessage: "commit message",
-		branchName:    "main",
-		headers:       map[string]string{},
-		handler:       NewRequestHandlerWithClient(server.Client()),
+		agentless:         true,
+		baseURL:           server.URL,
+		environment:       "ci",
+		serviceName:       "service",
+		repositoryURL:     "https://github.com/DataDog/ddtest.git",
+		commitSha:         "abc123",
+		commitMessage:     "commit message",
+		branchName:        "main",
+		headers:           map[string]string{},
+		handler:           NewRequestHandlerWithClient(server.Client()),
+		testSkippingLevel: testSkippingLevel,
 		testConfigurations: testConfigurations{
 			OsPlatform:     "linux",
 			OsArchitecture: "amd64",
@@ -93,7 +99,7 @@ func TestClientStoresRawBackendResponses(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetSkippableTests() returned error: %v", err)
 	}
-	if correlationID != "correlation-id" || !skippableTests["module-a.suite-a.test-a.params"] {
+	if correlationID != "correlation-id" || !skippableTests.Tests["module-a.suite-a.test-a.params"] {
 		t.Fatalf("GetSkippableTests() returned unexpected processed data: correlationID=%s skippableTests=%+v", correlationID, skippableTests)
 	}
 	if string(client.GetSkippableTestsRawResponse()) != skippableTestsResponse {
@@ -127,7 +133,7 @@ func TestClientBuildsSkippableKeyFromTestBundle(t *testing.T) {
 		t.Fatalf("GetSkippableTests() returned error: %v", err)
 	}
 
-	if correlationID != "correlation-id" || !skippableTests["rspec.suite-a.test-a.params"] {
+	if correlationID != "correlation-id" || !skippableTests.Tests["rspec.suite-a.test-a.params"] {
 		t.Fatalf("GetSkippableTests() returned unexpected processed data: correlationID=%s skippableTests=%+v", correlationID, skippableTests)
 	}
 }
@@ -147,10 +153,10 @@ func TestClientWarnsWhenSkippableResponseIsMissingTestBundle(t *testing.T) {
 		t.Fatalf("GetSkippableTests() returned error: %v", err)
 	}
 
-	if !skippableTests[".suite-a.test-a.params"] {
+	if !skippableTests.Tests[".suite-a.test-a.params"] {
 		t.Fatalf("GetSkippableTests() returned unexpected processed data: skippableTests=%+v", skippableTests)
 	}
-	if !strings.Contains(logs.String(), "Datadog backend did not return test.bundle for skippable tests; please contact Datadog support") {
+	if !strings.Contains(logs.String(), "Datadog backend did not return test.bundle for skippable test or suite; please contact Datadog support") {
 		t.Fatalf("Expected missing test.bundle warning, got logs: %s", logs.String())
 	}
 }

--- a/internal/testoptimization/api/settings_api.go
+++ b/internal/testoptimization/api/settings_api.go
@@ -8,6 +8,8 @@ package api
 import (
 	"fmt"
 	"log/slog"
+
+	"github.com/DataDog/ddtest/internal/settings"
 )
 
 const (
@@ -27,12 +29,13 @@ type (
 	}
 
 	SettingsRequestData struct {
-		Service        string             `json:"service,omitempty"`
-		Env            string             `json:"env,omitempty"`
-		RepositoryURL  string             `json:"repository_url,omitempty"`
-		Branch         string             `json:"branch,omitempty"`
-		Sha            string             `json:"sha,omitempty"`
-		Configurations testConfigurations `json:"configurations,omitempty"`
+		Service        string                     `json:"service,omitempty"`
+		Env            string                     `json:"env,omitempty"`
+		RepositoryURL  string                     `json:"repository_url,omitempty"`
+		Branch         string                     `json:"branch,omitempty"`
+		Sha            string                     `json:"sha,omitempty"`
+		TestLevel      settings.TestSkippingLevel `json:"test_level,omitempty"`
+		Configurations testConfigurations         `json:"configurations,omitempty"`
 	}
 
 	settingsResponse struct {
@@ -83,6 +86,7 @@ func (c *transport) GetSettings() (*SettingsResponseData, error) {
 				RepositoryURL:  c.repositoryURL,
 				Branch:         c.branchName,
 				Sha:            c.commitSha,
+				TestLevel:      c.getTestSkippingLevel(),
 				Configurations: c.testConfigurations,
 			},
 		},

--- a/internal/testoptimization/api/settings_api_test.go
+++ b/internal/testoptimization/api/settings_api_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/ddtest/internal/constants"
+	ddsettings "github.com/DataDog/ddtest/internal/settings"
 )
 
 func TestTransportGetSettingsRequiresRepositoryAndCommit(t *testing.T) {
@@ -65,6 +66,9 @@ func TestTransportGetSettingsRequestAndResponse(t *testing.T) {
 		t.Fatalf("request type = %q, want %q", captured.Data.Type, settingsRequestType)
 	}
 	attributes := captured.Data.Attributes
+	if attributes.TestLevel != ddsettings.TestSkippingLevelTest {
+		t.Fatalf("test level = %q, want test", attributes.TestLevel)
+	}
 	if attributes.Service != client.serviceName || attributes.Env != client.environment {
 		t.Fatalf("service/env = %q/%q, want %q/%q", attributes.Service, attributes.Env, client.serviceName, client.environment)
 	}
@@ -85,6 +89,27 @@ func TestTransportGetSettingsRequestAndResponse(t *testing.T) {
 	}
 	if len(client.GetSettingsRawResponse()) == 0 {
 		t.Fatal("expected raw settings response to be stored")
+	}
+}
+
+func TestTransportGetSettingsRequestUsesConfiguredTestLevel(t *testing.T) {
+	var captured settingsRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set(HeaderContentType, constants.ContentTypeJSON)
+		_, _ = w.Write([]byte(`{"data":{"attributes":{}}}`))
+	}))
+	defer server.Close()
+
+	client := newRawResponseTestClientWithTestSkippingLevel(server, ddsettings.TestSkippingLevelSuite)
+	if _, err := client.GetSettings(); err != nil {
+		t.Fatalf("GetSettings() returned error: %v", err)
+	}
+
+	if captured.Data.Attributes.TestLevel != ddsettings.TestSkippingLevelSuite {
+		t.Fatalf("test level = %q, want suite", captured.Data.Attributes.TestLevel)
 	}
 }
 

--- a/internal/testoptimization/api/skippable.go
+++ b/internal/testoptimization/api/skippable.go
@@ -8,6 +8,8 @@ package api
 import (
 	"fmt"
 	"log/slog"
+
+	"github.com/DataDog/ddtest/internal/settings"
 )
 
 const (
@@ -26,12 +28,12 @@ type (
 	}
 
 	skippableRequestData struct {
-		TestLevel      string             `json:"test_level"`
-		Configurations testConfigurations `json:"configurations"`
-		Service        string             `json:"service"`
-		Env            string             `json:"env"`
-		RepositoryURL  string             `json:"repository_url"`
-		Sha            string             `json:"sha"`
+		TestLevel      settings.TestSkippingLevel `json:"test_level"`
+		Configurations testConfigurations         `json:"configurations"`
+		Service        string                     `json:"service"`
+		Env            string                     `json:"env"`
+		RepositoryURL  string                     `json:"repository_url"`
+		Sha            string                     `json:"sha"`
 	}
 
 	skippableResponse struct {
@@ -57,9 +59,32 @@ type (
 	}
 
 	SkippableTests map[string]bool
+
+	SkippableSuite struct {
+		Module string
+		Suite  string
+	}
+
+	SkippableSuites map[SkippableSuite]bool
+
+	Skippables struct {
+		Tests  SkippableTests
+		Suites SkippableSuites
+	}
 )
 
-func (c *transport) GetSkippableTests() (correlationID string, skippables SkippableTests, err error) {
+func NewSkippables() Skippables {
+	return Skippables{
+		Tests:  SkippableTests{},
+		Suites: SkippableSuites{},
+	}
+}
+
+func (s Skippables) Count() int {
+	return len(s.Tests) + len(s.Suites)
+}
+
+func (c *transport) GetSkippableTests() (correlationID string, skippables Skippables, err error) {
 	if c.repositoryURL == "" || c.commitSha == "" {
 		err = fmt.Errorf("testoptimization.GetSkippableTests: repository URL and commit SHA are required")
 		return
@@ -70,7 +95,7 @@ func (c *transport) GetSkippableTests() (correlationID string, skippables Skippa
 		Data: skippableRequestHeader{
 			Type: skippableRequestType,
 			Attributes: skippableRequestData{
-				TestLevel:      "test",
+				TestLevel:      c.getTestSkippingLevel(),
 				Configurations: c.testConfigurations,
 				Service:        c.serviceName,
 				Env:            c.environment,
@@ -84,17 +109,17 @@ func (c *transport) GetSkippableTests() (correlationID string, skippables Skippa
 	response, err := c.handler.SendRequest(*request)
 
 	if err != nil {
-		return "", nil, fmt.Errorf("sending skippable tests request: %s", err)
+		return "", NewSkippables(), fmt.Errorf("sending skippable tests request: %s", err)
 	}
 	c.skippableTestsRawResponse = cloneRawMessage(response.Body)
 
 	var responseObject skippableResponse
 	err = response.Unmarshal(&responseObject)
 	if err != nil {
-		return "", nil, fmt.Errorf("unmarshalling skippable tests response: %s", err)
+		return "", NewSkippables(), fmt.Errorf("unmarshalling skippable tests response: %s", err)
 	}
 
-	skippableTestsMap := SkippableTests{}
+	skippables = NewSkippables()
 	warnedMissingTestBundle := false
 	for _, data := range responseObject.Data {
 
@@ -125,15 +150,30 @@ func (c *transport) GetSkippableTests() (correlationID string, skippables Skippa
 		}
 
 		if data.Attributes.Configurations.TestBundle == "" && !warnedMissingTestBundle {
-			slog.Warn("Datadog backend did not return test.bundle for skippable tests; please contact Datadog support")
+			slog.Warn("Datadog backend did not return test.bundle for skippable test or suite; please contact Datadog support")
 			warnedMissingTestBundle = true
 		}
-		skippableTestsMap[skippableTestKey(data.Attributes)] = true
+
+		switch data.Type {
+		case string(settings.TestSkippingLevelTest):
+			skippables.Tests[skippableTestKey(data.Attributes)] = true
+		case string(settings.TestSkippingLevelSuite):
+			if data.Attributes.Suite != "" {
+				skippables.Suites[skippableSuiteKey(data.Attributes)] = true
+			}
+		}
 	}
 
-	return responseObject.Meta.CorrelationID, skippableTestsMap, nil
+	return responseObject.Meta.CorrelationID, skippables, nil
 }
 
 func skippableTestKey(test SkippableResponseDataAttributes) string {
 	return test.Configurations.TestBundle + "." + test.Suite + "." + test.Name + "." + test.Parameters
+}
+
+func skippableSuiteKey(test SkippableResponseDataAttributes) SkippableSuite {
+	return SkippableSuite{
+		Module: test.Configurations.TestBundle,
+		Suite:  test.Suite,
+	}
 }

--- a/internal/testoptimization/api/skippable_test.go
+++ b/internal/testoptimization/api/skippable_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/ddtest/internal/constants"
+	"github.com/DataDog/ddtest/internal/settings"
 )
 
 func TestTransportGetSkippableTestsRequestAndResponse(t *testing.T) {
@@ -63,7 +64,7 @@ func TestTransportGetSkippableTestsRequestAndResponse(t *testing.T) {
 		t.Fatalf("request type = %q, want %q", captured.Data.Type, skippableRequestType)
 	}
 	attributes := captured.Data.Attributes
-	if attributes.TestLevel != "test" {
+	if attributes.TestLevel != settings.TestSkippingLevelTest {
 		t.Fatalf("test level = %q, want test", attributes.TestLevel)
 	}
 	if attributes.Service != client.serviceName || attributes.Env != client.environment {
@@ -82,11 +83,32 @@ func TestTransportGetSkippableTestsRequestAndResponse(t *testing.T) {
 	if correlationID != "correlation-id" {
 		t.Fatalf("correlation ID = %q, want correlation-id", correlationID)
 	}
-	if len(skippable) != 1 || !skippable["bundle.suite.name.params"] {
+	if len(skippable.Tests) != 1 || !skippable.Tests["bundle.suite.name.params"] {
 		t.Fatalf("unexpected skippable map: %#v", skippable)
 	}
 	if len(client.GetSkippableTestsRawResponse()) == 0 {
 		t.Fatal("expected raw skippable response to be stored")
+	}
+}
+
+func TestTransportGetSkippableTestsRequestUsesConfiguredTestLevel(t *testing.T) {
+	var captured skippableRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set(HeaderContentType, constants.ContentTypeJSON)
+		_, _ = w.Write([]byte(`{"meta":{"correlation_id":"cid"},"data":[]}`))
+	}))
+	defer server.Close()
+
+	client := newRawResponseTestClientWithTestSkippingLevel(server, settings.TestSkippingLevelSuite)
+	if _, _, err := client.GetSkippableTests(); err != nil {
+		t.Fatalf("GetSkippableTests() returned error: %v", err)
+	}
+
+	if captured.Data.Attributes.TestLevel != settings.TestSkippingLevelSuite {
+		t.Fatalf("test level = %q, want suite", captured.Data.Attributes.TestLevel)
 	}
 }
 
@@ -123,14 +145,14 @@ func TestTransportGetSkippableTestsErrors(t *testing.T) {
 
 func TestTransportGetSkippableTestsFiltersConfigurations(t *testing.T) {
 	response := `{"meta":{"correlation_id":"cid"},"data":[
-		{"attributes":{"suite":"suite-a","name":"match","parameters":"","configurations":{"test.bundle":"rspec","os.platform":"linux","os.version":"ubuntu","os.architecture":"amd64","runtime.name":"ruby","runtime.architecture":"x86_64","runtime.version":"3.3.0"}}},
-		{"attributes":{"suite":"suite-a","name":"no-config","parameters":"","configurations":{"test.bundle":"rspec"}}},
-		{"attributes":{"suite":"suite-a","name":"wrong-os","parameters":"","configurations":{"test.bundle":"rspec","os.platform":"windows"}}},
-		{"attributes":{"suite":"suite-a","name":"wrong-os-version","parameters":"","configurations":{"test.bundle":"rspec","os.version":"debian"}}},
-		{"attributes":{"suite":"suite-a","name":"wrong-os-arch","parameters":"","configurations":{"test.bundle":"rspec","os.architecture":"arm64"}}},
-		{"attributes":{"suite":"suite-a","name":"wrong-runtime","parameters":"","configurations":{"test.bundle":"rspec","runtime.name":"python"}}},
-		{"attributes":{"suite":"suite-a","name":"wrong-runtime-arch","parameters":"","configurations":{"test.bundle":"rspec","runtime.architecture":"arm64"}}},
-		{"attributes":{"suite":"suite-a","name":"wrong-runtime-version","parameters":"","configurations":{"test.bundle":"rspec","runtime.version":"3.2.0"}}}
+		{"type":"test","attributes":{"suite":"suite-a","name":"match","parameters":"","configurations":{"test.bundle":"rspec","os.platform":"linux","os.version":"ubuntu","os.architecture":"amd64","runtime.name":"ruby","runtime.architecture":"x86_64","runtime.version":"3.3.0"}}},
+		{"type":"test","attributes":{"suite":"suite-a","name":"no-config","parameters":"","configurations":{"test.bundle":"rspec"}}},
+		{"type":"test","attributes":{"suite":"suite-a","name":"wrong-os","parameters":"","configurations":{"test.bundle":"rspec","os.platform":"windows"}}},
+		{"type":"test","attributes":{"suite":"suite-a","name":"wrong-os-version","parameters":"","configurations":{"test.bundle":"rspec","os.version":"debian"}}},
+		{"type":"test","attributes":{"suite":"suite-a","name":"wrong-os-arch","parameters":"","configurations":{"test.bundle":"rspec","os.architecture":"arm64"}}},
+		{"type":"test","attributes":{"suite":"suite-a","name":"wrong-runtime","parameters":"","configurations":{"test.bundle":"rspec","runtime.name":"python"}}},
+		{"type":"test","attributes":{"suite":"suite-a","name":"wrong-runtime-arch","parameters":"","configurations":{"test.bundle":"rspec","runtime.architecture":"arm64"}}},
+		{"type":"test","attributes":{"suite":"suite-a","name":"wrong-runtime-version","parameters":"","configurations":{"test.bundle":"rspec","runtime.version":"3.2.0"}}}
 	]}`
 	server := newRawResponseTestServer(t, map[string]string{skippableURLPath: response})
 	defer server.Close()
@@ -150,13 +172,34 @@ func TestTransportGetSkippableTestsFiltersConfigurations(t *testing.T) {
 		"rspec.suite-a.match.",
 		"rspec.suite-a.no-config.",
 	}
-	if len(skippable) != len(expected) {
+	if len(skippable.Tests) != len(expected) {
 		t.Fatalf("unexpected skippable map: %#v", skippable)
 	}
 	for _, key := range expected {
-		if !skippable[key] {
+		if !skippable.Tests[key] {
 			t.Fatalf("expected skippable key %q in %#v", key, skippable)
 		}
+	}
+}
+
+func TestTransportGetSkippableTestsParsesMixedResponse(t *testing.T) {
+	response := `{"meta":{"correlation_id":"cid"},"data":[
+		{"type":"test","attributes":{"suite":"suite-a","name":"test-a","parameters":"","configurations":{"test.bundle":"rspec"}}},
+		{"type":"suite","attributes":{"suite":"suite-b","configurations":{"test.bundle":"rspec"}}}
+	]}`
+	server := newRawResponseTestServer(t, map[string]string{skippableURLPath: response})
+	defer server.Close()
+
+	_, skippable, err := newRawResponseTestClient(server).GetSkippableTests()
+	if err != nil {
+		t.Fatalf("GetSkippableTests() returned error: %v", err)
+	}
+
+	if !skippable.Tests["rspec.suite-a.test-a."] {
+		t.Fatalf("expected skippable test, got %#v", skippable)
+	}
+	if !skippable.Suites[SkippableSuite{Module: "rspec", Suite: "suite-b"}] {
+		t.Fatalf("expected skippable suite, got %#v", skippable)
 	}
 }
 

--- a/internal/testoptimization/api/transport.go
+++ b/internal/testoptimization/api/transport.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/ddtest/internal/constants"
 	"github.com/DataDog/ddtest/internal/environment"
 	"github.com/DataDog/ddtest/internal/runmetadata"
+	"github.com/DataDog/ddtest/internal/settings"
 	"github.com/DataDog/ddtest/internal/utils"
 )
 
@@ -41,7 +42,7 @@ type (
 		GetTestSuiteDurations() *TestSuiteDurationsResponseData
 		GetCommits(localCommits []string) ([]string, error)
 		SendPackFiles(commitSha string, packFiles []string) (bytes int64, err error)
-		GetSkippableTests() (correlationID string, skippables SkippableTests, err error)
+		GetSkippableTests() (correlationID string, skippables Skippables, err error)
 		GetSkippableTestsRawResponse() json.RawMessage
 		GetTestManagementTests() (*TestManagementTestsResponseDataModules, error)
 		GetTestManagementTestsRawResponse() json.RawMessage
@@ -62,6 +63,7 @@ type (
 		headCommitMessage  string
 		branchName         string
 		testConfigurations testConfigurations
+		testSkippingLevel  settings.TestSkippingLevel
 		headers            map[string]string
 		handler            *RequestHandler
 
@@ -92,6 +94,14 @@ var defaultTraceAgentUDSPath = "/var/run/datadog/apm.socket"
 
 // NewTransportWithServiceNameAndSubdomain creates a new transport with the given service name and subdomain.
 func NewTransportWithServiceNameAndSubdomain(serviceName, subdomain string) Transport {
+	return newTransportWithServiceNameAndSubdomain(serviceName, subdomain, settings.TestSkippingLevelTest)
+}
+
+func NewTransportWithServiceNameAndTestSkippingLevel(serviceName string, testSkippingLevel settings.TestSkippingLevel) Transport {
+	return newTransportWithServiceNameAndSubdomain(serviceName, "api", testSkippingLevel)
+}
+
+func newTransportWithServiceNameAndSubdomain(serviceName, subdomain string, testSkippingLevel settings.TestSkippingLevel) Transport {
 	ciTags := environment.GetCITags()
 
 	// get the environment
@@ -228,6 +238,7 @@ func NewTransportWithServiceNameAndSubdomain(serviceName, subdomain string) Tran
 		headCommitSha:     ciTags[constants.GitHeadCommit],
 		headCommitMessage: ciTags[constants.GitHeadMessage],
 		branchName:        bName,
+		testSkippingLevel: testSkippingLevel,
 		testConfigurations: testConfigurations{
 			OsPlatform:     ciTags[constants.OSPlatform],
 			OsVersion:      ciTags[constants.OSVersion],
@@ -338,6 +349,13 @@ func (c *transport) GetKnownTestsRawResponse() json.RawMessage {
 
 func (c *transport) GetSkippableTestsRawResponse() json.RawMessage {
 	return cloneRawMessage(c.skippableTestsRawResponse)
+}
+
+func (c *transport) getTestSkippingLevel() settings.TestSkippingLevel {
+	if c.testSkippingLevel == "" {
+		return settings.TestSkippingLevelTest
+	}
+	return c.testSkippingLevel
 }
 
 func (c *transport) GetTestManagementTestsRawResponse() json.RawMessage {

--- a/internal/testoptimization/testoptimization.go
+++ b/internal/testoptimization/testoptimization.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/ddtest/internal/constants"
 	"github.com/DataDog/ddtest/internal/environment"
 	"github.com/DataDog/ddtest/internal/git"
+	"github.com/DataDog/ddtest/internal/settings"
 	"github.com/DataDog/ddtest/internal/testoptimization/api"
 	"github.com/DataDog/ddtest/internal/utils"
 )
@@ -39,7 +40,7 @@ type searchCommitsResponse struct {
 
 type TestOptimizationClient struct {
 	apiTransport              api.Transport
-	newAPITransport           func(serviceName string) api.Transport
+	newAPITransport           func(serviceName string, testSkippingLevel settings.TestSkippingLevel) api.Transport
 	cacheManager              *CacheManager
 	repositoryChangesUploader func() (int64, error)
 	enableSignalHandler       bool
@@ -51,12 +52,17 @@ type TestOptimizationClient struct {
 	closeActions         []testOptimizationCloseAction
 	settings             *api.SettingsResponseData
 	knownTests           api.KnownTestsResponseData
-	skippableTests       api.SkippableTests
+	skippables           api.Skippables
+	testSkippingLevel    settings.TestSkippingLevel
 	testManagementTests  api.TestManagementTestsResponseDataModules
 }
 
 func NewTestOptimizationClient() *TestOptimizationClient {
-	return newTestOptimizationClient(nil, api.NewTransportWithServiceName, nil, true)
+	return NewTestOptimizationClientWithTestSkippingLevel(settings.TestSkippingLevelTest)
+}
+
+func NewTestOptimizationClientWithTestSkippingLevel(testSkippingLevel settings.TestSkippingLevel) *TestOptimizationClient {
+	return newTestOptimizationClientWithTestSkippingLevel(nil, api.NewTransportWithServiceNameAndTestSkippingLevel, nil, true, testSkippingLevel)
 }
 
 func NewTestOptimizationClientWithDependencies(apiTransport api.Transport) *TestOptimizationClient {
@@ -65,12 +71,28 @@ func NewTestOptimizationClientWithDependencies(apiTransport api.Transport) *Test
 
 func newTestOptimizationClient(
 	apiTransport api.Transport,
-	newAPITransport func(serviceName string) api.Transport,
+	newAPITransport func(serviceName string, testSkippingLevel settings.TestSkippingLevel) api.Transport,
 	repositoryChangesUploader func() (int64, error),
 	enableSignalHandler bool,
 ) *TestOptimizationClient {
+	return newTestOptimizationClientWithTestSkippingLevel(
+		apiTransport,
+		newAPITransport,
+		repositoryChangesUploader,
+		enableSignalHandler,
+		settings.TestSkippingLevelTest,
+	)
+}
+
+func newTestOptimizationClientWithTestSkippingLevel(
+	apiTransport api.Transport,
+	newAPITransport func(serviceName string, testSkippingLevel settings.TestSkippingLevel) api.Transport,
+	repositoryChangesUploader func() (int64, error),
+	enableSignalHandler bool,
+	testSkippingLevel settings.TestSkippingLevel,
+) *TestOptimizationClient {
 	if apiTransport == nil && newAPITransport == nil {
-		newAPITransport = api.NewTransportWithServiceName
+		newAPITransport = api.NewTransportWithServiceNameAndTestSkippingLevel
 	}
 
 	return &TestOptimizationClient{
@@ -79,6 +101,7 @@ func newTestOptimizationClient(
 		cacheManager:              NewCacheManager(),
 		repositoryChangesUploader: repositoryChangesUploader,
 		enableSignalHandler:       enableSignalHandler,
+		testSkippingLevel:         testSkippingLevel,
 	}
 }
 
@@ -101,13 +124,16 @@ func (c *TestOptimizationClient) GetSettings() *api.SettingsResponseData {
 	return c.ensureSettingsInitialization(autoDetectServiceName)
 }
 
-func (c *TestOptimizationClient) GetSkippableTests() map[string]bool {
+func (c *TestOptimizationClient) GetSkippables() api.Skippables {
 	startTime := time.Now()
 
-	slog.Debug("Fetching skippable tests...")
+	slog.Debug("Fetching skippable tests and suites...")
 	c.ensureTestOptimizationInitialized()
-	if c.skippableTests == nil {
-		c.skippableTests = api.SkippableTests{}
+	if c.skippables.Tests == nil {
+		c.skippables.Tests = api.SkippableTests{}
+	}
+	if c.skippables.Suites == nil {
+		c.skippables.Suites = api.SkippableSuites{}
 	}
 
 	if c.apiTransport != nil {
@@ -117,9 +143,12 @@ func (c *TestOptimizationClient) GetSkippableTests() map[string]bool {
 	}
 
 	duration := time.Since(startTime)
-	slog.Debug("Finished fetching skippable tests", "count", len(c.skippableTests), "duration", duration)
+	slog.Debug("Finished fetching skippable tests and suites",
+		"testsCount", len(c.skippables.Tests),
+		"suitesCount", len(c.skippables.Suites),
+		"duration", duration)
 
-	return c.skippableTests
+	return c.skippables
 }
 
 func (c *TestOptimizationClient) GetKnownTests() *api.KnownTestsResponseData {
@@ -273,7 +302,7 @@ func (c *TestOptimizationClient) ensureAPITransport(serviceName string) api.Tran
 	if c.newAPITransport == nil {
 		return nil
 	}
-	c.apiTransport = c.newAPITransport(serviceName)
+	c.apiTransport = c.newAPITransport(serviceName, c.testSkippingLevel)
 	return c.apiTransport
 }
 
@@ -350,13 +379,15 @@ func (c *TestOptimizationClient) ensureTestOptimizationInitialized() {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				correlationID, skippableTests, err := c.apiTransport.GetSkippableTests()
+				correlationID, skippables, err := c.apiTransport.GetSkippableTests()
 				if err != nil {
 					slog.Error("testoptimization: error getting test optimization skippable tests", "err", err.Error())
-				} else if skippableTests != nil {
-					slog.Debug("testoptimization: skippable tests loaded", "count", len(skippableTests))
+				} else {
+					slog.Debug("testoptimization: skippable tests loaded",
+						"testsCount", len(skippables.Tests),
+						"suitesCount", len(skippables.Suites))
 					setAdditionalTags(constants.ItrCorrelationIDTag, correlationID)
-					c.skippableTests = skippableTests
+					c.skippables = skippables
 				}
 			}()
 		}

--- a/internal/testoptimization/testoptimization_lifecycle_test.go
+++ b/internal/testoptimization/testoptimization_lifecycle_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/ddtest/internal/environment"
 	"github.com/DataDog/ddtest/internal/git"
 	"github.com/DataDog/ddtest/internal/git/gittest"
+	"github.com/DataDog/ddtest/internal/settings"
 	"github.com/DataDog/ddtest/internal/testoptimization/api"
 )
 
@@ -53,8 +54,10 @@ func TestTestOptimizationClientFeatureGetters(t *testing.T) {
 			},
 		},
 		SkippableCorrelationID: "correlation-id",
-		SkippableTests: api.SkippableTests{
-			"module.suite.test.": true,
+		Skippables: api.Skippables{
+			Tests: api.SkippableTests{
+				"module.suite.test.": true,
+			},
 		},
 		TestManagementTestsData: &api.TestManagementTestsResponseDataModules{
 			Modules: map[string]api.TestManagementTestsResponseDataSuites{
@@ -78,7 +81,7 @@ func TestTestOptimizationClientFeatureGetters(t *testing.T) {
 	if known := client.GetKnownTests(); known == nil || len(known.Tests) != 1 {
 		t.Fatalf("expected known tests, got %#v", known)
 	}
-	if skippable := client.GetSkippableTests(); len(skippable) != 1 || !skippable["module.suite.test."] {
+	if skippable := client.GetSkippables().Tests; len(skippable) != 1 || !skippable["module.suite.test."] {
 		t.Fatalf("expected skippable tests, got %#v", skippable)
 	}
 	if managed := client.GetTestManagementTestsData(); managed == nil || len(managed.Modules) != 1 {
@@ -92,6 +95,32 @@ func TestTestOptimizationClientFeatureGetters(t *testing.T) {
 	ciTags := environment.GetCITags()
 	if ciTags[constants.ItrCorrelationIDTag] != "correlation-id" {
 		t.Fatalf("expected correlation id tag, got %#v", ciTags)
+	}
+}
+
+func TestNewTestOptimizationClientWithTestSkippingLevelPropagatesToTransportFactory(t *testing.T) {
+	mockTransport := &MockAPIClient{
+		Settings: &api.SettingsResponseData{TestsSkipping: true},
+	}
+	var capturedLevel settings.TestSkippingLevel
+	client := newTestOptimizationClientWithTestSkippingLevel(
+		nil,
+		func(_ string, testSkippingLevel settings.TestSkippingLevel) api.Transport {
+			capturedLevel = testSkippingLevel
+			return mockTransport
+		},
+		func() (int64, error) { return 0, nil },
+		false,
+		settings.TestSkippingLevelSuite,
+	)
+
+	if err := client.Initialize(map[string]string{}); err != nil {
+		t.Fatalf("Initialize() returned error: %v", err)
+	}
+	client.GetSkippables()
+
+	if capturedLevel != settings.TestSkippingLevelSuite {
+		t.Fatalf("transport factory test skipping level = %q, want %q", capturedLevel, settings.TestSkippingLevelSuite)
 	}
 }
 
@@ -109,7 +138,7 @@ func TestTestOptimizationClientFeatureGettersDisabled(t *testing.T) {
 	if managed := client.GetTestManagementTestsData(); managed != nil {
 		t.Fatalf("expected nil test management tests when disabled, got %#v", managed)
 	}
-	if skippable := client.GetSkippableTests(); len(skippable) != 0 {
+	if skippable := client.GetSkippables().Tests; len(skippable) != 0 {
 		t.Fatalf("expected empty skippable map when disabled, got %#v", skippable)
 	}
 }
@@ -137,7 +166,7 @@ func TestEnsureSettingsInitializationRequireGitRetriesAfterUpload(t *testing.T) 
 }
 
 func TestEnsureSettingsInitializationHandlesMissingTransportAndErrors(t *testing.T) {
-	client := newTestOptimizationClient(nil, func(string) api.Transport { return nil }, nil, false)
+	client := newTestOptimizationClient(nil, func(string, settings.TestSkippingLevel) api.Transport { return nil }, nil, false)
 	if settings := client.GetSettings(); settings != nil {
 		t.Fatalf("expected nil settings without transport, got %#v", settings)
 	}

--- a/internal/testoptimization/testoptimization_test.go
+++ b/internal/testoptimization/testoptimization_test.go
@@ -30,7 +30,7 @@ type MockAPIClient struct {
 	SettingsErr                    error
 	SettingsRawResponse            json.RawMessage
 	SettingsCalls                  int
-	SkippableTests                 api.SkippableTests
+	Skippables                     api.Skippables
 	SkippableCorrelationID         string
 	SkippableErr                   error
 	SkippableTestsRawResponse      json.RawMessage
@@ -66,9 +66,16 @@ func (m *MockAPIClient) GetSettingsRawResponse() json.RawMessage {
 	return m.SettingsRawResponse
 }
 
-func (m *MockAPIClient) GetSkippableTests() (string, api.SkippableTests, error) {
+func (m *MockAPIClient) GetSkippableTests() (string, api.Skippables, error) {
 	m.SkippableTestsCalls++
-	return m.SkippableCorrelationID, m.SkippableTests, m.SkippableErr
+	skippables := m.Skippables
+	if skippables.Tests == nil {
+		skippables.Tests = api.SkippableTests{}
+	}
+	if skippables.Suites == nil {
+		skippables.Suites = api.SkippableSuites{}
+	}
+	return m.SkippableCorrelationID, skippables, m.SkippableErr
 }
 
 func (m *MockAPIClient) GetSkippableTestsRawResponse() json.RawMessage {
@@ -293,7 +300,7 @@ func TestTestOptimizationClient_Initialize(t *testing.T) {
 	}
 }
 
-func TestTestOptimizationClient_GetSkippableTests_NilResponse(t *testing.T) {
+func TestTestOptimizationClient_GetSkippables_NilResponse(t *testing.T) {
 	mockAPIClient := &MockAPIClient{
 		Settings: &api.SettingsResponseData{
 			ItrEnabled:    false,
@@ -308,27 +315,29 @@ func TestTestOptimizationClient_GetSkippableTests_NilResponse(t *testing.T) {
 		t.Fatalf("Initialize() failed: %v", err)
 	}
 
-	result := client.GetSkippableTests()
+	result := client.GetSkippables().Tests
 
 	if result == nil {
-		t.Error("GetSkippableTests() should return non-nil map")
+		t.Error("GetSkippables().Tests should return non-nil map")
 	}
 
 	if len(result) != 0 {
-		t.Errorf("GetSkippableTests() should return empty map when ITR is disabled, got %d items", len(result))
+		t.Errorf("GetSkippables().Tests should return empty map when ITR is disabled, got %d items", len(result))
 	}
 }
 
-func TestTestOptimizationClient_GetSkippableTests(t *testing.T) {
+func TestTestOptimizationClient_GetSkippables(t *testing.T) {
 	mockAPIClient := &MockAPIClient{
 		Settings: &api.SettingsResponseData{
 			ItrEnabled:    true,
 			TestsSkipping: true,
 		},
-		SkippableTests: api.SkippableTests{
-			"module1.TestSuite1.test_method_1.param1": true,
-			"module1.TestSuite1.test_method_2.param2": true,
-			"module2.TestSuite2.test_method_3.param3": true,
+		Skippables: api.Skippables{
+			Tests: api.SkippableTests{
+				"module1.TestSuite1.test_method_1.param1": true,
+				"module1.TestSuite1.test_method_2.param2": true,
+				"module2.TestSuite2.test_method_3.param3": true,
+			},
 		},
 	}
 	client := newTestOptimizationClientForTest(t, mockAPIClient)
@@ -339,10 +348,10 @@ func TestTestOptimizationClient_GetSkippableTests(t *testing.T) {
 		t.Fatalf("Initialize() failed: %v", err)
 	}
 
-	result := client.GetSkippableTests()
+	result := client.GetSkippables().Tests
 
 	if result == nil {
-		t.Error("GetSkippableTests() should return non-nil map")
+		t.Error("GetSkippables().Tests should return non-nil map")
 	}
 
 	// Verify expected test FQNs are present
@@ -559,13 +568,13 @@ func TestTestOptimizationClient_GetDisabledTestsDisabled(t *testing.T) {
 	}
 }
 
-func TestTestOptimizationClient_GetSkippableTests_EmptyData(t *testing.T) {
+func TestTestOptimizationClient_GetSkippables_EmptyData(t *testing.T) {
 	mockAPIClient := &MockAPIClient{
 		Settings: &api.SettingsResponseData{
 			ItrEnabled:    true,
 			TestsSkipping: true,
 		},
-		SkippableTests: api.SkippableTests{},
+		Skippables: api.NewSkippables(),
 	}
 	client := newTestOptimizationClientForTest(t, mockAPIClient)
 
@@ -575,18 +584,18 @@ func TestTestOptimizationClient_GetSkippableTests_EmptyData(t *testing.T) {
 		t.Fatalf("Initialize() failed: %v", err)
 	}
 
-	result := client.GetSkippableTests()
+	result := client.GetSkippables().Tests
 
 	if result == nil {
-		t.Error("GetSkippableTests() should return non-nil map even with empty data")
+		t.Error("GetSkippables().Tests should return non-nil map even with empty data")
 	}
 
 	if len(result) != 0 {
-		t.Errorf("GetSkippableTests() should return empty map with empty data, got %d items", len(result))
+		t.Errorf("GetSkippables().Tests should return empty map with empty data, got %d items", len(result))
 	}
 }
 
-func TestTestOptimizationClient_GetSkippableTests_WritesHTTPCache(t *testing.T) {
+func TestTestOptimizationClient_GetSkippables_WritesHTTPCache(t *testing.T) {
 	cleanPlanDirectory(t)
 
 	skippableTestsResponse := json.RawMessage(`{"data":[{"id":"test-id","type":"test","attributes":{"suite":"TestSuite1","name":"test_method_1"}}]}`)
@@ -596,8 +605,10 @@ func TestTestOptimizationClient_GetSkippableTests_WritesHTTPCache(t *testing.T) 
 			ItrEnabled:    true,
 			TestsSkipping: true,
 		},
-		SkippableTests: api.SkippableTests{
-			"module1.TestSuite1.test_method_1.param1": true,
+		Skippables: api.Skippables{
+			Tests: api.SkippableTests{
+				"module1.TestSuite1.test_method_1.param1": true,
+			},
 		},
 		SkippableTestsRawResponse: skippableTestsResponse,
 	}
@@ -608,7 +619,7 @@ func TestTestOptimizationClient_GetSkippableTests_WritesHTTPCache(t *testing.T) 
 		t.Fatalf("Initialize() failed: %v", err)
 	}
 
-	result := client.GetSkippableTests()
+	result := client.GetSkippables().Tests
 
 	if len(result) != 1 {
 		t.Fatalf("Expected 1 skippable test, got %d", len(result))

--- a/internal/testoptimization/types.go
+++ b/internal/testoptimization/types.go
@@ -19,3 +19,8 @@ func (t *Test) FQN() string {
 func (t *Test) DatadogTestId() string {
 	return fmt.Sprintf("%s.%s.%s.%s", t.Module, t.Suite, t.Name, t.Parameters)
 }
+
+// DatadogSuiteId returns the parameter-free suite identity used for suite-level TIA matching.
+func (t *Test) DatadogSuiteId() string {
+	return fmt.Sprintf("%s.%s", t.Module, t.Suite)
+}

--- a/internal/utils/file.go
+++ b/internal/utils/file.go
@@ -1,0 +1,24 @@
+package utils
+
+import (
+	"os"
+	"strings"
+)
+
+// FileContainsAll reports whether a file contains every marker.
+// If the file cannot be read, it returns true so callers that use this as a
+// safety guard keep the file runnable.
+func FileContainsAll(path string, markers ...string) bool {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return true
+	}
+
+	text := string(content)
+	for _, marker := range markers {
+		if !strings.Contains(text, marker) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/utils/path.go
+++ b/internal/utils/path.go
@@ -89,8 +89,8 @@ func stripSubdirPrefix(path string, subdirPrefix string) string {
 		return path
 	}
 
-	normalizedPath := filepath.ToSlash(path)
-	prefixWithSlash := subdirPrefix + "/"
+	normalizedPath := NormalizePath(path)
+	prefixWithSlash := NormalizePath(subdirPrefix) + "/"
 	if strings.HasPrefix(normalizedPath, prefixWithSlash) {
 		stripped := strings.TrimPrefix(normalizedPath, prefixWithSlash)
 		slog.Debug("Normalized test file path for subdirectory execution",

--- a/internal/utils/path_test.go
+++ b/internal/utils/path_test.go
@@ -82,6 +82,25 @@ func TestStripCwdSubdirPrefix_SubdirPrefixMatch_StripsPrefix(t *testing.T) {
 	}
 }
 
+func TestStripCwdSubdirPrefix_LeadingCurrentDir_StripsPrefix(t *testing.T) {
+	repoRoot := t.TempDir()
+	initGitRepoInDir(t, repoRoot)
+
+	coreDir := filepath.Join(repoRoot, "core")
+	_ = os.MkdirAll(coreDir, 0755)
+
+	oldWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldWd) }()
+	_ = os.Chdir(coreDir)
+	resetCwdSubdirPrefixCache(t)
+
+	result := StripCwdSubdirPrefix("./core/spec/models/order_spec.rb")
+	expected := "spec/models/order_spec.rb"
+	if result != expected {
+		t.Errorf("Expected %q, got %q", expected, result)
+	}
+}
+
 func TestStripCwdSubdirPrefix_NestedSubdirPrefixMatch_StripsFullPrefix(t *testing.T) {
 	repoRoot := t.TempDir()
 	initGitRepoInDir(t, repoRoot)


### PR DESCRIPTION
## What

Add suite-level Test Impact Analysis skipping support across settings, platform/framework capabilities, backend API parsing, and planner behaviour.

Python remains test-level, JavaScript/Jest uses suite-level, and Ruby gets configurable test/suite mode through `DD_TESTOPTIMIZATION_TIA_TEST_SKIPPING_MODE` with invalid values falling back to test mode. Settings and skippables requests now include `test_level`, skippable responses can contain tests and suites, and the planner can apply suite-level skips from fast file discovery for Jest and Ruby suite mode.

The implementation also keeps conservative file-skip guards for tracer-side unskippable markers and preserves test-level behavior for existing full-discovery flows.

## Why

DDTest needs to support tracers that skip at suite level, including JavaScript today and Ruby when configured for suite skipping. Suite-level mode should not require full test discovery when the tracer suite name already identifies the source file, otherwise ddtest misses valid skips for JS and does unnecessary discovery for Ruby suite mode.

## E2E testing

Test with a real Datadog backend (EU target): feature branch in a playground, make some changes, commit, run tests, observe results. Test for Minitest and RSpec.

1. Make sure that the old functionality did not regress: by default ddtest uses test level skipping, ddtest runs full tests discovery, it doesn't schedule fully skipped test suites, it schedules partially skipped test suites, Ruby library skips tests inside partially skipped test suites
2. Set `DD_TESTOPTIMIZATION_TIA_TEST_SKIPPING_MODE=suite` and confirm that ddtest works as well in suite skipping mode: it correctly avoids scheduling skipped test suites, it correctly schedules all other test suites, it doesn't need to run full tests discovery to make proper scheduling decisions.
3. Make sure that if a test suite has unskippable tests, it is always scheduled by ddtest (consult Datadog docs to learn about how to mark tests unskippable in code)