### PR TITLE
docs: update Python ddtrace requirement to 4.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Before using DDTest, you must have **Datadog Test Optimization** already set up 
 Minimum supported library and runtime requirements:
 
 - Ruby requires the `datadog-ci` gem **1.31.0** or higher.
-- Python requires the `ddtrace` package **4.10.3** or higher and `pytest`.
+- Python requires the `ddtrace` package **4.11.0** or higher and `pytest`.
 - JavaScript requires the `dd-trace` package **5.111.0** or higher, Node.js, and
   Jest.
 

--- a/docs/examples/circleci.md
+++ b/docs/examples/circleci.md
@@ -151,7 +151,7 @@ jobs:
       - checkout
       - run:
           name: Install Python dependencies
-          command: python -m pip install -r requirements.txt "ddtrace>=4.10.3" pytest
+          command: python -m pip install -r requirements.txt "ddtrace>=4.11.0" pytest
       - test-optimization-circleci-orb/autoinstrument:
           languages: python
           site: datadoghq.eu

--- a/docs/examples/github-actions.md
+++ b/docs/examples/github-actions.md
@@ -116,7 +116,7 @@ Replace each Ruby setup step with Python dependency installation:
     python-version: "3.12"
     cache: pip
 - name: Install Python dependencies
-  run: python -m pip install -r requirements.txt "ddtrace>=4.10.3" pytest
+  run: python -m pip install -r requirements.txt "ddtrace>=4.11.0" pytest
 ```
 
 Configure Datadog Test Optimization for Python:

--- a/docs/upgrade-1.0.md
+++ b/docs/upgrade-1.0.md
@@ -9,7 +9,7 @@ Before upgrading to 1.0, update CI jobs and custom integrations to consume the
 Minimum supported library and runtime requirements:
 
 - Ruby requires the `datadog-ci` gem 1.31.0 or higher.
-- Python requires the `ddtrace` package 4.10.3 or higher and `pytest`.
+- Python requires the `ddtrace` package 4.11.0 or higher and `pytest`.
 - JavaScript requires the `dd-trace` package 5.111.0 or higher, Node.js, and
   Jest.
 
@@ -27,7 +27,7 @@ these paths:
 ## Validation Checklist
 
 1. Verify the Datadog Test Optimization library version for your platform:
-   `datadog-ci` 1.31.0 or higher for Ruby, or `ddtrace` 4.10.3 or higher for
+   `datadog-ci` 1.31.0 or higher for Ruby, or `ddtrace` 4.11.0 or higher for
    Python, or `dd-trace` 5.111.0 or higher for JavaScript.
 2. Remove references to legacy root plan paths from CI templates and custom scripts.
 3. Run `ddtest plan` in CI.


### PR DESCRIPTION
## What
Updated documentation to require ddtrace 4.11.0 or higher for Python instead of 4.10.3.

## Why
Ensures documentation points to the correct minimum version for Python ddtrace package.

## E2E testing
Verified that all instances of 4.10.3 were updated to 4.11.0 across README.md, GitHub Actions example, CircleCI example, and upgrade guide.