### PR TITLE
docs: lower JavaScript dd-trace requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Minimum supported library and runtime requirements:
 
 - Ruby requires the `datadog-ci` gem **1.31.0** or higher.
 - Python requires the `ddtrace` package **4.10.3** or higher and `pytest`.
-- JavaScript requires the `dd-trace` package **6.0.0** or higher, Node.js, and
+- JavaScript requires the `dd-trace` package **5.111.0** or higher, Node.js, and
   Jest.
 
 For instructions on setting up Test Optimization, see the [Datadog Test Optimization documentation](https://docs.datadoghq.com/tests/setup/).

--- a/docs/upgrade-1.0.md
+++ b/docs/upgrade-1.0.md
@@ -10,7 +10,7 @@ Minimum supported library and runtime requirements:
 
 - Ruby requires the `datadog-ci` gem 1.31.0 or higher.
 - Python requires the `ddtrace` package 4.10.3 or higher and `pytest`.
-- JavaScript requires the `dd-trace` package 6.0.0 or higher, Node.js, and
+- JavaScript requires the `dd-trace` package 5.111.0 or higher, Node.js, and
   Jest.
 
 DDTest 1.0 writes plan files under `.testoptimization/runner/*`. If your
@@ -28,7 +28,7 @@ these paths:
 
 1. Verify the Datadog Test Optimization library version for your platform:
    `datadog-ci` 1.31.0 or higher for Ruby, or `ddtrace` 4.10.3 or higher for
-   Python, or `dd-trace` 6.0.0 or higher for JavaScript.
+   Python, or `dd-trace` 5.111.0 or higher for JavaScript.
 2. Remove references to legacy root plan paths from CI templates and custom scripts.
 3. Run `ddtest plan` in CI.
 4. Run one CI shard with `DD_TEST_OPTIMIZATION_RUNNER_CI_NODE=0 ddtest run`.


### PR DESCRIPTION
## What

Update DDTest JavaScript prerequisites from dd-trace 6.0.0 or higher to dd-trace 5.111.0 or higher in README and upgrade guide.

## Why

dd-trace-js v5.111.0 also contains the Jest support needed for DDTest. This keeps repository docs aligned with the public documentation update in DataDog/documentation#37980 and avoids forcing customers on the v5 release line to jump to v6 just for DDTest.

## E2E testing

Docs-only change. Validation performed:
- make test
- make lint