### PR TITLE
ci: install python test dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,11 @@ jobs:
         with:
           go-version: "1.26.3"
 
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
       - name: Cache Go modules
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
@@ -34,6 +39,9 @@ jobs:
 
       - name: Verify dependencies
         run: go mod verify
+
+      - name: Install Python test dependencies
+        run: python -m pip install "ddtrace>=4.10.3" pytest
 
       - name: Format check
         run: |


### PR DESCRIPTION
## What

Install Python 3.12 test dependencies in CI before running the Go test suite: `pytest` and `ddtrace>=4.10.3`.

## Why

The Python platform integration test checks `DetectPlatform` against a real `python` executable and requires `ddtrace` to be importable. Without installing these dependencies in CI, `TestDetectPlatform_Python` skips instead of validating the Python support path added for pytest. Installing the dependencies makes CI exercise the Python sanity check and catches regressions in the `ddtrace` version gate and platform detection behavior.

## E2E testing

Run the CI test job on this branch and verify `go test -race -coverpkg=./... -coverprofile=coverage.out -covermode=atomic ./...` completes after the Python dependency installation step. Locally, `go test -v ./internal/platform -run TestDetectPlatform_Python` should pass rather than skip when `ddtrace` and `pytest` are installed.