### PR TITLE
[SDTEST-3873] Add internal telemetry metrics

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -4,15 +4,12 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"net/url"
 	"os"
-	"time"
 
 	"github.com/DataDog/ddtest/internal/buildinfo"
 	"github.com/DataDog/ddtest/internal/constants"
 	"github.com/DataDog/ddtest/internal/environment"
 	"github.com/DataDog/ddtest/internal/git"
-	"github.com/DataDog/ddtest/internal/httptransport"
 	"github.com/DataDog/ddtest/internal/planner"
 	"github.com/DataDog/ddtest/internal/runmetadata"
 	"github.com/DataDog/ddtest/internal/runner"
@@ -20,12 +17,6 @@ import (
 	"github.com/DataDog/ddtest/internal/telemetry"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-)
-
-const (
-	telemetryAPIPath     = "/api/v2/apmtelemetry"
-	telemetryAgentPath   = "/telemetry/proxy/api/v2/apmtelemetry"
-	telemetryHTTPTimeout = 5 * time.Second
 )
 
 // defaultParallelism stores the computed default at init time for CLI flags
@@ -162,37 +153,11 @@ func runTestCommand(cmd *cobra.Command, args []string) {
 }
 
 func createTelemetryClient() (telemetry.Client, error) {
-	connection, err := httptransport.ResolveDatadogConnection()
-	if err != nil {
-		return nil, err
-	}
-
-	var endpoint, apiKey string
-	httpClient := httptransport.NewHTTPClient(telemetryHTTPTimeout)
-	if connection.Agentless {
-		baseURL := connection.AgentlessURL
-		if baseURL == "" {
-			baseURL = fmt.Sprintf("https://instrumentation-telemetry-intake.%s", connection.Site)
-		}
-		apiKey = connection.APIKey
-		endpoint, err = url.JoinPath(baseURL, telemetryAPIPath)
-	} else {
-		agentURL, agentHTTPClient := httptransport.AgentHTTPTransport(connection.AgentURL, telemetryHTTPTimeout)
-		httpClient = agentHTTPClient
-		endpoint, err = url.JoinPath(agentURL.String(), telemetryAgentPath)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("create telemetry endpoint: %w", err)
-	}
-
 	ciTags := environment.GetCITags()
 	return telemetry.NewClient(telemetry.Config{
-		Endpoint:       endpoint,
-		APIKey:         apiKey,
 		ServiceName:    runmetadata.New(ciTags).Service,
 		Environment:    os.Getenv("DD_ENV"),
 		LibraryVersion: buildinfo.CurrentVersion(),
-		HTTPClient:     httpClient,
 	})
 }
 
@@ -204,9 +169,7 @@ func runWithTelemetry(ctx context.Context, operation func(telemetry.Client) erro
 	}
 
 	operationErr := operation(telemetryClient)
-	flushCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), telemetryHTTPTimeout)
-	defer cancel()
-	if err := telemetryClient.Flush(flushCtx); err != nil {
+	if err := telemetryClient.Flush(context.WithoutCancel(ctx)); err != nil {
 		slog.Debug("Failed to flush telemetry metrics", "error", err)
 	}
 	return operationErr

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -4,16 +4,28 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"os"
+	"time"
 
 	"github.com/DataDog/ddtest/internal/buildinfo"
 	"github.com/DataDog/ddtest/internal/constants"
+	"github.com/DataDog/ddtest/internal/environment"
 	"github.com/DataDog/ddtest/internal/git"
+	"github.com/DataDog/ddtest/internal/httptransport"
 	"github.com/DataDog/ddtest/internal/planner"
+	"github.com/DataDog/ddtest/internal/runmetadata"
 	"github.com/DataDog/ddtest/internal/runner"
 	"github.com/DataDog/ddtest/internal/settings"
+	"github.com/DataDog/ddtest/internal/telemetry"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+)
+
+const (
+	telemetryAPIPath     = "/api/v2/apmtelemetry"
+	telemetryAgentPath   = "/telemetry/proxy/api/v2/apmtelemetry"
+	telemetryHTTPTimeout = 5 * time.Second
 )
 
 // defaultParallelism stores the computed default at init time for CLI flags
@@ -30,9 +42,12 @@ var rootCmd = &cobra.Command{
 }
 
 var (
-	planCommand = planner.Plan
-	newRunner   = func() runner.Runner { return runner.New() }
-	exitProcess = os.Exit
+	planCommand = func(ctx context.Context, telemetryClient telemetry.Client) error {
+		return planner.NewWithTelemetry(telemetryClient).Plan(ctx)
+	}
+	newRunner          = func(telemetryClient telemetry.Client) runner.Runner { return runner.NewWithTelemetry(telemetryClient) }
+	newTelemetryClient = createTelemetryClient
+	exitProcess        = os.Exit
 )
 
 var planCmd = &cobra.Command{
@@ -124,7 +139,10 @@ func bindPersistentFlags(cmd *cobra.Command, bindings []persistentFlagBinding) e
 
 func runPlanCommand(cmd *cobra.Command, args []string) {
 	ctx := context.Background()
-	if err := planCommand(ctx); err != nil {
+	err := runWithTelemetry(ctx, func(telemetryClient telemetry.Client) error {
+		return planCommand(ctx, telemetryClient)
+	})
+	if err != nil {
 		slog.Error("Planner failed", "error", err)
 		exitProcess(1)
 		return
@@ -133,12 +151,65 @@ func runPlanCommand(cmd *cobra.Command, args []string) {
 
 func runTestCommand(cmd *cobra.Command, args []string) {
 	ctx := context.Background()
-	testRunner := newRunner()
-	if err := testRunner.Run(ctx); err != nil {
+	err := runWithTelemetry(ctx, func(telemetryClient telemetry.Client) error {
+		return newRunner(telemetryClient).Run(ctx)
+	})
+	if err != nil {
 		slog.Error("Runner failed", "error", err)
 		exitProcess(1)
 		return
 	}
+}
+
+func createTelemetryClient() (telemetry.Client, error) {
+	connection, err := httptransport.ResolveDatadogConnection()
+	if err != nil {
+		return nil, err
+	}
+
+	var endpoint, apiKey string
+	httpClient := httptransport.NewHTTPClient(telemetryHTTPTimeout)
+	if connection.Agentless {
+		baseURL := connection.AgentlessURL
+		if baseURL == "" {
+			baseURL = fmt.Sprintf("https://instrumentation-telemetry-intake.%s", connection.Site)
+		}
+		apiKey = connection.APIKey
+		endpoint, err = url.JoinPath(baseURL, telemetryAPIPath)
+	} else {
+		agentURL, agentHTTPClient := httptransport.AgentHTTPTransport(connection.AgentURL, telemetryHTTPTimeout)
+		httpClient = agentHTTPClient
+		endpoint, err = url.JoinPath(agentURL.String(), telemetryAgentPath)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("create telemetry endpoint: %w", err)
+	}
+
+	ciTags := environment.GetCITags()
+	return telemetry.NewClient(telemetry.Config{
+		Endpoint:       endpoint,
+		APIKey:         apiKey,
+		ServiceName:    runmetadata.New(ciTags).Service,
+		Environment:    os.Getenv("DD_ENV"),
+		LibraryVersion: buildinfo.CurrentVersion(),
+		HTTPClient:     httpClient,
+	})
+}
+
+func runWithTelemetry(ctx context.Context, operation func(telemetry.Client) error) error {
+	telemetryClient, err := newTelemetryClient()
+	if err != nil {
+		slog.Debug("Failed to create telemetry client", "error", err)
+		telemetryClient = telemetry.NoopClient()
+	}
+
+	operationErr := operation(telemetryClient)
+	flushCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), telemetryHTTPTimeout)
+	defer cancel()
+	if err := telemetryClient.Flush(flushCtx); err != nil {
+		slog.Debug("Failed to flush telemetry metrics", "error", err)
+	}
+	return operationErr
 }
 
 func Execute() error {

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/DataDog/ddtest/internal/git"
 	runnerpkg "github.com/DataDog/ddtest/internal/runner"
 	"github.com/DataDog/ddtest/internal/settings"
+	"github.com/DataDog/ddtest/internal/telemetry"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -192,15 +193,22 @@ func TestRootPersistentPreRunChecksGitAvailability(t *testing.T) {
 
 func TestRunPlanCommand(t *testing.T) {
 	originalPlanCommand := planCommand
+	originalNewTelemetryClient := newTelemetryClient
 	originalExitProcess := exitProcess
 	t.Cleanup(func() {
 		planCommand = originalPlanCommand
+		newTelemetryClient = originalNewTelemetryClient
 		exitProcess = originalExitProcess
 	})
 
+	telemetryClient := &fakeTelemetryClient{}
+	newTelemetryClient = func() (telemetry.Client, error) { return telemetryClient, nil }
 	calls := 0
-	planCommand = func(ctx context.Context) error {
+	planCommand = func(ctx context.Context, got telemetry.Client) error {
 		calls++
+		if got != telemetryClient {
+			t.Fatal("plan command did not receive the command telemetry client")
+		}
 		return nil
 	}
 	exitProcess = func(code int) {
@@ -212,18 +220,25 @@ func TestRunPlanCommand(t *testing.T) {
 	if calls != 1 {
 		t.Fatalf("expected plan command to be called once, got %d", calls)
 	}
+	if telemetryClient.flushCalls != 1 {
+		t.Fatalf("telemetry flush calls = %d, want 1", telemetryClient.flushCalls)
+	}
 }
 
 func TestRunPlanCommandExitsOnError(t *testing.T) {
 	originalPlanCommand := planCommand
+	originalNewTelemetryClient := newTelemetryClient
 	originalExitProcess := exitProcess
 	t.Cleanup(func() {
 		planCommand = originalPlanCommand
+		newTelemetryClient = originalNewTelemetryClient
 		exitProcess = originalExitProcess
 	})
 
+	telemetryClient := &fakeTelemetryClient{}
+	newTelemetryClient = func() (telemetry.Client, error) { return telemetryClient, nil }
 	planErr := errors.New("planner failed")
-	planCommand = func(ctx context.Context) error {
+	planCommand = func(ctx context.Context, got telemetry.Client) error {
 		return planErr
 	}
 	var exitCodes []int
@@ -236,18 +251,28 @@ func TestRunPlanCommandExitsOnError(t *testing.T) {
 	if len(exitCodes) != 1 || exitCodes[0] != 1 {
 		t.Fatalf("expected exit code 1, got %v", exitCodes)
 	}
+	if telemetryClient.flushCalls != 1 {
+		t.Fatalf("telemetry flush calls = %d, want 1", telemetryClient.flushCalls)
+	}
 }
 
 func TestRunTestCommand(t *testing.T) {
 	originalNewRunner := newRunner
+	originalNewTelemetryClient := newTelemetryClient
 	originalExitProcess := exitProcess
 	t.Cleanup(func() {
 		newRunner = originalNewRunner
+		newTelemetryClient = originalNewTelemetryClient
 		exitProcess = originalExitProcess
 	})
 
+	telemetryClient := &fakeTelemetryClient{}
+	newTelemetryClient = func() (telemetry.Client, error) { return telemetryClient, nil }
 	fake := &fakeCommandRunner{}
-	newRunner = func() runnerpkg.Runner {
+	newRunner = func(got telemetry.Client) runnerpkg.Runner {
+		if got != telemetryClient {
+			t.Fatal("runner did not receive the command telemetry client")
+		}
 		return fake
 	}
 	exitProcess = func(code int) {
@@ -259,18 +284,25 @@ func TestRunTestCommand(t *testing.T) {
 	if fake.calls != 1 {
 		t.Fatalf("expected runner to be called once, got %d", fake.calls)
 	}
+	if telemetryClient.flushCalls != 1 {
+		t.Fatalf("telemetry flush calls = %d, want 1", telemetryClient.flushCalls)
+	}
 }
 
 func TestRunTestCommandExitsOnError(t *testing.T) {
 	originalNewRunner := newRunner
+	originalNewTelemetryClient := newTelemetryClient
 	originalExitProcess := exitProcess
 	t.Cleanup(func() {
 		newRunner = originalNewRunner
+		newTelemetryClient = originalNewTelemetryClient
 		exitProcess = originalExitProcess
 	})
 
+	telemetryClient := &fakeTelemetryClient{}
+	newTelemetryClient = func() (telemetry.Client, error) { return telemetryClient, nil }
 	fake := &fakeCommandRunner{err: errors.New("runner failed")}
-	newRunner = func() runnerpkg.Runner {
+	newRunner = func(got telemetry.Client) runnerpkg.Runner {
 		return fake
 	}
 	var exitCodes []int
@@ -282,6 +314,47 @@ func TestRunTestCommandExitsOnError(t *testing.T) {
 
 	if len(exitCodes) != 1 || exitCodes[0] != 1 {
 		t.Fatalf("expected exit code 1, got %v", exitCodes)
+	}
+	if telemetryClient.flushCalls != 1 {
+		t.Fatalf("telemetry flush calls = %d, want 1", telemetryClient.flushCalls)
+	}
+}
+
+func TestRunWithTelemetryFallsBackWhenCreationFails(t *testing.T) {
+	originalNewTelemetryClient := newTelemetryClient
+	t.Cleanup(func() { newTelemetryClient = originalNewTelemetryClient })
+	newTelemetryClient = func() (telemetry.Client, error) {
+		return nil, errors.New("telemetry unavailable")
+	}
+
+	operationErr := errors.New("operation failed")
+	got := runWithTelemetry(context.Background(), func(client telemetry.Client) error {
+		if client == nil {
+			t.Fatal("operation received nil telemetry client")
+		}
+		client.Count("safe", nil).Submit(1)
+		return operationErr
+	})
+	if !errors.Is(got, operationErr) {
+		t.Fatalf("runWithTelemetry() error = %v, want operation error", got)
+	}
+}
+
+func TestRunWithTelemetryDoesNotReplaceCommandErrorWithFlushError(t *testing.T) {
+	originalNewTelemetryClient := newTelemetryClient
+	t.Cleanup(func() { newTelemetryClient = originalNewTelemetryClient })
+	telemetryClient := &fakeTelemetryClient{flushErr: errors.New("flush failed")}
+	newTelemetryClient = func() (telemetry.Client, error) { return telemetryClient, nil }
+	operationErr := errors.New("operation failed")
+
+	got := runWithTelemetry(context.Background(), func(telemetry.Client) error {
+		return operationErr
+	})
+	if !errors.Is(got, operationErr) {
+		t.Fatalf("runWithTelemetry() error = %v, want operation error", got)
+	}
+	if telemetryClient.flushCalls != 1 {
+		t.Fatalf("telemetry flush calls = %d, want 1", telemetryClient.flushCalls)
 	}
 }
 
@@ -560,3 +633,25 @@ func (f *fakeCommandRunner) Run(ctx context.Context) error {
 	f.calls++
 	return f.err
 }
+
+type fakeTelemetryClient struct {
+	flushCalls int
+	flushErr   error
+}
+
+func (f *fakeTelemetryClient) Count(string, []string) telemetry.Metric {
+	return fakeTelemetryMetric{}
+}
+
+func (f *fakeTelemetryClient) Distribution(string, []string) telemetry.Metric {
+	return fakeTelemetryMetric{}
+}
+
+func (f *fakeTelemetryClient) Flush(context.Context) error {
+	f.flushCalls++
+	return f.flushErr
+}
+
+type fakeTelemetryMetric struct{}
+
+func (fakeTelemetryMetric) Submit(float64) {}

--- a/internal/cmd/telemetry_test.go
+++ b/internal/cmd/telemetry_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/DataDog/ddtest/internal/buildinfo"
@@ -36,7 +35,7 @@ func setTelemetryVersion(t *testing.T, version string) {
 	t.Cleanup(func() { buildinfo.Version = originalVersion })
 }
 
-func TestCreateTelemetryClientUsesCIVisibilityTestURL(t *testing.T) {
+func TestCreateTelemetryClientUsesRunMetadata(t *testing.T) {
 	clearTelemetryEnvironment(t)
 	setTelemetryVersion(t, "2.3.4")
 
@@ -46,21 +45,15 @@ func TestCreateTelemetryClientUsesCIVisibilityTestURL(t *testing.T) {
 		LibraryVersion string `json:"tracer_version"`
 		LanguageName   string `json:"language_name"`
 	}
-	var received struct {
-		path        string
-		apiKey      string
-		application application
-	}
+	var received application
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
-		received.path = request.URL.Path
-		received.apiKey = request.Header.Get("DD-API-KEY")
 		var requestBody struct {
 			Application application `json:"application"`
 		}
 		if err := json.NewDecoder(request.Body).Decode(&requestBody); err != nil {
 			t.Errorf("decode telemetry request: %v", err)
 		}
-		received.application = requestBody.Application
+		received = requestBody.Application
 		response.WriteHeader(http.StatusAccepted)
 	}))
 	t.Cleanup(server.Close)
@@ -80,82 +73,10 @@ func TestCreateTelemetryClientUsesCIVisibilityTestURL(t *testing.T) {
 		t.Fatalf("Flush() error = %v", err)
 	}
 
-	if received.path != telemetryAPIPath || received.apiKey != "api-key" {
-		t.Errorf("request path/API key = %q/%q, want %q/api-key", received.path, received.apiKey, telemetryAPIPath)
+	if received.ServiceName != "checkout-service" || received.Environment != "ci" {
+		t.Errorf("unexpected service metadata: %#v", received)
 	}
-	if received.application.ServiceName != "checkout-service" || received.application.Environment != "ci" {
-		t.Errorf("unexpected service metadata: %#v", received.application)
-	}
-	if received.application.LibraryVersion != "2.3.4" || received.application.LanguageName != "ddtest" {
-		t.Errorf("unexpected library metadata: %#v", received.application)
-	}
-}
-
-func TestCreateTelemetryClientUsesAgentTelemetryProxy(t *testing.T) {
-	clearTelemetryEnvironment(t)
-	setTelemetryVersion(t, "2.3.4")
-
-	var receivedPath, receivedAPIKey string
-	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
-		receivedPath = request.URL.Path
-		receivedAPIKey = request.Header.Get("DD-API-KEY")
-		response.WriteHeader(http.StatusAccepted)
-	}))
-	t.Cleanup(server.Close)
-	t.Setenv("DD_TRACE_AGENT_URL", server.URL)
-
-	client, err := createTelemetryClient()
-	if err != nil {
-		t.Fatalf("createTelemetryClient() error = %v", err)
-	}
-	client.Count("command", nil).Submit(1)
-	if err := client.Flush(context.Background()); err != nil {
-		t.Fatalf("Flush() error = %v", err)
-	}
-
-	if receivedPath != telemetryAgentPath {
-		t.Errorf("request path = %q, want %q", receivedPath, telemetryAgentPath)
-	}
-	if receivedAPIKey != "" {
-		t.Errorf("agent request API key = %q, want empty", receivedAPIKey)
-	}
-}
-
-func TestCreateTelemetryClientAgentlessDefaults(t *testing.T) {
-	clearTelemetryEnvironment(t)
-	setTelemetryVersion(t, "2.3.4")
-	t.Setenv(constants.TestOptimizationAgentlessEnabledEnvironmentVariable, "true")
-	t.Setenv(constants.APIKeyEnvironmentVariable, "api-key")
-	t.Setenv("DD_SITE", "datadoghq.eu")
-
-	client, err := createTelemetryClient()
-	if err != nil {
-		t.Fatalf("createTelemetryClient() error = %v", err)
-	}
-	if client == nil {
-		t.Fatal("createTelemetryClient() returned nil")
-	}
-}
-
-func TestCreateTelemetryClientRequiresAgentlessAPIKey(t *testing.T) {
-	clearTelemetryEnvironment(t)
-	t.Setenv(constants.TestOptimizationAgentlessEnabledEnvironmentVariable, "true")
-
-	_, err := createTelemetryClient()
-	if err == nil || !strings.Contains(err.Error(), "API key must not be empty") {
-		t.Fatalf("createTelemetryClient() error = %v, want missing API key error", err)
-	}
-}
-
-func TestCreateTelemetryClientRejectsInvalidCIVisibilityTestURL(t *testing.T) {
-	clearTelemetryEnvironment(t)
-	setTelemetryVersion(t, "2.3.4")
-	t.Setenv(constants.TestOptimizationAgentlessEnabledEnvironmentVariable, "true")
-	t.Setenv(constants.APIKeyEnvironmentVariable, "api-key")
-	t.Setenv(constants.TestOptimizationAgentlessURLEnvironmentVariable, "://bad")
-
-	_, err := createTelemetryClient()
-	if err == nil {
-		t.Fatal("createTelemetryClient() error = nil, want invalid URL error")
+	if received.LibraryVersion != "2.3.4" || received.LanguageName != "ddtest" {
+		t.Errorf("unexpected library metadata: %#v", received)
 	}
 }

--- a/internal/cmd/telemetry_test.go
+++ b/internal/cmd/telemetry_test.go
@@ -1,0 +1,161 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/DataDog/ddtest/internal/buildinfo"
+	"github.com/DataDog/ddtest/internal/constants"
+)
+
+func clearTelemetryEnvironment(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{
+		constants.TestOptimizationAgentlessEnabledEnvironmentVariable,
+		constants.TestOptimizationAgentlessURLEnvironmentVariable,
+		constants.APIKeyEnvironmentVariable,
+		"DD_SITE",
+		"DD_SERVICE",
+		"DD_ENV",
+		"DD_TRACE_AGENT_URL",
+		"DD_AGENT_HOST",
+		"DD_TRACE_AGENT_PORT",
+	} {
+		t.Setenv(name, "")
+	}
+}
+
+func setTelemetryVersion(t *testing.T, version string) {
+	t.Helper()
+	originalVersion := buildinfo.Version
+	buildinfo.Version = version
+	t.Cleanup(func() { buildinfo.Version = originalVersion })
+}
+
+func TestCreateTelemetryClientUsesCIVisibilityTestURL(t *testing.T) {
+	clearTelemetryEnvironment(t)
+	setTelemetryVersion(t, "2.3.4")
+
+	type application struct {
+		ServiceName    string `json:"service_name"`
+		Environment    string `json:"env"`
+		LibraryVersion string `json:"tracer_version"`
+		LanguageName   string `json:"language_name"`
+	}
+	var received struct {
+		path        string
+		apiKey      string
+		application application
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		received.path = request.URL.Path
+		received.apiKey = request.Header.Get("DD-API-KEY")
+		var requestBody struct {
+			Application application `json:"application"`
+		}
+		if err := json.NewDecoder(request.Body).Decode(&requestBody); err != nil {
+			t.Errorf("decode telemetry request: %v", err)
+		}
+		received.application = requestBody.Application
+		response.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(server.Close)
+
+	t.Setenv(constants.TestOptimizationAgentlessEnabledEnvironmentVariable, "true")
+	t.Setenv(constants.TestOptimizationAgentlessURLEnvironmentVariable, server.URL)
+	t.Setenv(constants.APIKeyEnvironmentVariable, "api-key")
+	t.Setenv("DD_SERVICE", "checkout-service")
+	t.Setenv("DD_ENV", "ci")
+
+	client, err := createTelemetryClient()
+	if err != nil {
+		t.Fatalf("createTelemetryClient() error = %v", err)
+	}
+	client.Count("command", nil).Submit(1)
+	if err := client.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+
+	if received.path != telemetryAPIPath || received.apiKey != "api-key" {
+		t.Errorf("request path/API key = %q/%q, want %q/api-key", received.path, received.apiKey, telemetryAPIPath)
+	}
+	if received.application.ServiceName != "checkout-service" || received.application.Environment != "ci" {
+		t.Errorf("unexpected service metadata: %#v", received.application)
+	}
+	if received.application.LibraryVersion != "2.3.4" || received.application.LanguageName != "ddtest" {
+		t.Errorf("unexpected library metadata: %#v", received.application)
+	}
+}
+
+func TestCreateTelemetryClientUsesAgentTelemetryProxy(t *testing.T) {
+	clearTelemetryEnvironment(t)
+	setTelemetryVersion(t, "2.3.4")
+
+	var receivedPath, receivedAPIKey string
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		receivedPath = request.URL.Path
+		receivedAPIKey = request.Header.Get("DD-API-KEY")
+		response.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(server.Close)
+	t.Setenv("DD_TRACE_AGENT_URL", server.URL)
+
+	client, err := createTelemetryClient()
+	if err != nil {
+		t.Fatalf("createTelemetryClient() error = %v", err)
+	}
+	client.Count("command", nil).Submit(1)
+	if err := client.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+
+	if receivedPath != telemetryAgentPath {
+		t.Errorf("request path = %q, want %q", receivedPath, telemetryAgentPath)
+	}
+	if receivedAPIKey != "" {
+		t.Errorf("agent request API key = %q, want empty", receivedAPIKey)
+	}
+}
+
+func TestCreateTelemetryClientAgentlessDefaults(t *testing.T) {
+	clearTelemetryEnvironment(t)
+	setTelemetryVersion(t, "2.3.4")
+	t.Setenv(constants.TestOptimizationAgentlessEnabledEnvironmentVariable, "true")
+	t.Setenv(constants.APIKeyEnvironmentVariable, "api-key")
+	t.Setenv("DD_SITE", "datadoghq.eu")
+
+	client, err := createTelemetryClient()
+	if err != nil {
+		t.Fatalf("createTelemetryClient() error = %v", err)
+	}
+	if client == nil {
+		t.Fatal("createTelemetryClient() returned nil")
+	}
+}
+
+func TestCreateTelemetryClientRequiresAgentlessAPIKey(t *testing.T) {
+	clearTelemetryEnvironment(t)
+	t.Setenv(constants.TestOptimizationAgentlessEnabledEnvironmentVariable, "true")
+
+	_, err := createTelemetryClient()
+	if err == nil || !strings.Contains(err.Error(), "API key must not be empty") {
+		t.Fatalf("createTelemetryClient() error = %v, want missing API key error", err)
+	}
+}
+
+func TestCreateTelemetryClientRejectsInvalidCIVisibilityTestURL(t *testing.T) {
+	clearTelemetryEnvironment(t)
+	setTelemetryVersion(t, "2.3.4")
+	t.Setenv(constants.TestOptimizationAgentlessEnabledEnvironmentVariable, "true")
+	t.Setenv(constants.APIKeyEnvironmentVariable, "api-key")
+	t.Setenv(constants.TestOptimizationAgentlessURLEnvironmentVariable, "://bad")
+
+	_, err := createTelemetryClient()
+	if err == nil {
+		t.Fatal("createTelemetryClient() error = nil, want invalid URL error")
+	}
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -25,6 +25,28 @@ const (
 	MaxPackFileSizeInMb = 3
 )
 
+// CommandType identifies the purpose of a Git command.
+type CommandType string
+
+const (
+	CommandGetRemote                 CommandType = "get_remote"
+	CommandGetRemoteUpstreamTracking CommandType = "get_remote_upstream_tracking"
+	CommandGetHead                   CommandType = "get_head"
+	CommandGetBranch                 CommandType = "get_branch"
+	CommandCheckShallow              CommandType = "check_shallow"
+	CommandUnshallow                 CommandType = "unshallow"
+	CommandGetLocalCommits           CommandType = "get_local_commits"
+	CommandGetObjects                CommandType = "get_objects"
+	CommandPackObjects               CommandType = "pack_objects"
+)
+
+// CommandTelemetry observes Git command executions.
+type CommandTelemetry interface {
+	Command(commandType CommandType)
+	CommandError(commandType CommandType, err error)
+	CommandDuration(commandType CommandType, duration time.Duration)
+}
+
 // LocalCommitData holds information about a single commit in the local Git repository.
 type LocalCommitData struct {
 	CommitSha      string
@@ -87,6 +109,51 @@ var (
 	// safeDirectoryValue holds the cached repository root path for safe.directory config.
 	safeDirectoryValue string
 )
+
+// CommandRunner runs the Git operations used during Test Optimization and
+// reports their command-level telemetry.
+type CommandRunner struct {
+	telemetry CommandTelemetry
+}
+
+// NewCommandRunner creates a Git command runner using commandTelemetry.
+func NewCommandRunner(commandTelemetry CommandTelemetry) *CommandRunner {
+	return &CommandRunner{telemetry: commandTelemetry}
+}
+
+func (r *CommandRunner) execGit(commandType CommandType, args ...string) (val []byte, err error) {
+	startTime := time.Now()
+	if r.telemetry != nil {
+		r.telemetry.Command(commandType)
+	}
+	defer func() {
+		if r.telemetry != nil {
+			r.telemetry.CommandDuration(commandType, time.Since(startTime))
+			r.telemetry.CommandError(commandType, err)
+		}
+	}()
+	return execGit(args...)
+}
+
+func (r *CommandRunner) execGitString(commandType CommandType, args ...string) (string, error) {
+	out, err := r.execGit(commandType, args...)
+	strOut := strings.TrimSpace(strings.Trim(string(out), "\n"))
+	return strOut, err
+}
+
+func (r *CommandRunner) execGitStringWithInput(commandType CommandType, input string, args ...string) (val string, err error) {
+	startTime := time.Now()
+	if r.telemetry != nil {
+		r.telemetry.Command(commandType)
+	}
+	defer func() {
+		if r.telemetry != nil {
+			r.telemetry.CommandDuration(commandType, time.Since(startTime))
+			r.telemetry.CommandError(commandType, err)
+		}
+	}()
+	return execGitStringWithInput(input, args...)
+}
 
 // CheckAvailable verifies that git is available and the current directory is a git repository.
 // Returns an error if git is not installed or the current directory is not a git repository.
@@ -351,9 +418,14 @@ func FetchCommitData(commitSha string) (LocalCommitData, error) {
 
 // GetLastLocalGitCommitShas retrieves the commit SHAs of the last 1000 commits in the local Git repository.
 func GetLastLocalGitCommitShas() []string {
+	return NewCommandRunner(nil).GetLastLocalGitCommitShas()
+}
+
+// GetLastLocalGitCommitShas retrieves recent commit SHAs and records the Git command telemetry.
+func (r *CommandRunner) GetLastLocalGitCommitShas() []string {
 	// git log --format=%H -n 1000 --since=\"1 month ago\"
 	slog.Debug("testoptimization.git: getting the commit SHAs of the last 1000 commits in the local Git repository")
-	out, err := execGitString("log", "--format=%H", "-n", "1000", "--since=\"1 month ago\"")
+	out, err := r.execGitString(CommandGetLocalCommits, "log", "--format=%H", "-n", "1000", "--since=\"1 month ago\"")
 	if err != nil || out == "" {
 		return []string{}
 	}
@@ -362,10 +434,15 @@ func GetLastLocalGitCommitShas() []string {
 
 // UnshallowGitRepository converts a shallow clone into a complete clone by fetching all missing commits without git content (only commits and tree objects).
 func UnshallowGitRepository() (bool, error) {
+	return NewCommandRunner(nil).UnshallowGitRepository()
+}
+
+// UnshallowGitRepository fetches missing commit history and records the Git command telemetry.
+func (r *CommandRunner) UnshallowGitRepository() (bool, error) {
 
 	// let's do a first check to see if the repository is a shallow clone
 	slog.Debug("testoptimization.unshallow: checking if the repository is a shallow clone")
-	isAShallowClone, err := isAShallowCloneRepository()
+	isAShallowClone, err := r.isAShallowCloneRepository()
 	if err != nil {
 		return false, fmt.Errorf("testoptimization.unshallow: error checking if the repository is a shallow clone: %s", err)
 	}
@@ -378,7 +455,7 @@ func UnshallowGitRepository() (bool, error) {
 
 	// the git repo is a shallow clone, we need to double check if there are more than just 1 commit in the logs.
 	slog.Debug("testoptimization.unshallow: the repository is a shallow clone, checking if there are more than one commit in the logs")
-	hasMoreThanOneCommits, err := hasTheGitLogHaveMoreThanOneCommits()
+	hasMoreThanOneCommits, err := r.hasTheGitLogHaveMoreThanOneCommits()
 	if err != nil {
 		return false, fmt.Errorf("testoptimization.unshallow: error checking if the git log has more than one commit: %s", err)
 	}
@@ -405,7 +482,7 @@ func UnshallowGitRepository() (bool, error) {
 	// to ask for git commits and trees of the last month (no blobs)
 
 	// let's get the remote name
-	remoteName, err := getRemoteName()
+	remoteName, err := r.getRemoteName()
 	if err != nil {
 		return false, fmt.Errorf("testoptimization.unshallow: error getting the remote name: %s\n%s", err, remoteName)
 	}
@@ -416,13 +493,13 @@ func UnshallowGitRepository() (bool, error) {
 	slog.Debug("testoptimization.unshallow: remote name", "remoteName", remoteName)
 
 	// let's get the sha of the HEAD (git rev-parse HEAD)
-	headSha, err := execGitString("rev-parse", "HEAD")
+	headSha, err := r.execGitString(CommandGetHead, "rev-parse", "HEAD")
 	if err != nil {
 		return false, fmt.Errorf("testoptimization.unshallow: error getting the HEAD sha: %s\n%s", err, headSha)
 	}
 	if headSha == "" {
 		// if the HEAD is empty, we fallback to the current branch (git branch --show-current)
-		headSha, err = execGitString("branch", "--show-current")
+		headSha, err = r.execGitString(CommandGetBranch, "branch", "--show-current")
 		if err != nil {
 			return false, fmt.Errorf("testoptimization.unshallow: error getting the current branch: %s\n%s", err, headSha)
 		}
@@ -432,7 +509,7 @@ func UnshallowGitRepository() (bool, error) {
 	// let's fetch the missing commits and trees from the last month
 	// git fetch --shallow-since="1 month ago" --update-shallow --filter="blob:none" --recurse-submodules=no $(git config --default origin --get clone.defaultRemoteName) $(git rev-parse HEAD)
 	slog.Debug("testoptimization.unshallow: fetching the missing commits and trees from the last month")
-	fetchOutput, err := execGitString("fetch", "--shallow-since=\"1 month ago\"", "--update-shallow", "--filter=blob:none", "--recurse-submodules=no", remoteName, headSha)
+	fetchOutput, err := r.execGitString(CommandUnshallow, "fetch", "--shallow-since=\"1 month ago\"", "--update-shallow", "--filter=blob:none", "--recurse-submodules=no", remoteName, headSha)
 
 	// let's check if the last command was unsuccessful
 	if err != nil || fetchOutput == "" {
@@ -446,11 +523,11 @@ func UnshallowGitRepository() (bool, error) {
 		// let's get the remote branch name: git rev-parse --abbrev-ref --symbolic-full-name @{upstream}
 		var remoteBranchName string
 		slog.Debug("testoptimization.unshallow: getting the remote branch name")
-		remoteBranchName, err = execGitString("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}")
+		remoteBranchName, err = r.execGitString(CommandUnshallow, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}")
 		if err == nil {
 			// let's try the alternative: git fetch --shallow-since="1 month ago" --update-shallow --filter="blob:none" --recurse-submodules=no $(git config --default origin --get clone.defaultRemoteName) $(git rev-parse --abbrev-ref --symbolic-full-name @{upstream})
 			slog.Debug("testoptimization.unshallow: fetching the missing commits and trees from the last month using the remote branch name")
-			fetchOutput, err = execGitString("fetch", "--shallow-since=\"1 month ago\"", "--update-shallow", "--filter=blob:none", "--recurse-submodules=no", remoteName, remoteBranchName)
+			fetchOutput, err = r.execGitString(CommandUnshallow, "fetch", "--shallow-since=\"1 month ago\"", "--update-shallow", "--filter=blob:none", "--recurse-submodules=no", remoteName, remoteBranchName)
 		}
 	}
 
@@ -465,7 +542,7 @@ func UnshallowGitRepository() (bool, error) {
 
 		// let's try the last fallback: git fetch --shallow-since="1 month ago" --update-shallow --filter="blob:none" --recurse-submodules=no $(git config --default origin --get clone.defaultRemoteName)
 		slog.Debug("testoptimization.unshallow: fetching the missing commits and trees from the last month using the origin name")
-		fetchOutput, err = execGitString("fetch", "--shallow-since=\"1 month ago\"", "--update-shallow", "--filter=blob:none", "--recurse-submodules=no", remoteName)
+		fetchOutput, err = r.execGitString(CommandUnshallow, "fetch", "--shallow-since=\"1 month ago\"", "--update-shallow", "--filter=blob:none", "--recurse-submodules=no", remoteName)
 	}
 
 	if err != nil {
@@ -494,6 +571,10 @@ func FilterSensitiveInfo(url string) string {
 
 // isAShallowCloneRepository checks if the local Git repository is a shallow clone.
 func isAShallowCloneRepository() (bool, error) {
+	return NewCommandRunner(nil).isAShallowCloneRepository()
+}
+
+func (r *CommandRunner) isAShallowCloneRepository() (bool, error) {
 	var fErr error
 	var sOnce *sync.Once
 	sOnce = isAShallowCloneRepositoryOnce.Load()
@@ -503,7 +584,7 @@ func isAShallowCloneRepository() (bool, error) {
 	}
 	sOnce.Do(func() {
 		// git rev-parse --is-shallow-repository
-		out, err := execGitString("rev-parse", "--is-shallow-repository")
+		out, err := r.execGitString(CommandCheckShallow, "rev-parse", "--is-shallow-repository")
 		if err != nil {
 			isAShallowCloneRepositoryValue = false
 			fErr = err
@@ -518,8 +599,12 @@ func isAShallowCloneRepository() (bool, error) {
 
 // hasTheGitLogHaveMoreThanOneCommits checks if the local Git repository has more than one commit.
 func hasTheGitLogHaveMoreThanOneCommits() (bool, error) {
+	return NewCommandRunner(nil).hasTheGitLogHaveMoreThanOneCommits()
+}
+
+func (r *CommandRunner) hasTheGitLogHaveMoreThanOneCommits() (bool, error) {
 	// git log --format=oneline -n 2
-	out, err := execGitString("log", "--format=oneline", "-n", "2")
+	out, err := r.execGitString(CommandCheckShallow, "log", "--format=oneline", "-n", "2")
 	if err != nil || out == "" {
 		return false, err
 	}
@@ -530,13 +615,17 @@ func hasTheGitLogHaveMoreThanOneCommits() (bool, error) {
 
 // getObjectsSha get the objects shas from the git repository based on the commits to include and exclude
 func getObjectsSha(commitsToInclude []string, commitsToExclude []string) []string {
+	return NewCommandRunner(nil).getObjectsSha(commitsToInclude, commitsToExclude)
+}
+
+func (r *CommandRunner) getObjectsSha(commitsToInclude []string, commitsToExclude []string) []string {
 	// git rev-list --objects --no-object-names --filter=blob:none --since="1 month ago" HEAD " + string.Join(" ", commitsToExclude.Select(c => "^" + c)) + " " + string.Join(" ", commitsToInclude);
 	commitsToExcludeArgs := make([]string, len(commitsToExclude))
 	for i, c := range commitsToExclude {
 		commitsToExcludeArgs[i] = "^" + c
 	}
 	args := append([]string{"rev-list", "--objects", "--no-object-names", "--filter=blob:none", "--since=\"1 month ago\"", "HEAD"}, append(commitsToExcludeArgs, commitsToInclude...)...)
-	out, err := execGitString(args...)
+	out, err := r.execGitString(CommandGetObjects, args...)
 	if err != nil {
 		return []string{}
 	}
@@ -545,8 +634,13 @@ func getObjectsSha(commitsToInclude []string, commitsToExclude []string) []strin
 
 // CreatePackFiles creates pack files from the given commits to include and exclude.
 func CreatePackFiles(commitsToInclude []string, commitsToExclude []string) []string {
+	return NewCommandRunner(nil).CreatePackFiles(commitsToInclude, commitsToExclude)
+}
+
+// CreatePackFiles creates pack files and records the Git command telemetry.
+func (r *CommandRunner) CreatePackFiles(commitsToInclude []string, commitsToExclude []string) []string {
 	// get the objects shas to send
-	objectsShas := getObjectsSha(commitsToInclude, commitsToExclude)
+	objectsShas := r.getObjectsSha(commitsToInclude, commitsToExclude)
 	if len(objectsShas) == 0 {
 		slog.Debug("testoptimization: no objects found to send")
 		return nil
@@ -581,7 +675,7 @@ func CreatePackFiles(commitsToInclude []string, commitsToExclude []string) []str
 		}
 
 		// git pack-objects --compression=9 --max-pack-size={MaxPackFileSizeInMb}m "{temporaryPath}"
-		out, err = execGitStringWithInput(objectsShasString,
+		out, err = r.execGitStringWithInput(CommandPackObjects, objectsShasString,
 			"pack-objects", "--compression=9", "--max-pack-size="+strconv.Itoa(MaxPackFileSizeInMb)+"m", temporaryPath+"/")
 		if err == nil {
 			break
@@ -644,8 +738,12 @@ func getParentGitFolder(innerFolder string) (string, error) {
 
 // getRemoteName determines the remote name.
 func getRemoteName() (string, error) {
+	return NewCommandRunner(nil).getRemoteName()
+}
+
+func (r *CommandRunner) getRemoteName() (string, error) {
 	// Try to find remote from upstream tracking
-	upstream, err := execGitString("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}")
+	upstream, err := r.execGitString(CommandGetRemoteUpstreamTracking, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}")
 	if err == nil && upstream != "" {
 		parts := strings.Split(upstream, "/")
 		if len(parts) > 0 {
@@ -654,7 +752,7 @@ func getRemoteName() (string, error) {
 	}
 
 	// Fallback to first remote if no upstream
-	remotes, err := execGitString("remote")
+	remotes, err := r.execGitString(CommandGetRemote, "remote")
 	if err != nil {
 		return "origin", nil // ultimate fallback
 	}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -13,6 +13,48 @@ import (
 	"github.com/DataDog/ddtest/internal/git/gittest"
 )
 
+type gitTelemetryClient struct {
+	mu      sync.Mutex
+	metrics map[string]float64
+}
+
+func newGitTelemetryClient() *gitTelemetryClient {
+	return &gitTelemetryClient{metrics: make(map[string]float64)}
+}
+
+func (c *gitTelemetryClient) Command(commandType CommandType) {
+	c.add("command", commandType)
+}
+
+func (c *gitTelemetryClient) CommandError(commandType CommandType, err error) {
+	if err != nil {
+		c.add("error", commandType)
+	}
+}
+
+func (c *gitTelemetryClient) CommandDuration(commandType CommandType, _ time.Duration) {
+	c.add("duration", commandType)
+}
+
+func (c *gitTelemetryClient) add(kind string, commandType CommandType) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.metrics[kind+"|"+string(commandType)]++
+}
+
+func (c *gitTelemetryClient) value(kind string, commandType CommandType) float64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.metrics[kind+"|"+string(commandType)]
+}
+
+func (c *gitTelemetryClient) recorded(kind string, commandType CommandType) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	_, ok := c.metrics[kind+"|"+string(commandType)]
+	return ok
+}
+
 func TestCheckAvailableSuccess(t *testing.T) {
 	repo := gittest.NewRepository(t)
 	t.Chdir(repo.Path)
@@ -271,6 +313,60 @@ func TestGitIntegrationLastLocalCommitShas(t *testing.T) {
 	}
 }
 
+func TestCommandRunnerRecordsGitCommandTelemetry(t *testing.T) {
+	repo := gittest.NewRepository(t)
+	t.Chdir(repo.Path)
+	resetGitPackageState(t)
+
+	recorder := newGitTelemetryClient()
+	runner := NewCommandRunner(recorder)
+	shas := runner.GetLastLocalGitCommitShas()
+	if len(shas) < 2 {
+		t.Fatalf("expected at least two commits, got %v", shas)
+	}
+	if got := recorder.value("command", CommandGetLocalCommits); got != 1 {
+		t.Errorf("get_local_commits command count = %v, want 1", got)
+	}
+	if !recorder.recorded("duration", CommandGetLocalCommits) {
+		t.Error("get_local_commits duration was not recorded")
+	}
+	if got := recorder.value("error", CommandGetLocalCommits); got != 0 {
+		t.Errorf("unexpected get_local_commits error count = %v", got)
+	}
+}
+
+func TestCommandRunnerRecordsMissingAndKnownExitCodes(t *testing.T) {
+	t.Run("missing exit code", func(t *testing.T) {
+		resetGitPackageState(t)
+		LookPathFunc = func(string) (string, error) {
+			return "", errors.New("missing git")
+		}
+
+		recorder := newGitTelemetryClient()
+		if got := NewCommandRunner(recorder).GetLastLocalGitCommitShas(); len(got) != 0 {
+			t.Fatalf("expected no commits, got %v", got)
+		}
+		if got := recorder.value("error", CommandGetLocalCommits); got != 1 {
+			t.Errorf("missing-exit-code error count = %v, want 1", got)
+		}
+	})
+
+	t.Run("known exit code", func(t *testing.T) {
+		fakeBin := t.TempDir()
+		writeFakeGit(t, fakeBin, "#!/bin/sh\nexit 1\n")
+		t.Setenv("PATH", fakeBin)
+		resetGitPackageState(t)
+
+		recorder := newGitTelemetryClient()
+		if got := NewCommandRunner(recorder).GetLastLocalGitCommitShas(); len(got) != 0 {
+			t.Fatalf("expected no commits, got %v", got)
+		}
+		if got := recorder.value("error", CommandGetLocalCommits); got != 1 {
+			t.Errorf("exit-code-1 error count = %v, want 1", got)
+		}
+	})
+}
+
 func TestGitIntegrationShallowHelpersOnNormalRepository(t *testing.T) {
 	repo := gittest.NewRepository(t)
 	t.Chdir(repo.Path)
@@ -305,8 +401,10 @@ func TestGitIntegrationUnshallowRepository(t *testing.T) {
 	repo := gittest.NewShallowRepository(t)
 	t.Chdir(repo.Path)
 	resetGitPackageState(t)
+	recorder := newGitTelemetryClient()
+	runner := NewCommandRunner(recorder)
 
-	shallow, err := isAShallowCloneRepository()
+	shallow, err := runner.isAShallowCloneRepository()
 	if err != nil {
 		t.Fatalf("expected shallow check to succeed, got %v", err)
 	}
@@ -314,12 +412,12 @@ func TestGitIntegrationUnshallowRepository(t *testing.T) {
 		t.Fatal("expected depth-1 clone to be shallow")
 	}
 
-	commits := GetLastLocalGitCommitShas()
+	commits := runner.GetLastLocalGitCommitShas()
 	if len(commits) != 1 {
 		t.Fatalf("expected shallow clone to see one commit before unshallowing, got %v", commits)
 	}
 
-	unshallowed, err := UnshallowGitRepository()
+	unshallowed, err := runner.UnshallowGitRepository()
 	if err != nil {
 		t.Fatalf("expected unshallow to succeed against local origin, got %v", err)
 	}
@@ -327,7 +425,7 @@ func TestGitIntegrationUnshallowRepository(t *testing.T) {
 		t.Fatal("expected shallow clone to be unshallowed")
 	}
 
-	shallow, err = isAShallowCloneRepository()
+	shallow, err = runner.isAShallowCloneRepository()
 	if err != nil {
 		t.Fatalf("expected shallow check after unshallow to succeed, got %v", err)
 	}
@@ -335,12 +433,26 @@ func TestGitIntegrationUnshallowRepository(t *testing.T) {
 		t.Fatal("expected repository not to be shallow after unshallowing")
 	}
 
-	commits = GetLastLocalGitCommitShas()
+	commits = runner.GetLastLocalGitCommitShas()
 	if len(commits) < 3 {
 		t.Fatalf("expected unshallowed clone to see full local history, got %v", commits)
 	}
 	if commits[0] != repo.Commits[2] || commits[1] != repo.Commits[1] || commits[2] != repo.Commits[0] {
 		t.Fatalf("expected latest commits %v, got %v", repo.Commits, commits[:3])
+	}
+	for _, command := range []string{
+		"check_shallow",
+		"get_local_commits",
+		"get_remote_upstream_tracking",
+		"get_head",
+		"unshallow",
+	} {
+		if got := recorder.value("command", CommandType(command)); got == 0 {
+			t.Errorf("expected %s command telemetry", command)
+		}
+		if !recorder.recorded("duration", CommandType(command)) {
+			t.Errorf("expected %s duration telemetry", command)
+		}
 	}
 }
 
@@ -388,7 +500,9 @@ func TestGitIntegrationObjectCollectionAndPackFiles(t *testing.T) {
 	t.Chdir(repo.Path)
 	resetGitPackageState(t)
 
-	objects := getObjectsSha([]string{repo.Commits[1]}, []string{repo.Commits[0]})
+	recorder := newGitTelemetryClient()
+	runner := NewCommandRunner(recorder)
+	objects := runner.getObjectsSha([]string{repo.Commits[1]}, []string{repo.Commits[0]})
 	if len(objects) == 0 {
 		t.Fatal("expected objects for latest commit")
 	}
@@ -398,7 +512,7 @@ func TestGitIntegrationObjectCollectionAndPackFiles(t *testing.T) {
 		}
 	}
 
-	packFiles := CreatePackFiles([]string{repo.Commits[1]}, []string{repo.Commits[0]})
+	packFiles := runner.CreatePackFiles([]string{repo.Commits[1]}, []string{repo.Commits[0]})
 	if len(packFiles) == 0 {
 		t.Fatal("expected pack files")
 	}
@@ -413,6 +527,16 @@ func TestGitIntegrationObjectCollectionAndPackFiles(t *testing.T) {
 		t.Cleanup(func() {
 			_ = os.RemoveAll(filepath.Dir(packFile))
 		})
+	}
+	if got := recorder.value("command", CommandGetObjects); got != 2 {
+		t.Errorf("get_objects command count = %v, want 2", got)
+	}
+	if got := recorder.value("command", CommandPackObjects); got != 1 {
+		t.Errorf("pack_objects command count = %v, want 1", got)
+	}
+	if !recorder.recorded("duration", CommandGetObjects) ||
+		!recorder.recorded("duration", CommandPackObjects) {
+		t.Error("object and pack command durations were not both recorded")
 	}
 }
 

--- a/internal/httptransport/datadog.go
+++ b/internal/httptransport/datadog.go
@@ -1,0 +1,133 @@
+package httptransport
+
+import (
+	"errors"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/DataDog/ddtest/internal/constants"
+	"github.com/DataDog/ddtest/internal/utils"
+)
+
+const (
+	defaultAgentHost = "localhost"
+	defaultAgentPort = "8126"
+	defaultSite      = "datadoghq.com"
+)
+
+var defaultAgentSocketPath = "/var/run/datadog/apm.socket"
+
+// DatadogConnection contains the shared Agent/agentless configuration used by
+// Datadog HTTP clients. Products remain responsible for constructing their
+// product-specific endpoint paths and headers.
+type DatadogConnection struct {
+	Agentless    bool
+	APIKey       string
+	Site         string
+	AgentlessURL string
+	AgentURL     *url.URL
+}
+
+// ResolveDatadogConnection resolves the standard ddtest Agent/agentless
+// environment configuration.
+func ResolveDatadogConnection() (DatadogConnection, error) {
+	if utils.BoolEnv(constants.TestOptimizationAgentlessEnabledEnvironmentVariable, false) {
+		apiKey := os.Getenv(constants.APIKeyEnvironmentVariable)
+		if apiKey == "" {
+			return DatadogConnection{}, errors.New("datadog API key must not be empty in agentless mode")
+		}
+		site := os.Getenv("DD_SITE")
+		if site == "" {
+			site = defaultSite
+		}
+		return DatadogConnection{
+			Agentless:    true,
+			APIKey:       apiKey,
+			Site:         site,
+			AgentlessURL: os.Getenv(constants.TestOptimizationAgentlessURLEnvironmentVariable),
+		}, nil
+	}
+
+	return DatadogConnection{AgentURL: AgentURLFromEnv()}, nil
+}
+
+// AgentURLFromEnv resolves the trace Agent URL using DD_TRACE_AGENT_URL,
+// DD_AGENT_HOST, DD_TRACE_AGENT_PORT, the default Unix socket, then
+// localhost:8126, in that order. Invalid explicit URLs are ignored.
+func AgentURLFromEnv() *url.URL {
+	if configured := os.Getenv("DD_TRACE_AGENT_URL"); configured != "" {
+		agentURL, err := url.Parse(configured)
+		if err != nil {
+			slog.Warn("Failed to parse DD_TRACE_AGENT_URL", "error", err.Error())
+		} else if validAgentURL(agentURL) {
+			return agentURL
+		} else {
+			slog.Warn("Unsupported or incomplete Agent URL; using default Agent configuration", "url", configured)
+		}
+	}
+
+	host, hostConfigured := os.LookupEnv("DD_AGENT_HOST")
+	port, portConfigured := os.LookupEnv("DD_TRACE_AGENT_PORT")
+	if host == "" {
+		host = defaultAgentHost
+		hostConfigured = false
+	}
+	if port == "" {
+		port = defaultAgentPort
+		portConfigured = false
+	}
+	httpURL := &url.URL{Scheme: "http", Host: net.JoinHostPort(host, port)}
+	if hostConfigured || portConfigured {
+		return httpURL
+	}
+	if _, err := os.Stat(defaultAgentSocketPath); err == nil {
+		return &url.URL{Scheme: "unix", Path: defaultAgentSocketPath}
+	}
+	return httpURL
+}
+
+func validAgentURL(agentURL *url.URL) bool {
+	switch agentURL.Scheme {
+	case "http", "https":
+		return agentURL.Host != ""
+	case "unix":
+		return agentURL.Path != ""
+	default:
+		return false
+	}
+}
+
+// NewHTTPClient returns an uninstrumented HTTP client suitable for Datadog
+// intake requests.
+func NewHTTPClient(timeout time.Duration) *http.Client {
+	return &http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}).DialContext,
+			ForceAttemptHTTP2:     true,
+			MaxIdleConns:          100,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+		},
+	}
+}
+
+// AgentHTTPTransport returns an HTTP-compatible Agent base URL and matching
+// client, including Unix-socket adaptation when required. The input URL is not
+// mutated.
+func AgentHTTPTransport(agentURL *url.URL, timeout time.Duration) (*url.URL, *http.Client) {
+	resolvedURL := *agentURL
+	if resolvedURL.Scheme == "unix" {
+		return UnixSocketURL(resolvedURL.Path), UnixSocketClient(resolvedURL.Path, timeout)
+	}
+	return &resolvedURL, NewHTTPClient(timeout)
+}

--- a/internal/httptransport/datadog_test.go
+++ b/internal/httptransport/datadog_test.go
@@ -1,0 +1,160 @@
+package httptransport
+
+import (
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/DataDog/ddtest/internal/constants"
+)
+
+func clearDatadogEnvironment(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{
+		constants.TestOptimizationAgentlessEnabledEnvironmentVariable,
+		constants.TestOptimizationAgentlessURLEnvironmentVariable,
+		constants.APIKeyEnvironmentVariable,
+		"DD_SITE",
+		"DD_TRACE_AGENT_URL",
+		"DD_AGENT_HOST",
+		"DD_TRACE_AGENT_PORT",
+	} {
+		t.Setenv(name, "")
+	}
+}
+
+func TestResolveDatadogConnectionAgentless(t *testing.T) {
+	clearDatadogEnvironment(t)
+	t.Setenv(constants.TestOptimizationAgentlessEnabledEnvironmentVariable, "true")
+	t.Setenv(constants.APIKeyEnvironmentVariable, "api-key")
+	t.Setenv(constants.TestOptimizationAgentlessURLEnvironmentVariable, "https://tests.example")
+	t.Setenv("DD_SITE", "datadoghq.eu")
+
+	connection, err := ResolveDatadogConnection()
+	if err != nil {
+		t.Fatalf("ResolveDatadogConnection() error = %v", err)
+	}
+	if !connection.Agentless || connection.APIKey != "api-key" || connection.Site != "datadoghq.eu" {
+		t.Fatalf("unexpected agentless connection: %#v", connection)
+	}
+	if connection.AgentlessURL != "https://tests.example" || connection.AgentURL != nil {
+		t.Fatalf("unexpected agentless URLs: %#v", connection)
+	}
+
+	t.Setenv("DD_SITE", "")
+	connection, err = ResolveDatadogConnection()
+	if err != nil {
+		t.Fatalf("ResolveDatadogConnection() with default site error = %v", err)
+	}
+	if connection.Site != "datadoghq.com" {
+		t.Fatalf("default site = %q, want datadoghq.com", connection.Site)
+	}
+}
+
+func TestResolveDatadogConnectionRequiresAgentlessAPIKey(t *testing.T) {
+	clearDatadogEnvironment(t)
+	t.Setenv(constants.TestOptimizationAgentlessEnabledEnvironmentVariable, "true")
+
+	if _, err := ResolveDatadogConnection(); err == nil {
+		t.Fatal("ResolveDatadogConnection() error = nil, want missing API key error")
+	}
+}
+
+func TestAgentURLFromEnv(t *testing.T) {
+	originalSocketPath := defaultAgentSocketPath
+	t.Cleanup(func() { defaultAgentSocketPath = originalSocketPath })
+
+	t.Run("defaults to localhost", func(t *testing.T) {
+		clearDatadogEnvironment(t)
+		defaultAgentSocketPath = filepath.Join(t.TempDir(), "missing.sock")
+		if got := AgentURLFromEnv().String(); got != "http://localhost:8126" {
+			t.Fatalf("AgentURLFromEnv() = %q, want http://localhost:8126", got)
+		}
+	})
+
+	t.Run("uses explicit URL", func(t *testing.T) {
+		clearDatadogEnvironment(t)
+		t.Setenv("DD_TRACE_AGENT_URL", "https://agent.example:8127")
+		if got := AgentURLFromEnv().String(); got != "https://agent.example:8127" {
+			t.Fatalf("AgentURLFromEnv() = %q, want explicit URL", got)
+		}
+	})
+
+	t.Run("uses host and port", func(t *testing.T) {
+		clearDatadogEnvironment(t)
+		t.Setenv("DD_AGENT_HOST", "agent.internal")
+		t.Setenv("DD_TRACE_AGENT_PORT", "9126")
+		if got := AgentURLFromEnv().String(); got != "http://agent.internal:9126" {
+			t.Fatalf("AgentURLFromEnv() = %q, want host and port URL", got)
+		}
+	})
+
+	t.Run("uses default Unix socket", func(t *testing.T) {
+		clearDatadogEnvironment(t)
+		defaultAgentSocketPath = filepath.Join(t.TempDir(), "apm.socket")
+		if err := os.WriteFile(defaultAgentSocketPath, nil, 0o600); err != nil {
+			t.Fatalf("write socket placeholder: %v", err)
+		}
+		got := AgentURLFromEnv()
+		if got.Scheme != "unix" || got.Path != defaultAgentSocketPath {
+			t.Fatalf("AgentURLFromEnv() = %#v, want Unix socket", got)
+		}
+	})
+
+	for _, test := range []struct {
+		name string
+		url  string
+	}{
+		{name: "malformed URL", url: "http://%"},
+		{name: "missing HTTP host", url: "http:///agent"},
+		{name: "missing Unix path", url: "unix://"},
+		{name: "unsupported scheme", url: "ftp://agent.example"},
+	} {
+		t.Run(test.name+" falls back", func(t *testing.T) {
+			clearDatadogEnvironment(t)
+			defaultAgentSocketPath = filepath.Join(t.TempDir(), "missing.sock")
+			t.Setenv("DD_TRACE_AGENT_URL", test.url)
+			if got := AgentURLFromEnv().String(); got != "http://localhost:8126" {
+				t.Fatalf("AgentURLFromEnv() = %q, want fallback", got)
+			}
+		})
+	}
+}
+
+func TestNewHTTPClient(t *testing.T) {
+	client := NewHTTPClient(17 * time.Second)
+	if client.Timeout != 17*time.Second {
+		t.Fatalf("client timeout = %s, want 17s", client.Timeout)
+	}
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok || !transport.ForceAttemptHTTP2 {
+		t.Fatalf("client transport = %#v, want HTTP/2-enabled transport", client.Transport)
+	}
+}
+
+func TestAgentHTTPTransport(t *testing.T) {
+	t.Run("HTTP", func(t *testing.T) {
+		agentURL := &url.URL{Scheme: "http", Host: "agent.example:8126"}
+		resolvedURL, client := AgentHTTPTransport(agentURL, 7*time.Second)
+		if resolvedURL == agentURL {
+			t.Fatal("AgentHTTPTransport() returned the mutable input URL")
+		}
+		if client.Timeout != 7*time.Second {
+			t.Fatalf("client timeout = %s, want 7s", client.Timeout)
+		}
+	})
+
+	t.Run("Unix socket", func(t *testing.T) {
+		agentURL := &url.URL{Scheme: "unix", Path: "/tmp/apm.socket"}
+		resolvedURL, client := AgentHTTPTransport(agentURL, 7*time.Second)
+		if got := resolvedURL.String(); got != "http://UDS__tmp_apm.socket" {
+			t.Fatalf("resolved URL = %q, want Unix socket URL", got)
+		}
+		if _, ok := client.Transport.(*http.Transport); !ok {
+			t.Fatalf("client transport = %T, want *http.Transport", client.Transport)
+		}
+	})
+}

--- a/internal/planner/discovered_tests.go
+++ b/internal/planner/discovered_tests.go
@@ -8,6 +8,7 @@ import (
 	"github.com/DataDog/ddtest/internal/discovery"
 	"github.com/DataDog/ddtest/internal/framework"
 	"github.com/DataDog/ddtest/internal/settings"
+	"github.com/DataDog/ddtest/internal/telemetry"
 	"github.com/DataDog/ddtest/internal/testoptimization"
 	"github.com/DataDog/ddtest/internal/testoptimization/api"
 	"github.com/DataDog/ddtest/internal/utils"
@@ -158,6 +159,18 @@ func (tp *TestPlanner) recordAppliedSkippable(match skippableMatch) {
 		tp.reportStats.uniqueTIASkippableSuitesApplied[match.suiteKey] = struct{}{}
 	case skippableMatchDisabledTest:
 		tp.reportStats.disabledTestsApplied++
+	}
+}
+
+func (tp *TestPlanner) recordITRSkippedTelemetry(suiteLevel bool) {
+	eventType := telemetry.EventTypeTest
+	count := tp.reportStats.tiaSkippableTestsApplied
+	if suiteLevel {
+		eventType = telemetry.EventTypeSuite
+		count = len(tp.reportStats.uniqueTIASkippableSuitesApplied)
+	}
+	if count > 0 {
+		telemetry.ITRSkipped(tp.telemetryClient, eventType, count)
 	}
 }
 

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -19,6 +19,7 @@ import (
 	"github.com/DataDog/ddtest/internal/platform"
 	"github.com/DataDog/ddtest/internal/runmetadata"
 	"github.com/DataDog/ddtest/internal/settings"
+	"github.com/DataDog/ddtest/internal/telemetry"
 	"github.com/DataDog/ddtest/internal/testoptimization"
 	"github.com/DataDog/ddtest/internal/testoptimization/api"
 	"github.com/DataDog/ddtest/internal/utils"
@@ -85,6 +86,7 @@ type TestPlanner struct {
 	optimizationClient      testOptimizationClient
 	newOptimizationClient   func(testSkippingLevel settings.TestSkippingLevel) testOptimizationClient
 	ciProviderDetector      environment.CIProviderDetector
+	telemetryClient         telemetry.Client
 	reportWriter            io.Writer
 }
 
@@ -159,6 +161,14 @@ func New() *TestPlanner {
 	return planner
 }
 
+// NewWithTelemetry creates a planner that reports internal metrics through the
+// provided telemetry client.
+func NewWithTelemetry(telemetryClient telemetry.Client) *TestPlanner {
+	planner := New()
+	planner.telemetryClient = telemetryClient
+	return planner
+}
+
 func NewWithDependencies(
 	platformDetector platform.PlatformDetector,
 	optimizationClient testOptimizationClient,
@@ -181,6 +191,7 @@ func newTestPlannerWithDefaults() *TestPlanner {
 		testFileDurationSources: make(map[string]testFileDurationSource),
 		reportStats:             newPlanningReportStats(),
 		skippablePercentage:     0.0,
+		telemetryClient:         telemetry.NoopClient(),
 		reportWriter:            os.Stderr,
 	}
 }

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -166,6 +166,9 @@ func New() *TestPlanner {
 func NewWithTelemetry(telemetryClient telemetry.Client) *TestPlanner {
 	planner := New()
 	planner.telemetryClient = telemetryClient
+	planner.newOptimizationClient = func(testSkippingLevel settings.TestSkippingLevel) testOptimizationClient {
+		return testoptimization.NewTestOptimizationClientWithTelemetry(testSkippingLevel, telemetryClient)
+	}
 	return planner
 }
 
@@ -477,6 +480,7 @@ func (tp *TestPlanner) PreparePlanningData(ctx context.Context) error {
 	}
 
 	tp.keepUnskippableMarkerSuitesRunnable(testFramework)
+	tp.recordITRSkippedTelemetry(isSuiteLevelSkipping)
 	tp.suitesBySourceFile = indexSuitesBySourceFile(tp.suiteAggregates)
 	tp.skippablePercentage = calculateSavedTimePercentage(tp.suiteAggregates)
 	tp.testFileWeights = tp.calculateFileWeights()

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/DataDog/ddtest/internal/framework"
 	"github.com/DataDog/ddtest/internal/platform"
 	"github.com/DataDog/ddtest/internal/settings"
+	"github.com/DataDog/ddtest/internal/telemetry"
 	"github.com/DataDog/ddtest/internal/testoptimization"
 	"github.com/DataDog/ddtest/internal/testoptimization/api"
 	ciUtils "github.com/DataDog/ddtest/internal/utils"
@@ -603,6 +604,15 @@ func TestNew(t *testing.T) {
 
 	if runner.newOptimizationClient == nil {
 		t.Error("New() should initialize optimization client factory")
+	}
+}
+
+func TestNewWithTelemetry(t *testing.T) {
+	telemetryClient := telemetry.NoopClient()
+	planner := NewWithTelemetry(telemetryClient)
+
+	if planner.telemetryClient != telemetryClient {
+		t.Fatal("NewWithTelemetry() did not retain the injected client")
 	}
 }
 

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -38,6 +38,42 @@ type MockPlatformDetector struct {
 	Err      error
 }
 
+type plannerTelemetryClient struct {
+	mu      sync.Mutex
+	metrics map[string]float64
+}
+
+type plannerTelemetryMetric struct {
+	client *plannerTelemetryClient
+	key    string
+}
+
+func newPlannerTelemetryClient() *plannerTelemetryClient {
+	return &plannerTelemetryClient{metrics: make(map[string]float64)}
+}
+
+func (c *plannerTelemetryClient) Count(name string, tags []string) telemetry.Metric {
+	return &plannerTelemetryMetric{client: c, key: name + "|" + strings.Join(tags, ",")}
+}
+
+func (c *plannerTelemetryClient) Distribution(name string, tags []string) telemetry.Metric {
+	return &plannerTelemetryMetric{client: c, key: name + "|" + strings.Join(tags, ",")}
+}
+
+func (c *plannerTelemetryClient) Flush(context.Context) error { return nil }
+
+func (m *plannerTelemetryMetric) Submit(value float64) {
+	m.client.mu.Lock()
+	defer m.client.mu.Unlock()
+	m.client.metrics[m.key] += value
+}
+
+func (c *plannerTelemetryClient) value(name string, tags ...string) float64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.metrics[name+"|"+strings.Join(tags, ",")]
+}
+
 func (m *MockPlatformDetector) DetectPlatform() (platform.Platform, error) {
 	return m.Platform, m.Err
 }
@@ -1039,6 +1075,8 @@ func TestTestPlanner_PreparePlanningData_RubySuiteModeForceFullDiscovery(t *test
 		mockOptimizationClient,
 		newDefaultMockCIProviderDetector(),
 	)
+	telemetryClient := newPlannerTelemetryClient()
+	runner.telemetryClient = telemetryClient
 
 	if err := runner.PreparePlanningData(context.Background()); err != nil {
 		t.Fatalf("PreparePlanningData() should not return error, got: %v", err)
@@ -1078,6 +1116,15 @@ func TestTestPlanner_PreparePlanningData_RubySuiteModeForceFullDiscovery(t *test
 		report.Planning.Skipping.UnskippableMarkerSuitesForced != 1 ||
 		report.Planning.Skipping.FullySkippedFiles != 1 {
 		t.Errorf("expected full discovery skipping application report, got %+v", report.Planning.Skipping)
+	}
+	if got := telemetryClient.value("itr_skipped", "event_type:suite"); got != 3 {
+		t.Errorf("itr_skipped suite count = %v, want 3", got)
+	}
+	if got := telemetryClient.value("itr_unskippable", "event_type:suite"); got != 0 {
+		t.Errorf("itr_unskippable suite count = %v, want 0", got)
+	}
+	if got := telemetryClient.value("itr_forced_run", "event_type:suite"); got != 0 {
+		t.Errorf("itr_forced_run suite count = %v, want 0", got)
 	}
 }
 
@@ -1314,6 +1361,8 @@ func TestTestPlanner_PreparePlanningData_TestLevelFullDiscoveryKeepsUnskippableM
 		mockOptimizationClient,
 		newDefaultMockCIProviderDetector(),
 	)
+	telemetryClient := newPlannerTelemetryClient()
+	runner.telemetryClient = telemetryClient
 
 	if err := runner.PreparePlanningData(context.Background()); err != nil {
 		t.Fatalf("PreparePlanningData() should not return error, got: %v", err)
@@ -1333,6 +1382,15 @@ func TestTestPlanner_PreparePlanningData_TestLevelFullDiscoveryKeepsUnskippableM
 	unguardedAggregate := runner.suiteAggregates[testSuiteKey{Module: "rspec", Suite: unguardedTest.Suite}]
 	if unguardedAggregate.NumTests != 1 || unguardedAggregate.NumTestsSkipped != 1 {
 		t.Fatalf("expected unguarded test to remain skipped, got %+v", unguardedAggregate)
+	}
+	if got := telemetryClient.value("itr_skipped", "event_type:test"); got != 2 {
+		t.Errorf("itr_skipped test count = %v, want 2", got)
+	}
+	if got := telemetryClient.value("itr_unskippable", "event_type:test"); got != 0 {
+		t.Errorf("itr_unskippable test count = %v, want 0", got)
+	}
+	if got := telemetryClient.value("itr_forced_run", "event_type:test"); got != 0 {
+		t.Errorf("itr_forced_run test count = %v, want 0", got)
 	}
 }
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/ddtest/internal/platform"
 	"github.com/DataDog/ddtest/internal/runmetadata"
 	"github.com/DataDog/ddtest/internal/settings"
+	"github.com/DataDog/ddtest/internal/telemetry"
 )
 
 type Runner interface {
@@ -30,11 +31,23 @@ type Planner interface {
 type TestRunner struct {
 	platformDetector platform.PlatformDetector
 	planner          Planner
+	telemetryClient  telemetry.Client
 	reportWriter     io.Writer
 }
 
 func New() *TestRunner {
-	return NewWithDependencies(platform.NewPlatformDetector(), planner.New())
+	return NewWithTelemetry(telemetry.NoopClient())
+}
+
+// NewWithTelemetry creates a runner and planner that share one telemetry
+// client for the lifetime of the command.
+func NewWithTelemetry(telemetryClient telemetry.Client) *TestRunner {
+	runner := NewWithDependencies(
+		platform.NewPlatformDetector(),
+		planner.NewWithTelemetry(telemetryClient),
+	)
+	runner.telemetryClient = telemetryClient
+	return runner
 }
 
 func NewWithDependencies(
@@ -49,8 +62,9 @@ func NewWithDependencies(
 
 func newTestRunnerWithDefaults() *TestRunner {
 	return &TestRunner{
-		planner:      planner.New(),
-		reportWriter: os.Stderr,
+		planner:         planner.New(),
+		telemetryClient: telemetry.NoopClient(),
+		reportWriter:    os.Stderr,
 	}
 }
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/DataDog/ddtest/internal/constants"
 	"github.com/DataDog/ddtest/internal/planner"
 	"github.com/DataDog/ddtest/internal/settings"
+	"github.com/DataDog/ddtest/internal/telemetry"
 	"github.com/spf13/viper"
 )
 
@@ -53,6 +54,15 @@ func (f *fakePlanner) DistributeTestFiles(testFiles []string, parallelRunners in
 func TestNew(t *testing.T) {
 	if runner := New(); runner == nil {
 		t.Fatal("New() returned nil")
+	}
+}
+
+func TestNewWithTelemetry(t *testing.T) {
+	telemetryClient := telemetry.NoopClient()
+	runner := NewWithTelemetry(telemetryClient)
+
+	if runner.telemetryClient != telemetryClient {
+		t.Fatal("NewWithTelemetry() did not retain the injected client")
 	}
 }
 

--- a/internal/telemetry/civisibility.go
+++ b/internal/telemetry/civisibility.go
@@ -1,0 +1,264 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package telemetry
+
+import (
+	"errors"
+	"os/exec"
+	"strconv"
+	"time"
+
+	"github.com/DataDog/ddtest/internal/git"
+)
+
+// EventType identifies the CI Visibility event affected by an ITR decision.
+type EventType string
+
+const (
+	EventTypeTest  EventType = "test"
+	EventTypeSuite EventType = "suite"
+)
+
+// SettingsResponse describes the settings flags represented in telemetry.
+type SettingsResponse struct {
+	CodeCoverageEnabled        bool
+	ITRSkippingEnabled         bool
+	EarlyFlakeDetectionEnabled bool
+	FlakyTestRetriesEnabled    bool
+	TestManagementEnabled      bool
+}
+
+func count(client Client, name string, tags []string, value float64) {
+	if client != nil {
+		client.Count(name, tags).Submit(value)
+	}
+}
+
+func distribution(client Client, name string, tags []string, value float64) {
+	if client != nil {
+		client.Distribution(name, tags).Submit(value)
+	}
+}
+
+func requestCompressedTags(compressed bool) []string {
+	if compressed {
+		return []string{"rq_compressed:true"}
+	}
+	return nil
+}
+
+func responseCompressedTags(compressed bool) []string {
+	if compressed {
+		return []string{"rs_compressed:true"}
+	}
+	return nil
+}
+
+func requestErrorTags(statusCode int) []string {
+	switch statusCode {
+	case 0:
+		return []string{"error_type:network"}
+	case 400, 401, 403, 404, 408, 429:
+		return []string{"error_type:status_code_4xx_response", "status_code:" + strconv.Itoa(statusCode)}
+	default:
+		if statusCode >= 500 && statusCode < 600 {
+			return []string{"error_type:status_code_5xx_response"}
+		}
+		if statusCode >= 400 && statusCode < 500 {
+			return []string{"error_type:status_code_4xx_response"}
+		}
+		return []string{"error_type:status_code"}
+	}
+}
+
+func milliseconds(duration time.Duration) float64 {
+	return float64(duration.Milliseconds())
+}
+
+func GitRequestsSearchCommits(client Client, requestCompressed bool) {
+	count(client, "git_requests.search_commits", requestCompressedTags(requestCompressed), 1)
+}
+
+// NewGitCommandTelemetry adapts client to Git's command telemetry interface.
+func NewGitCommandTelemetry(client Client) git.CommandTelemetry {
+	return gitCommandTelemetry{client: client}
+}
+
+type gitCommandTelemetry struct {
+	client Client
+}
+
+var _ git.CommandTelemetry = gitCommandTelemetry{}
+
+func (t gitCommandTelemetry) Command(commandType git.CommandType) {
+	GitCommand(t.client, commandType)
+}
+
+func (t gitCommandTelemetry) CommandError(commandType git.CommandType, err error) {
+	GitCommandErrors(t.client, commandType, err)
+}
+
+func (t gitCommandTelemetry) CommandDuration(commandType git.CommandType, duration time.Duration) {
+	GitCommandMs(t.client, commandType, duration)
+}
+
+func GitCommand(client Client, commandType git.CommandType) {
+	count(client, "git.command", []string{"command:" + string(commandType)}, 1)
+}
+
+func GitCommandErrors(client Client, commandType git.CommandType, err error) {
+	if err == nil {
+		return
+	}
+	tags := []string{"command:" + string(commandType)}
+	tags = append(tags, gitCommandErrorTags(err)...)
+	count(client, "git.command_errors", tags, 1)
+}
+
+func GitCommandMs(client Client, commandType git.CommandType, duration time.Duration) {
+	distribution(client, "git.command_ms", []string{"command:" + string(commandType)}, milliseconds(duration))
+}
+
+func gitCommandErrorTags(err error) []string {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return []string{"exit_code:missing"}
+	}
+	return []string{"exit_code:" + gitCommandExitCode(exitErr.ExitCode())}
+}
+
+func gitCommandExitCode(exitCode int) string {
+	switch exitCode {
+	case -1, 1, 2, 127, 128, 129:
+		return strconv.Itoa(exitCode)
+	default:
+		return "unknown"
+	}
+}
+
+func GitRequestsSearchCommitsErrors(client Client, statusCode int) {
+	count(client, "git_requests.search_commits_errors", requestErrorTags(statusCode), 1)
+}
+
+func GitRequestsSearchCommitsMs(client Client, responseCompressed bool, duration time.Duration) {
+	distribution(client, "git_requests.search_commits_ms", responseCompressedTags(responseCompressed), milliseconds(duration))
+}
+
+func GitRequestsObjectsPack(client Client, requestCompressed bool) {
+	count(client, "git_requests.objects_pack", requestCompressedTags(requestCompressed), 1)
+}
+
+func GitRequestsObjectsPackErrors(client Client, statusCode int) {
+	count(client, "git_requests.objects_pack_errors", requestErrorTags(statusCode), 1)
+}
+
+func GitRequestsObjectsPackMs(client Client, duration time.Duration) {
+	distribution(client, "git_requests.objects_pack_ms", nil, milliseconds(duration))
+}
+
+func GitRequestsObjectsPackBytes(client Client, value int64) {
+	distribution(client, "git_requests.objects_pack_bytes", nil, float64(value))
+}
+
+func GitRequestsObjectsPackFiles(client Client, value int) {
+	distribution(client, "git_requests.objects_pack_files", nil, float64(value))
+}
+
+func GitRequestsSettings(client Client, requestCompressed bool) {
+	count(client, "git_requests.settings", requestCompressedTags(requestCompressed), 1)
+}
+
+func GitRequestsSettingsErrors(client Client, statusCode int) {
+	count(client, "git_requests.settings_errors", requestErrorTags(statusCode), 1)
+}
+
+func GitRequestsSettingsResponse(client Client, response SettingsResponse) {
+	tags := make([]string, 0, 5)
+	if response.CodeCoverageEnabled {
+		tags = append(tags, "coverage_enabled")
+	}
+	if response.ITRSkippingEnabled {
+		tags = append(tags, "itrskip_enabled")
+	}
+	if response.EarlyFlakeDetectionEnabled {
+		tags = append(tags, "early_flake_detection_enabled:true")
+	}
+	if response.FlakyTestRetriesEnabled {
+		tags = append(tags, "flaky_test_retries_enabled:true")
+	}
+	if response.TestManagementEnabled {
+		tags = append(tags, "test_management_enabled:true")
+	}
+	count(client, "git_requests.settings_response", tags, 1)
+}
+
+func GitRequestsSettingsMs(client Client, duration time.Duration) {
+	distribution(client, "git_requests.settings_ms", nil, milliseconds(duration))
+}
+
+func ITRSkippableTestsRequest(client Client, requestCompressed bool) {
+	count(client, "itr_skippable_tests.request", requestCompressedTags(requestCompressed), 1)
+}
+
+func ITRSkippableTestsRequestErrors(client Client, statusCode int) {
+	count(client, "itr_skippable_tests.request_errors", requestErrorTags(statusCode), 1)
+}
+
+func ITRSkippableTestsResponseTests(client Client, value int) {
+	count(client, "itr_skippable_tests.response_tests", nil, float64(value))
+}
+
+func ITRSkippableTestsRequestMs(client Client, duration time.Duration) {
+	distribution(client, "itr_skippable_tests.request_ms", nil, milliseconds(duration))
+}
+
+func ITRSkippableTestsResponseBytes(client Client, responseCompressed bool, value int) {
+	distribution(client, "itr_skippable_tests.response_bytes", responseCompressedTags(responseCompressed), float64(value))
+}
+
+func ITRSkipped(client Client, eventType EventType, value int) {
+	count(client, "itr_skipped", []string{"event_type:" + string(eventType)}, float64(value))
+}
+
+func KnownTestsRequest(client Client, requestCompressed bool) {
+	count(client, "known_tests.request", requestCompressedTags(requestCompressed), 1)
+}
+
+func KnownTestsRequestErrors(client Client, statusCode int) {
+	count(client, "known_tests.request_errors", requestErrorTags(statusCode), 1)
+}
+
+func KnownTestsRequestMs(client Client, duration time.Duration) {
+	distribution(client, "known_tests.request_ms", nil, milliseconds(duration))
+}
+
+func KnownTestsResponseBytes(client Client, responseCompressed bool, value int) {
+	distribution(client, "known_tests.response_bytes", responseCompressedTags(responseCompressed), float64(value))
+}
+
+func KnownTestsResponseTests(client Client, value int) {
+	distribution(client, "known_tests.response_tests", nil, float64(value))
+}
+
+func TestManagementTestsRequest(client Client, requestCompressed bool) {
+	count(client, "test_management_tests.request", requestCompressedTags(requestCompressed), 1)
+}
+
+func TestManagementTestsRequestErrors(client Client, statusCode int) {
+	count(client, "test_management_tests.request_errors", requestErrorTags(statusCode), 1)
+}
+
+func TestManagementTestsRequestMs(client Client, duration time.Duration) {
+	distribution(client, "test_management_tests.request_ms", nil, milliseconds(duration))
+}
+
+func TestManagementTestsResponseBytes(client Client, responseCompressed bool, value int) {
+	distribution(client, "test_management_tests.response_bytes", responseCompressedTags(responseCompressed), float64(value))
+}
+
+func TestManagementTestsResponseTests(client Client, value int) {
+	distribution(client, "test_management_tests.response_tests", nil, float64(value))
+}

--- a/internal/telemetry/civisibility.go
+++ b/internal/telemetry/civisibility.go
@@ -211,6 +211,10 @@ func ITRSkippableTestsResponseTests(client Client, value int) {
 	count(client, "itr_skippable_tests.response_tests", nil, float64(value))
 }
 
+func ITRSkippableTestsResponseSuites(client Client, value int) {
+	count(client, "itr_skippable_tests.response_suites", nil, float64(value))
+}
+
 func ITRSkippableTestsRequestMs(client Client, duration time.Duration) {
 	distribution(client, "itr_skippable_tests.request_ms", nil, milliseconds(duration))
 }

--- a/internal/telemetry/civisibility_test.go
+++ b/internal/telemetry/civisibility_test.go
@@ -1,0 +1,248 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package telemetry
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/DataDog/ddtest/internal/git"
+)
+
+type recordedMetric struct {
+	kind  string
+	name  string
+	tags  []string
+	value float64
+}
+
+type recordingClient struct {
+	metrics []recordedMetric
+}
+
+type recordingMetric struct {
+	client *recordingClient
+	kind   string
+	name   string
+	tags   []string
+}
+
+func (c *recordingClient) Count(name string, tags []string) Metric {
+	return &recordingMetric{client: c, kind: "count", name: name, tags: slices.Clone(tags)}
+}
+
+func (c *recordingClient) Distribution(name string, tags []string) Metric {
+	return &recordingMetric{client: c, kind: "distribution", name: name, tags: slices.Clone(tags)}
+}
+
+func (c *recordingClient) Flush(context.Context) error { return nil }
+
+func (m *recordingMetric) Submit(value float64) {
+	m.client.metrics = append(m.client.metrics, recordedMetric{
+		kind:  m.kind,
+		name:  m.name,
+		tags:  m.tags,
+		value: value,
+	})
+}
+
+func TestRequestErrorTags(t *testing.T) {
+	tests := []struct {
+		statusCode int
+		want       []string
+	}{
+		{statusCode: 0, want: []string{"error_type:network"}},
+		{statusCode: 400, want: []string{"error_type:status_code_4xx_response", "status_code:400"}},
+		{statusCode: 401, want: []string{"error_type:status_code_4xx_response", "status_code:401"}},
+		{statusCode: 403, want: []string{"error_type:status_code_4xx_response", "status_code:403"}},
+		{statusCode: 404, want: []string{"error_type:status_code_4xx_response", "status_code:404"}},
+		{statusCode: 408, want: []string{"error_type:status_code_4xx_response", "status_code:408"}},
+		{statusCode: 429, want: []string{"error_type:status_code_4xx_response", "status_code:429"}},
+		{statusCode: 418, want: []string{"error_type:status_code_4xx_response"}},
+		{statusCode: 503, want: []string{"error_type:status_code_5xx_response"}},
+		{statusCode: 302, want: []string{"error_type:status_code"}},
+	}
+
+	for _, test := range tests {
+		if got := requestErrorTags(test.statusCode); !slices.Equal(got, test.want) {
+			t.Errorf("requestErrorTags(%d) = %v, want %v", test.statusCode, got, test.want)
+		}
+	}
+}
+
+func TestCIVisibilityRequestMetrics(t *testing.T) {
+	client := &recordingClient{}
+	duration := 1500 * time.Millisecond
+
+	GitRequestsSearchCommits(client, true)
+	GitRequestsSearchCommitsErrors(client, 404)
+	GitRequestsSearchCommitsMs(client, true, duration)
+	GitRequestsObjectsPack(client, false)
+	GitRequestsObjectsPackErrors(client, 0)
+	GitRequestsObjectsPackMs(client, duration)
+	GitRequestsObjectsPackBytes(client, 42)
+	GitRequestsObjectsPackFiles(client, 2)
+	GitRequestsSettings(client, false)
+	GitRequestsSettingsErrors(client, 503)
+	GitRequestsSettingsMs(client, duration)
+	ITRSkippableTestsRequest(client, true)
+	ITRSkippableTestsRequestErrors(client, 418)
+	ITRSkippableTestsRequestMs(client, duration)
+	ITRSkippableTestsResponseBytes(client, true, 43)
+	ITRSkippableTestsResponseTests(client, 3)
+	KnownTestsRequest(client, false)
+	KnownTestsRequestErrors(client, 0)
+	KnownTestsRequestMs(client, duration)
+	KnownTestsResponseBytes(client, false, 44)
+	KnownTestsResponseTests(client, 4)
+	TestManagementTestsRequest(client, true)
+	TestManagementTestsRequestErrors(client, 400)
+	TestManagementTestsRequestMs(client, duration)
+	TestManagementTestsResponseBytes(client, true, 45)
+	TestManagementTestsResponseTests(client, 5)
+
+	want := []recordedMetric{
+		{kind: "count", name: "git_requests.search_commits", tags: []string{"rq_compressed:true"}, value: 1},
+		{kind: "count", name: "git_requests.search_commits_errors", tags: []string{"error_type:status_code_4xx_response", "status_code:404"}, value: 1},
+		{kind: "distribution", name: "git_requests.search_commits_ms", tags: []string{"rs_compressed:true"}, value: 1500},
+		{kind: "count", name: "git_requests.objects_pack", value: 1},
+		{kind: "count", name: "git_requests.objects_pack_errors", tags: []string{"error_type:network"}, value: 1},
+		{kind: "distribution", name: "git_requests.objects_pack_ms", value: 1500},
+		{kind: "distribution", name: "git_requests.objects_pack_bytes", value: 42},
+		{kind: "distribution", name: "git_requests.objects_pack_files", value: 2},
+		{kind: "count", name: "git_requests.settings", value: 1},
+		{kind: "count", name: "git_requests.settings_errors", tags: []string{"error_type:status_code_5xx_response"}, value: 1},
+		{kind: "distribution", name: "git_requests.settings_ms", value: 1500},
+		{kind: "count", name: "itr_skippable_tests.request", tags: []string{"rq_compressed:true"}, value: 1},
+		{kind: "count", name: "itr_skippable_tests.request_errors", tags: []string{"error_type:status_code_4xx_response"}, value: 1},
+		{kind: "distribution", name: "itr_skippable_tests.request_ms", value: 1500},
+		{kind: "distribution", name: "itr_skippable_tests.response_bytes", tags: []string{"rs_compressed:true"}, value: 43},
+		{kind: "count", name: "itr_skippable_tests.response_tests", value: 3},
+		{kind: "count", name: "known_tests.request", value: 1},
+		{kind: "count", name: "known_tests.request_errors", tags: []string{"error_type:network"}, value: 1},
+		{kind: "distribution", name: "known_tests.request_ms", value: 1500},
+		{kind: "distribution", name: "known_tests.response_bytes", value: 44},
+		{kind: "distribution", name: "known_tests.response_tests", value: 4},
+		{kind: "count", name: "test_management_tests.request", tags: []string{"rq_compressed:true"}, value: 1},
+		{kind: "count", name: "test_management_tests.request_errors", tags: []string{"error_type:status_code_4xx_response", "status_code:400"}, value: 1},
+		{kind: "distribution", name: "test_management_tests.request_ms", value: 1500},
+		{kind: "distribution", name: "test_management_tests.response_bytes", tags: []string{"rs_compressed:true"}, value: 45},
+		{kind: "distribution", name: "test_management_tests.response_tests", value: 5},
+	}
+	assertRecordedMetrics(t, client.metrics, want)
+}
+
+func TestCIVisibilitySettingsAndITRMetrics(t *testing.T) {
+	client := &recordingClient{}
+	GitRequestsSettingsResponse(client, SettingsResponse{
+		CodeCoverageEnabled:        true,
+		ITRSkippingEnabled:         true,
+		EarlyFlakeDetectionEnabled: true,
+		FlakyTestRetriesEnabled:    true,
+		TestManagementEnabled:      true,
+	})
+	ITRSkipped(client, EventTypeTest, 2)
+
+	want := []recordedMetric{
+		{
+			kind:  "count",
+			name:  "git_requests.settings_response",
+			tags:  []string{"coverage_enabled", "itrskip_enabled", "early_flake_detection_enabled:true", "flaky_test_retries_enabled:true", "test_management_enabled:true"},
+			value: 1,
+		},
+		{kind: "count", name: "itr_skipped", tags: []string{"event_type:test"}, value: 2},
+	}
+	assertRecordedMetrics(t, client.metrics, want)
+
+	// A nil client is intentionally safe for optional telemetry wiring.
+	ITRSkipped(nil, EventTypeTest, 1)
+}
+
+func TestGitCommandMetrics(t *testing.T) {
+	client := &recordingClient{}
+	GitCommand(client, git.CommandGetObjects)
+	GitCommandMs(client, git.CommandGetObjects, 1500*time.Millisecond)
+	GitCommandErrors(client, git.CommandGetObjects, errors.New("git unavailable"))
+	GitCommandErrors(client, git.CommandGetObjects, nil)
+
+	want := []recordedMetric{
+		{kind: "count", name: "git.command", tags: []string{"command:get_objects"}, value: 1},
+		{kind: "distribution", name: "git.command_ms", tags: []string{"command:get_objects"}, value: 1500},
+		{kind: "count", name: "git.command_errors", tags: []string{"command:get_objects", "exit_code:missing"}, value: 1},
+	}
+	assertRecordedMetrics(t, client.metrics, want)
+}
+
+func TestGitCommandExitCode(t *testing.T) {
+	for _, test := range []struct {
+		exitCode int
+		want     string
+	}{
+		{exitCode: -1, want: "-1"},
+		{exitCode: 1, want: "1"},
+		{exitCode: 2, want: "2"},
+		{exitCode: 127, want: "127"},
+		{exitCode: 128, want: "128"},
+		{exitCode: 129, want: "129"},
+		{exitCode: 3, want: "unknown"},
+	} {
+		if got := gitCommandExitCode(test.exitCode); got != test.want {
+			t.Errorf("gitCommandExitCode(%d) = %q, want %q", test.exitCode, got, test.want)
+		}
+	}
+}
+
+func TestGitCommandErrorTagsFromExitError(t *testing.T) {
+	err := exec.Command("sh", "-c", "exit 1").Run()
+	if got := gitCommandErrorTags(err); !slices.Equal(got, []string{"exit_code:1"}) {
+		t.Fatalf("gitCommandErrorTags() = %v, want [exit_code:1]", got)
+	}
+}
+
+func TestGitCommandTypes(t *testing.T) {
+	client := &recordingClient{}
+	tests := []struct {
+		command git.CommandType
+		tag     string
+	}{
+		{command: git.CommandGetRemote, tag: "command:get_remote"},
+		{command: git.CommandGetRemoteUpstreamTracking, tag: "command:get_remote_upstream_tracking"},
+		{command: git.CommandGetHead, tag: "command:get_head"},
+		{command: git.CommandGetBranch, tag: "command:get_branch"},
+		{command: git.CommandCheckShallow, tag: "command:check_shallow"},
+		{command: git.CommandUnshallow, tag: "command:unshallow"},
+		{command: git.CommandGetLocalCommits, tag: "command:get_local_commits"},
+		{command: git.CommandGetObjects, tag: "command:get_objects"},
+		{command: git.CommandPackObjects, tag: "command:pack_objects"},
+	}
+	for _, test := range tests {
+		GitCommand(client, test.command)
+	}
+	if len(client.metrics) != len(tests) {
+		t.Fatalf("recorded %d command metrics, want %d", len(client.metrics), len(tests))
+	}
+	for i, test := range tests {
+		if got := client.metrics[i].tags; !slices.Equal(got, []string{test.tag}) {
+			t.Errorf("command %q tags = %v, want [%s]", test.command, got, test.tag)
+		}
+	}
+}
+
+func assertRecordedMetrics(t *testing.T, got, want []recordedMetric) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("recorded %d metrics, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i].kind != want[i].kind || got[i].name != want[i].name || got[i].value != want[i].value || !slices.Equal(got[i].tags, want[i].tags) {
+			t.Errorf("metric %d = %#v, want %#v", i, got[i], want[i])
+		}
+	}
+}

--- a/internal/telemetry/civisibility_test.go
+++ b/internal/telemetry/civisibility_test.go
@@ -97,6 +97,7 @@ func TestCIVisibilityRequestMetrics(t *testing.T) {
 	ITRSkippableTestsRequestMs(client, duration)
 	ITRSkippableTestsResponseBytes(client, true, 43)
 	ITRSkippableTestsResponseTests(client, 3)
+	ITRSkippableTestsResponseSuites(client, 2)
 	KnownTestsRequest(client, false)
 	KnownTestsRequestErrors(client, 0)
 	KnownTestsRequestMs(client, duration)
@@ -125,6 +126,7 @@ func TestCIVisibilityRequestMetrics(t *testing.T) {
 		{kind: "distribution", name: "itr_skippable_tests.request_ms", value: 1500},
 		{kind: "distribution", name: "itr_skippable_tests.response_bytes", tags: []string{"rs_compressed:true"}, value: 43},
 		{kind: "count", name: "itr_skippable_tests.response_tests", value: 3},
+		{kind: "count", name: "itr_skippable_tests.response_suites", value: 2},
 		{kind: "count", name: "known_tests.request", value: 1},
 		{kind: "count", name: "known_tests.request_errors", tags: []string{"error_type:network"}, value: 1},
 		{kind: "distribution", name: "known_tests.request_ms", value: 1500},

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -1,0 +1,245 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+// Package telemetry sends ddtest's internal CI Visibility metrics through the
+// Datadog instrumentation telemetry API.
+//
+// It deliberately supports metrics only. It does not send application
+// lifecycle, configuration, dependency, integration, log, or heartbeat events.
+package telemetry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+)
+
+const namespaceCIVisibility = "civisibility"
+
+// Metric receives values for one metric name and tag combination. Metric
+// handles are safe for concurrent use.
+type Metric interface {
+	Submit(value float64)
+}
+
+// Client collects and sends ddtest's internal telemetry metrics. Implementations
+// must be safe for concurrent use.
+type Client interface {
+	// Count returns a handle whose submitted values are summed between flushes.
+	Count(name string, tags []string) Metric
+
+	// Distribution returns a handle that retains every submitted value between
+	// flushes.
+	Distribution(name string, tags []string) Metric
+
+	// Flush synchronously sends all metrics submitted since the last successful
+	// flush. Failed payloads remain buffered for the next call.
+	Flush(ctx context.Context) error
+}
+
+// Config describes the destination and application metadata attached to every
+// telemetry request.
+type Config struct {
+	Endpoint       string
+	APIKey         string
+	ServiceName    string
+	Environment    string
+	LibraryVersion string
+	RuntimeID      string
+	HTTPClient     *http.Client
+}
+
+type metricKind uint8
+
+const (
+	countMetric metricKind = iota
+	distributionMetric
+)
+
+type metricKey struct {
+	name string
+	tags string
+}
+
+func newMetricKey(name string, tags []string) metricKey {
+	tags = slices.Clone(tags)
+	slices.Sort(tags)
+	return metricKey{name: name, tags: strings.Join(tags, ",")}
+}
+
+func (k metricKey) splitTags() []string {
+	if k.tags == "" {
+		return nil
+	}
+	return strings.Split(k.tags, ",")
+}
+
+type metric struct {
+	client *client
+	kind   metricKind
+	key    metricKey
+}
+
+func (m *metric) Submit(value float64) {
+	m.client.submit(m.kind, m.key, value)
+}
+
+type countPoint struct {
+	value float64
+	time  time.Time
+}
+
+type client struct {
+	mu            sync.Mutex
+	flushMu       sync.Mutex
+	counts        map[metricKey]countPoint
+	distributions map[metricKey][]float64
+	sender        *sender
+	now           func() time.Time
+}
+
+var _ Client = (*client)(nil)
+
+type noopMetric struct{}
+
+func (noopMetric) Submit(float64) {}
+
+type noopClient struct{}
+
+func (noopClient) Count(string, []string) Metric        { return noopMetric{} }
+func (noopClient) Distribution(string, []string) Metric { return noopMetric{} }
+func (noopClient) Flush(context.Context) error          { return nil }
+
+// NoopClient returns a telemetry client that safely discards all metrics.
+func NoopClient() Client {
+	return noopClient{}
+}
+
+// NewClient creates a metrics-only telemetry client.
+func NewClient(config Config) (Client, error) {
+	if config.ServiceName == "" {
+		return nil, errors.New("telemetry: service name must not be empty")
+	}
+	if config.LibraryVersion == "" {
+		return nil, errors.New("telemetry: library version must not be empty")
+	}
+	endpoint, err := url.Parse(config.Endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("telemetry: invalid endpoint: %w", err)
+	}
+	if endpoint.Scheme != "http" && endpoint.Scheme != "https" {
+		return nil, errors.New("telemetry: endpoint must use http or https")
+	}
+	if endpoint.Host == "" {
+		return nil, errors.New("telemetry: endpoint host must not be empty")
+	}
+
+	telemetrySender, err := newSender(config, endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	return &client{
+		counts:        make(map[metricKey]countPoint),
+		distributions: make(map[metricKey][]float64),
+		sender:        telemetrySender,
+		now:           time.Now,
+	}, nil
+}
+
+func (c *client) Count(name string, tags []string) Metric {
+	return &metric{client: c, kind: countMetric, key: newMetricKey(name, tags)}
+}
+
+func (c *client) Distribution(name string, tags []string) Metric {
+	return &metric{client: c, kind: distributionMetric, key: newMetricKey(name, tags)}
+}
+
+func (c *client) submit(kind metricKind, key metricKey, value float64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	switch kind {
+	case countMetric:
+		point := c.counts[key]
+		point.value += value
+		point.time = c.now()
+		c.counts[key] = point
+	case distributionMetric:
+		c.distributions[key] = append(c.distributions[key], value)
+	}
+}
+
+func (c *client) Flush(ctx context.Context) error {
+	c.flushMu.Lock()
+	defer c.flushMu.Unlock()
+
+	counts, distributions := c.drain()
+	payloads := make([]payload, 0, 2)
+	if len(counts) > 0 {
+		payloads = append(payloads, generateMetricsPayload(counts))
+	}
+	if len(distributions) > 0 {
+		payloads = append(payloads, distributionsPayload(distributions))
+	}
+
+	payload := reducePayloads(payloads)
+	if payload == nil {
+		return nil
+	}
+	if err := c.sender.send(ctx, payload); err != nil {
+		c.restoreCounts(counts)
+		c.restoreDistributions(distributions)
+		return err
+	}
+	return nil
+}
+
+func (c *client) drain() (map[metricKey]countPoint, map[metricKey][]float64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	counts := c.counts
+	distributions := c.distributions
+	c.counts = make(map[metricKey]countPoint)
+	c.distributions = make(map[metricKey][]float64)
+	return counts, distributions
+}
+
+func (c *client) restoreCounts(failed map[metricKey]countPoint) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for key, old := range failed {
+		current, ok := c.counts[key]
+		if !ok {
+			c.counts[key] = old
+			continue
+		}
+		current.value += old.value
+		if old.time.After(current.time) {
+			current.time = old.time
+		}
+		c.counts[key] = current
+	}
+}
+
+func (c *client) restoreDistributions(failed map[metricKey][]float64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for key, old := range failed {
+		values := make([]float64, 0, len(old)+len(c.distributions[key]))
+		values = append(values, old...)
+		values = append(values, c.distributions[key]...)
+		c.distributions[key] = values
+	}
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -13,9 +13,6 @@ package telemetry
 import (
 	"context"
 	"errors"
-	"fmt"
-	"net/http"
-	"net/url"
 	"slices"
 	"strings"
 	"sync"
@@ -45,16 +42,13 @@ type Client interface {
 	Flush(ctx context.Context) error
 }
 
-// Config describes the destination and application metadata attached to every
-// telemetry request.
+// Config describes the application metadata attached to every telemetry
+// request. NewClient resolves the destination from ddtest's standard Datadog
+// Agent/agentless configuration.
 type Config struct {
-	Endpoint       string
-	APIKey         string
 	ServiceName    string
 	Environment    string
 	LibraryVersion string
-	RuntimeID      string
-	HTTPClient     *http.Client
 }
 
 type metricKind uint8
@@ -125,24 +119,28 @@ func NoopClient() Client {
 
 // NewClient creates a metrics-only telemetry client.
 func NewClient(config Config) (Client, error) {
+	if err := validateConfig(config); err != nil {
+		return nil, err
+	}
+	destination, err := resolveDestination()
+	if err != nil {
+		return nil, err
+	}
+	return newClient(config, destination)
+}
+
+func validateConfig(config Config) error {
 	if config.ServiceName == "" {
-		return nil, errors.New("telemetry: service name must not be empty")
+		return errors.New("telemetry: service name must not be empty")
 	}
 	if config.LibraryVersion == "" {
-		return nil, errors.New("telemetry: library version must not be empty")
+		return errors.New("telemetry: library version must not be empty")
 	}
-	endpoint, err := url.Parse(config.Endpoint)
-	if err != nil {
-		return nil, fmt.Errorf("telemetry: invalid endpoint: %w", err)
-	}
-	if endpoint.Scheme != "http" && endpoint.Scheme != "https" {
-		return nil, errors.New("telemetry: endpoint must use http or https")
-	}
-	if endpoint.Host == "" {
-		return nil, errors.New("telemetry: endpoint host must not be empty")
-	}
+	return nil
+}
 
-	telemetrySender, err := newSender(config, endpoint)
+func newClient(config Config, destination destination) (Client, error) {
+	telemetrySender, err := newSender(config, destination)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -13,13 +13,18 @@ package telemetry
 import (
 	"context"
 	"errors"
+	"os"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 )
 
-const namespaceCIVisibility = "civisibility"
+const (
+	namespaceCIVisibility               = "civisibility"
+	telemetryEnabledEnvironmentVariable = "DD_INSTRUMENTATION_TELEMETRY_ENABLED"
+)
 
 // Metric receives values for one metric name and tag combination. Metric
 // handles are safe for concurrent use.
@@ -119,6 +124,9 @@ func NoopClient() Client {
 
 // NewClient creates a metrics-only telemetry client.
 func NewClient(config Config) (Client, error) {
+	if !telemetryEnabled() {
+		return NoopClient(), nil
+	}
 	if err := validateConfig(config); err != nil {
 		return nil, err
 	}
@@ -127,6 +135,15 @@ func NewClient(config Config) (Client, error) {
 		return nil, err
 	}
 	return newClient(config, destination)
+}
+
+func telemetryEnabled() bool {
+	value, found := os.LookupEnv(telemetryEnabledEnvironmentVariable)
+	if !found {
+		return true
+	}
+	enabled, err := strconv.ParseBool(strings.TrimSpace(value))
+	return err != nil || enabled
 }
 
 func validateConfig(config Config) error {

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -79,8 +79,26 @@ func clearDestinationEnvironment(t *testing.T) {
 		"DD_TRACE_AGENT_URL",
 		"DD_AGENT_HOST",
 		"DD_TRACE_AGENT_PORT",
+		telemetryEnabledEnvironmentVariable,
 	} {
 		t.Setenv(name, "")
+	}
+}
+
+func TestNewClientDisabled(t *testing.T) {
+	clearDestinationEnvironment(t)
+	t.Setenv(telemetryEnabledEnvironmentVariable, "false")
+
+	client, err := NewClient(Config{})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	if _, ok := client.(noopClient); !ok {
+		t.Fatalf("NewClient() = %T, want noopClient", client)
+	}
+	client.Count("count", nil).Submit(1)
+	if err := client.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush() error = %v", err)
 	}
 }
 
@@ -338,6 +356,9 @@ func TestFlushSendsOnlyMetricPayloads(t *testing.T) {
 	if got := request.header.Get("DD-Client-Library-Version"); got != "1.2.3" {
 		t.Errorf("DD-Client-Library-Version = %q, want 1.2.3", got)
 	}
+	if got := request.header.Get("DD-Session-ID"); got != "runtime-id" {
+		t.Errorf("DD-Session-ID = %q, want runtime-id", got)
+	}
 	if got := request.header.Get("DD-API-KEY"); got != "api-key" {
 		t.Errorf("DD-API-KEY = %q, want api-key", got)
 	}
@@ -397,6 +418,9 @@ func TestFlushSendsOnlyMetricPayloads(t *testing.T) {
 	}
 	if len(distributionPayload.Series) != 1 {
 		t.Fatalf("distributions series count = %d, want 1", len(distributionPayload.Series))
+	}
+	if distributionPayload.Namespace != namespaceCIVisibility {
+		t.Errorf("distributions namespace = %q, want %q", distributionPayload.Namespace, namespaceCIVisibility)
 	}
 	distributionMetric := distributionPayload.Series[0]
 	if distributionMetric.Metric != "endpoint_payload.bytes" || distributionMetric.Namespace != namespaceCIVisibility || !distributionMetric.Common {

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -20,6 +20,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/DataDog/ddtest/internal/constants"
 )
 
 type receivedRequest struct {
@@ -46,19 +48,40 @@ type wireMessage struct {
 func clientForTest(t *testing.T, endpoint string, httpClient *http.Client) *client {
 	t.Helper()
 
-	telemetryClient, err := NewClient(Config{
-		Endpoint:       endpoint,
-		APIKey:         "api-key",
+	parsedEndpoint, err := parseEndpoint(endpoint)
+	if err != nil {
+		t.Fatalf("parseEndpoint() error = %v", err)
+	}
+	telemetryClient, err := newClient(Config{
 		ServiceName:    "test-service",
 		Environment:    "ci",
 		LibraryVersion: "1.2.3",
-		RuntimeID:      "runtime-id",
-		HTTPClient:     httpClient,
+	}, destination{
+		endpoint:   parsedEndpoint,
+		apiKey:     "api-key",
+		httpClient: httpClient,
 	})
 	if err != nil {
-		t.Fatalf("NewClient() error = %v", err)
+		t.Fatalf("newClient() error = %v", err)
 	}
-	return telemetryClient.(*client)
+	client := telemetryClient.(*client)
+	client.sender.body.RuntimeID = "runtime-id"
+	return client
+}
+
+func clearDestinationEnvironment(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{
+		constants.TestOptimizationAgentlessEnabledEnvironmentVariable,
+		constants.TestOptimizationAgentlessURLEnvironmentVariable,
+		constants.APIKeyEnvironmentVariable,
+		"DD_SITE",
+		"DD_TRACE_AGENT_URL",
+		"DD_AGENT_HOST",
+		"DD_TRACE_AGENT_PORT",
+	} {
+		t.Setenv(name, "")
+	}
 }
 
 func decodeWireBody(t *testing.T, encoded []byte) wireBody {
@@ -72,6 +95,7 @@ func decodeWireBody(t *testing.T, encoded []byte) wireBody {
 }
 
 func TestNewClientValidation(t *testing.T) {
+	clearDestinationEnvironment(t)
 	tests := []struct {
 		name    string
 		config  Config
@@ -80,7 +104,6 @@ func TestNewClientValidation(t *testing.T) {
 		{
 			name: "valid",
 			config: Config{
-				Endpoint:       "https://example.com/api/v2/apmtelemetry",
 				ServiceName:    "ddtest",
 				LibraryVersion: "1.0.0",
 			},
@@ -88,7 +111,6 @@ func TestNewClientValidation(t *testing.T) {
 		{
 			name: "missing service name",
 			config: Config{
-				Endpoint:       "https://example.com/api/v2/apmtelemetry",
 				LibraryVersion: "1.0.0",
 			},
 			wantErr: "service name must not be empty",
@@ -96,37 +118,9 @@ func TestNewClientValidation(t *testing.T) {
 		{
 			name: "missing library version",
 			config: Config{
-				Endpoint:    "https://example.com/api/v2/apmtelemetry",
 				ServiceName: "ddtest",
 			},
 			wantErr: "library version must not be empty",
-		},
-		{
-			name: "invalid endpoint",
-			config: Config{
-				Endpoint:       "://bad",
-				ServiceName:    "ddtest",
-				LibraryVersion: "1.0.0",
-			},
-			wantErr: "invalid endpoint",
-		},
-		{
-			name: "unsupported endpoint scheme",
-			config: Config{
-				Endpoint:       "ftp://example.com/telemetry",
-				ServiceName:    "ddtest",
-				LibraryVersion: "1.0.0",
-			},
-			wantErr: "endpoint must use http or https",
-		},
-		{
-			name: "missing endpoint host",
-			config: Config{
-				Endpoint:       "http:///telemetry",
-				ServiceName:    "ddtest",
-				LibraryVersion: "1.0.0",
-			},
-			wantErr: "endpoint host must not be empty",
 		},
 	}
 
@@ -144,6 +138,142 @@ func TestNewClientValidation(t *testing.T) {
 			}
 			if err == nil || !regexp.MustCompile(regexp.QuoteMeta(test.wantErr)).MatchString(err.Error()) {
 				t.Fatalf("NewClient() error = %v, want error containing %q", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestResolveDestinationAgentless(t *testing.T) {
+	t.Run("standard intake", func(t *testing.T) {
+		clearDestinationEnvironment(t)
+		t.Setenv(constants.TestOptimizationAgentlessEnabledEnvironmentVariable, "true")
+		t.Setenv(constants.APIKeyEnvironmentVariable, "api-key")
+		t.Setenv("DD_SITE", "datadoghq.eu")
+
+		destination, err := resolveDestination()
+		if err != nil {
+			t.Fatalf("resolveDestination() error = %v", err)
+		}
+		want := "https://instrumentation-telemetry-intake.datadoghq.eu/api/v2/apmtelemetry"
+		if destination.endpoint.String() != want || destination.apiKey != "api-key" {
+			t.Fatalf("destination = %#v, want endpoint %q and API key", destination, want)
+		}
+		if destination.httpClient == nil || destination.httpClient.Timeout != telemetryHTTPTimeout {
+			t.Fatalf("unexpected HTTP client: %#v", destination.httpClient)
+		}
+	})
+
+	t.Run("CI Visibility test intake", func(t *testing.T) {
+		clearDestinationEnvironment(t)
+		t.Setenv(constants.TestOptimizationAgentlessEnabledEnvironmentVariable, "true")
+		t.Setenv(constants.APIKeyEnvironmentVariable, "api-key")
+		t.Setenv(constants.TestOptimizationAgentlessURLEnvironmentVariable, "https://tests.example/intake")
+
+		destination, err := resolveDestination()
+		if err != nil {
+			t.Fatalf("resolveDestination() error = %v", err)
+		}
+		want := "https://tests.example/intake/api/v2/apmtelemetry"
+		if destination.endpoint.String() != want {
+			t.Fatalf("endpoint = %q, want %q", destination.endpoint, want)
+		}
+	})
+
+	t.Run("missing API key", func(t *testing.T) {
+		clearDestinationEnvironment(t)
+		t.Setenv(constants.TestOptimizationAgentlessEnabledEnvironmentVariable, "true")
+
+		_, err := resolveDestination()
+		if err == nil || !strings.Contains(err.Error(), "API key must not be empty") {
+			t.Fatalf("resolveDestination() error = %v, want missing API key error", err)
+		}
+	})
+
+	t.Run("invalid CI Visibility test intake", func(t *testing.T) {
+		clearDestinationEnvironment(t)
+		t.Setenv(constants.TestOptimizationAgentlessEnabledEnvironmentVariable, "true")
+		t.Setenv(constants.APIKeyEnvironmentVariable, "api-key")
+		t.Setenv(constants.TestOptimizationAgentlessURLEnvironmentVariable, "://bad")
+
+		_, err := resolveDestination()
+		if err == nil {
+			t.Fatal("resolveDestination() error = nil, want invalid URL error")
+		}
+	})
+}
+
+func TestResolveDestinationAgent(t *testing.T) {
+	t.Run("explicit HTTP URL", func(t *testing.T) {
+		clearDestinationEnvironment(t)
+		t.Setenv("DD_TRACE_AGENT_URL", "https://agent.example:9126")
+
+		destination, err := resolveDestination()
+		if err != nil {
+			t.Fatalf("resolveDestination() error = %v", err)
+		}
+		want := "https://agent.example:9126/telemetry/proxy/api/v2/apmtelemetry"
+		if destination.endpoint.String() != want || destination.apiKey != "" {
+			t.Fatalf("destination = %#v, want endpoint %q without API key", destination, want)
+		}
+		if destination.httpClient == nil || destination.httpClient.Timeout != telemetryHTTPTimeout {
+			t.Fatalf("unexpected HTTP client: %#v", destination.httpClient)
+		}
+	})
+
+	t.Run("host and port", func(t *testing.T) {
+		clearDestinationEnvironment(t)
+		t.Setenv("DD_AGENT_HOST", "agent.internal")
+		t.Setenv("DD_TRACE_AGENT_PORT", "8127")
+
+		destination, err := resolveDestination()
+		if err != nil {
+			t.Fatalf("resolveDestination() error = %v", err)
+		}
+		want := "http://agent.internal:8127/telemetry/proxy/api/v2/apmtelemetry"
+		if destination.endpoint.String() != want {
+			t.Fatalf("endpoint = %q, want %q", destination.endpoint, want)
+		}
+	})
+
+	t.Run("Unix socket", func(t *testing.T) {
+		clearDestinationEnvironment(t)
+		t.Setenv("DD_TRACE_AGENT_URL", "unix:///tmp/ddtest-apm.socket")
+
+		destination, err := resolveDestination()
+		if err != nil {
+			t.Fatalf("resolveDestination() error = %v", err)
+		}
+		want := "http://UDS__tmp_ddtest-apm.socket/telemetry/proxy/api/v2/apmtelemetry"
+		if destination.endpoint.String() != want {
+			t.Fatalf("endpoint = %q, want %q", destination.endpoint, want)
+		}
+		if _, ok := destination.httpClient.Transport.(*http.Transport); !ok {
+			t.Fatalf("HTTP transport = %T, want *http.Transport", destination.httpClient.Transport)
+		}
+	})
+}
+
+func TestParseEndpointValidation(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		value   string
+		wantErr string
+	}{
+		{name: "valid", value: "https://example.com/api/v2/apmtelemetry"},
+		{name: "invalid", value: "://bad", wantErr: "parse endpoint"},
+		{name: "unsupported scheme", value: "ftp://example.com/telemetry", wantErr: "must use HTTP(S)"},
+		{name: "missing host", value: "http:///telemetry", wantErr: "host must not be empty"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			endpoint, err := parseEndpoint(test.value)
+			if test.wantErr == "" {
+				if err != nil || endpoint.String() != test.value {
+					t.Fatalf("parseEndpoint() = %v, %v, want %q, nil", endpoint, err, test.value)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("parseEndpoint() error = %v, want error containing %q", err, test.wantErr)
 			}
 		})
 	}

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -1,0 +1,482 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package telemetry
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"runtime"
+	"slices"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type receivedRequest struct {
+	header http.Header
+	body   []byte
+}
+
+type wireBody struct {
+	APIVersion  string          `json:"api_version"`
+	RequestType string          `json:"request_type"`
+	TracerTime  int64           `json:"tracer_time"`
+	RuntimeID   string          `json:"runtime_id"`
+	SequenceID  int64           `json:"seq_id"`
+	Payload     json.RawMessage `json:"payload"`
+	Application application     `json:"application"`
+	Host        host            `json:"host"`
+}
+
+type wireMessage struct {
+	RequestType string          `json:"request_type"`
+	Payload     json.RawMessage `json:"payload"`
+}
+
+func clientForTest(t *testing.T, endpoint string, httpClient *http.Client) *client {
+	t.Helper()
+
+	telemetryClient, err := NewClient(Config{
+		Endpoint:       endpoint,
+		APIKey:         "api-key",
+		ServiceName:    "test-service",
+		Environment:    "ci",
+		LibraryVersion: "1.2.3",
+		RuntimeID:      "runtime-id",
+		HTTPClient:     httpClient,
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	return telemetryClient.(*client)
+}
+
+func decodeWireBody(t *testing.T, encoded []byte) wireBody {
+	t.Helper()
+
+	var body wireBody
+	if err := json.Unmarshal(encoded, &body); err != nil {
+		t.Fatalf("decode telemetry body: %v", err)
+	}
+	return body
+}
+
+func TestNewClientValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  Config
+		wantErr string
+	}{
+		{
+			name: "valid",
+			config: Config{
+				Endpoint:       "https://example.com/api/v2/apmtelemetry",
+				ServiceName:    "ddtest",
+				LibraryVersion: "1.0.0",
+			},
+		},
+		{
+			name: "missing service name",
+			config: Config{
+				Endpoint:       "https://example.com/api/v2/apmtelemetry",
+				LibraryVersion: "1.0.0",
+			},
+			wantErr: "service name must not be empty",
+		},
+		{
+			name: "missing library version",
+			config: Config{
+				Endpoint:    "https://example.com/api/v2/apmtelemetry",
+				ServiceName: "ddtest",
+			},
+			wantErr: "library version must not be empty",
+		},
+		{
+			name: "invalid endpoint",
+			config: Config{
+				Endpoint:       "://bad",
+				ServiceName:    "ddtest",
+				LibraryVersion: "1.0.0",
+			},
+			wantErr: "invalid endpoint",
+		},
+		{
+			name: "unsupported endpoint scheme",
+			config: Config{
+				Endpoint:       "ftp://example.com/telemetry",
+				ServiceName:    "ddtest",
+				LibraryVersion: "1.0.0",
+			},
+			wantErr: "endpoint must use http or https",
+		},
+		{
+			name: "missing endpoint host",
+			config: Config{
+				Endpoint:       "http:///telemetry",
+				ServiceName:    "ddtest",
+				LibraryVersion: "1.0.0",
+			},
+			wantErr: "endpoint host must not be empty",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client, err := NewClient(test.config)
+			if test.wantErr == "" {
+				if err != nil {
+					t.Fatalf("NewClient() error = %v", err)
+				}
+				if client == nil {
+					t.Fatal("NewClient() returned a nil client")
+				}
+				return
+			}
+			if err == nil || !regexp.MustCompile(regexp.QuoteMeta(test.wantErr)).MatchString(err.Error()) {
+				t.Fatalf("NewClient() error = %v, want error containing %q", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestNoopClient(t *testing.T) {
+	client := NoopClient()
+	client.Count("count", nil).Submit(1)
+	client.Distribution("distribution", nil).Submit(2)
+	if err := client.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+}
+
+func TestFlushSendsOnlyMetricPayloads(t *testing.T) {
+	var received []receivedRequest
+	httpClient := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		encoded, err := io.ReadAll(request.Body)
+		if err != nil {
+			t.Errorf("read request body: %v", err)
+		}
+		received = append(received, receivedRequest{header: request.Header.Clone(), body: encoded})
+		return httpResponse(http.StatusAccepted, ""), nil
+	})}
+
+	client := clientForTest(t, "https://example.com/telemetry", httpClient)
+	client.now = func() time.Time { return time.Unix(1_700_000_000, 0) }
+	client.sender.requestTime = func() time.Time { return time.Unix(1_700_000_010, 0) }
+
+	countTags := []string{"rq_compressed:true", "endpoint:test_cycle"}
+	client.Count("endpoint_payload.requests", countTags).Submit(1)
+	client.Count("endpoint_payload.requests", []string{"endpoint:test_cycle", "rq_compressed:true"}).Submit(2)
+	if !slices.Equal(countTags, []string{"rq_compressed:true", "endpoint:test_cycle"}) {
+		t.Fatalf("Count() mutated caller tags: %v", countTags)
+	}
+
+	distributionTags := []string{"endpoint:test_cycle"}
+	distribution := client.Distribution("endpoint_payload.bytes", distributionTags)
+	distribution.Submit(10)
+	distribution.Submit(20)
+
+	if err := client.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+
+	if len(received) != 1 {
+		t.Fatalf("request count = %d, want 1", len(received))
+	}
+	request := received[0]
+	if got := request.header.Get("DD-Telemetry-Request-Type"); got != requestTypeMessageBatch {
+		t.Fatalf("request type = %q, want %q", got, requestTypeMessageBatch)
+	}
+	if got := request.header.Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", got)
+	}
+	if got := request.header.Get("DD-Telemetry-API-Version"); got != apiVersion {
+		t.Errorf("DD-Telemetry-API-Version = %q, want %q", got, apiVersion)
+	}
+	if got := request.header.Get("DD-Client-Library-Language"); got != languageName {
+		t.Errorf("DD-Client-Library-Language = %q, want %q", got, languageName)
+	}
+	if got := request.header.Get("DD-Client-Library-Version"); got != "1.2.3" {
+		t.Errorf("DD-Client-Library-Version = %q, want 1.2.3", got)
+	}
+	if got := request.header.Get("DD-API-KEY"); got != "api-key" {
+		t.Errorf("DD-API-KEY = %q, want api-key", got)
+	}
+
+	batchBody := decodeWireBody(t, request.body)
+	if batchBody.RequestType != requestTypeMessageBatch || batchBody.SequenceID != 1 {
+		t.Fatalf("batch request type/sequence = %q/%d, want %q/1", batchBody.RequestType, batchBody.SequenceID, requestTypeMessageBatch)
+	}
+	if batchBody.APIVersion != apiVersion || batchBody.RuntimeID != "runtime-id" || batchBody.TracerTime != 1_700_000_010 {
+		t.Errorf("unexpected batch envelope: %#v", batchBody)
+	}
+	if batchBody.Application.ServiceName != "test-service" || batchBody.Application.LibraryVersion != "1.2.3" {
+		t.Errorf("unexpected application metadata: %#v", batchBody.Application)
+	}
+	if batchBody.Application.ServiceVersion != "" {
+		t.Errorf("service version = %q, want empty", batchBody.Application.ServiceVersion)
+	}
+	if batchBody.Application.LanguageName != languageName || batchBody.Application.LanguageVersion != runtime.Version() {
+		t.Errorf("unexpected language metadata: %#v", batchBody.Application)
+	}
+	if batchBody.Host.Hostname == "" || batchBody.Host.OS == "" || batchBody.Host.Architecture == "" {
+		t.Errorf("incomplete host metadata: %#v", batchBody.Host)
+	}
+
+	var batch []wireMessage
+	if err := json.Unmarshal(batchBody.Payload, &batch); err != nil {
+		t.Fatalf("decode message-batch payload: %v", err)
+	}
+	if len(batch) != 2 {
+		t.Fatalf("message-batch message count = %d, want 2", len(batch))
+	}
+	if batch[0].RequestType != requestTypeMetrics || batch[1].RequestType != requestTypeDistribution {
+		t.Fatalf("nested request types = [%q %q], want [%q %q]", batch[0].RequestType, batch[1].RequestType, requestTypeMetrics, requestTypeDistribution)
+	}
+
+	var metricsPayload generateMetrics
+	if err := json.Unmarshal(batch[0].Payload, &metricsPayload); err != nil {
+		t.Fatalf("decode generate-metrics payload: %v", err)
+	}
+	if len(metricsPayload.Series) != 1 {
+		t.Fatalf("generate-metrics series count = %d, want 1", len(metricsPayload.Series))
+	}
+	metric := metricsPayload.Series[0]
+	if metric.Metric != "endpoint_payload.requests" || metric.Type != "count" || metric.Namespace != namespaceCIVisibility || !metric.Common {
+		t.Errorf("unexpected count metric: %#v", metric)
+	}
+	if !slices.Equal(metric.Tags, []string{"endpoint:test_cycle", "rq_compressed:true"}) {
+		t.Errorf("count tags = %v, want sorted tags", metric.Tags)
+	}
+	if len(metric.Points) != 1 || metric.Points[0][0].(float64) != 1_700_000_000 || metric.Points[0][1].(float64) != 3 {
+		t.Errorf("count points = %#v, want [[1700000000, 3]]", metric.Points)
+	}
+
+	var distributionPayload distributions
+	if err := json.Unmarshal(batch[1].Payload, &distributionPayload); err != nil {
+		t.Fatalf("decode distributions payload: %v", err)
+	}
+	if len(distributionPayload.Series) != 1 {
+		t.Fatalf("distributions series count = %d, want 1", len(distributionPayload.Series))
+	}
+	distributionMetric := distributionPayload.Series[0]
+	if distributionMetric.Metric != "endpoint_payload.bytes" || distributionMetric.Namespace != namespaceCIVisibility || !distributionMetric.Common {
+		t.Errorf("unexpected distribution metric: %#v", distributionMetric)
+	}
+	if !slices.Equal(distributionMetric.Points, []float64{10, 20}) {
+		t.Errorf("distribution points = %v, want [10 20]", distributionMetric.Points)
+	}
+
+	if err := client.Flush(context.Background()); err != nil {
+		t.Fatalf("empty Flush() error = %v", err)
+	}
+	if len(received) != 1 {
+		t.Fatalf("empty Flush() sent a request; request count = %d, want 1", len(received))
+	}
+}
+
+func TestFlushRestoresFailedMetrics(t *testing.T) {
+	var calls atomic.Int32
+	var received [][]byte
+	httpClient := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		encoded, err := io.ReadAll(request.Body)
+		if err != nil {
+			t.Errorf("read request body: %v", err)
+		}
+		received = append(received, encoded)
+		if calls.Add(1) == 1 {
+			return httpResponse(http.StatusServiceUnavailable, "try again"), nil
+		}
+		return httpResponse(http.StatusAccepted, ""), nil
+	})}
+
+	client := clientForTest(t, "https://example.com/telemetry", httpClient)
+	client.now = func() time.Time { return time.Unix(1_700_000_000, 0) }
+	client.Count("git.command", nil).Submit(1)
+
+	if err := client.Flush(context.Background()); err == nil {
+		t.Fatal("first Flush() error = nil, want an HTTP status error")
+	}
+	client.Count("git.command", nil).Submit(2)
+	if err := client.Flush(context.Background()); err != nil {
+		t.Fatalf("second Flush() error = %v", err)
+	}
+
+	if len(received) != 2 {
+		t.Fatalf("request count = %d, want 2", len(received))
+	}
+	retryBody := decodeWireBody(t, received[1])
+	if retryBody.RequestType != requestTypeMetrics {
+		t.Fatalf("single count retry request type = %q, want %q", retryBody.RequestType, requestTypeMetrics)
+	}
+	var retryPayload generateMetrics
+	if err := json.Unmarshal(retryBody.Payload, &retryPayload); err != nil {
+		t.Fatalf("decode retry payload: %v", err)
+	}
+	if got := retryPayload.Series[0].Points[0][1].(float64); got != 3 {
+		t.Fatalf("retried count = %v, want 3", got)
+	}
+}
+
+func TestFlushRestoresFailedBatch(t *testing.T) {
+	var calls atomic.Int32
+	var received [][]byte
+	httpClient := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		encoded, err := io.ReadAll(request.Body)
+		if err != nil {
+			t.Errorf("read request body: %v", err)
+		}
+		received = append(received, encoded)
+		if calls.Add(1) == 1 {
+			return httpResponse(http.StatusServiceUnavailable, "try again"), nil
+		}
+		return httpResponse(http.StatusAccepted, ""), nil
+	})}
+
+	client := clientForTest(t, "https://example.com/telemetry", httpClient)
+	client.Count("git.command", nil).Submit(1)
+	client.Distribution("git.command_ms", nil).Submit(10)
+	if err := client.Flush(context.Background()); err == nil {
+		t.Fatal("first Flush() error = nil, want batch error")
+	}
+	client.Count("git.command", nil).Submit(2)
+	client.Distribution("git.command_ms", nil).Submit(20)
+	if err := client.Flush(context.Background()); err != nil {
+		t.Fatalf("second Flush() error = %v", err)
+	}
+
+	if len(received) != 2 {
+		t.Fatalf("request count = %d, want 2", len(received))
+	}
+	retryBody := decodeWireBody(t, received[1])
+	if retryBody.RequestType != requestTypeMessageBatch {
+		t.Fatalf("retry request type = %q, want %q", retryBody.RequestType, requestTypeMessageBatch)
+	}
+	var retryBatch []wireMessage
+	if err := json.Unmarshal(retryBody.Payload, &retryBatch); err != nil {
+		t.Fatalf("decode retry batch: %v", err)
+	}
+	if len(retryBatch) != 2 || retryBatch[0].RequestType != requestTypeMetrics || retryBatch[1].RequestType != requestTypeDistribution {
+		t.Fatalf("unexpected retry batch: %#v", retryBatch)
+	}
+	var metricsPayload generateMetrics
+	if err := json.Unmarshal(retryBatch[0].Payload, &metricsPayload); err != nil {
+		t.Fatalf("decode retried count: %v", err)
+	}
+	if got := metricsPayload.Series[0].Points[0][1].(float64); got != 3 {
+		t.Fatalf("retried count = %v, want 3", got)
+	}
+	var distributionPayload distributions
+	if err := json.Unmarshal(retryBatch[1].Payload, &distributionPayload); err != nil {
+		t.Fatalf("decode retried distribution: %v", err)
+	}
+	if got := distributionPayload.Series[0].Points; !slices.Equal(got, []float64{10, 20}) {
+		t.Fatalf("retried distribution = %v, want [10 20]", got)
+	}
+}
+
+func TestReducePayloads(t *testing.T) {
+	distribution := distributions{Series: []distributionSeries{{Metric: "git.command_ms"}}}
+	if got := reducePayloads(nil); got != nil {
+		t.Fatalf("reducePayloads(nil) = %#v, want nil", got)
+	}
+	if got := reducePayloads([]payload{distribution}); got.requestType() != requestTypeDistribution {
+		t.Fatalf("single payload request type = %q, want %q", got.requestType(), requestTypeDistribution)
+	}
+	reduced := reducePayloads([]payload{generateMetrics{}, distribution})
+	batch, ok := reduced.(messageBatch)
+	if !ok {
+		t.Fatalf("two payloads reduced to %T, want messageBatch", reduced)
+	}
+	if len(batch) != 2 || batch[0].RequestType != requestTypeMetrics || batch[1].RequestType != requestTypeDistribution {
+		t.Fatalf("unexpected reduced batch: %#v", batch)
+	}
+}
+
+func TestCountIsSafeForConcurrentUse(t *testing.T) {
+	client := clientForTest(t, "https://example.com/telemetry", &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusAccepted,
+				Status:     "202 Accepted",
+				Body:       io.NopCloser(&emptyReader{}),
+			}, nil
+		}),
+	})
+	count := client.Count("git.command", nil)
+
+	const submissions = 100
+	var waitGroup sync.WaitGroup
+	for range submissions {
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+			count.Submit(1)
+		}()
+	}
+	waitGroup.Wait()
+
+	counts, _ := client.drain()
+	if got := counts[newMetricKey("git.command", nil)].value; got != submissions {
+		t.Fatalf("concurrent count = %v, want %d", got, submissions)
+	}
+}
+
+func TestNewRuntimeID(t *testing.T) {
+	id, err := newRuntimeID()
+	if err != nil {
+		t.Fatalf("newRuntimeID() error = %v", err)
+	}
+	if matched := regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`).MatchString(id); !matched {
+		t.Fatalf("newRuntimeID() = %q, want a version 4 UUID", id)
+	}
+}
+
+func TestFlushHonorsContextCancellationAndRetainsMetrics(t *testing.T) {
+	client := clientForTest(t, "https://example.com/telemetry", &http.Client{
+		Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			return nil, request.Context().Err()
+		}),
+	})
+	client.Count("git.command", nil).Submit(1)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := client.Flush(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Flush() error = %v, want context.Canceled", err)
+	}
+	counts, _ := client.drain()
+	if got := counts[newMetricKey("git.command", nil)].value; got != 1 {
+		t.Fatalf("retained count = %v, want 1", got)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
+func httpResponse(statusCode int, responseBody string) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Status:     fmt.Sprintf("%d %s", statusCode, http.StatusText(statusCode)),
+		Body:       io.NopCloser(strings.NewReader(responseBody)),
+	}
+}
+
+type emptyReader struct{}
+
+func (*emptyReader) Read([]byte) (int, error) {
+	return 0, io.EOF
+}

--- a/internal/telemetry/transport.go
+++ b/internal/telemetry/transport.go
@@ -1,0 +1,292 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package telemetry
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"runtime"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/DataDog/ddtest/internal/utils/osinfo"
+)
+
+const (
+	apiVersion              = "v2"
+	languageName            = "ddtest"
+	requestTypeMetrics      = "generate-metrics"
+	requestTypeDistribution = "distributions"
+	requestTypeMessageBatch = "message-batch"
+)
+
+type payload interface {
+	requestType() string
+}
+
+type message struct {
+	RequestType string  `json:"request_type"`
+	Payload     payload `json:"payload"`
+}
+
+type messageBatch []message
+
+func (messageBatch) requestType() string {
+	return requestTypeMessageBatch
+}
+
+func reducePayloads(payloads []payload) payload {
+	switch len(payloads) {
+	case 0:
+		return nil
+	case 1:
+		return payloads[0]
+	}
+
+	messages := make(messageBatch, len(payloads))
+	for index, payload := range payloads {
+		messages[index] = message{
+			RequestType: payload.requestType(),
+			Payload:     payload,
+		}
+	}
+	return messages
+}
+
+type metricData struct {
+	Metric    string   `json:"metric"`
+	Points    [][2]any `json:"points"`
+	Type      string   `json:"type"`
+	Tags      []string `json:"tags,omitempty"`
+	Common    bool     `json:"common"`
+	Namespace string   `json:"namespace"`
+}
+
+type generateMetrics struct {
+	Series []metricData `json:"series"`
+}
+
+func (generateMetrics) requestType() string {
+	return requestTypeMetrics
+}
+
+func generateMetricsPayload(counts map[metricKey]countPoint) generateMetrics {
+	series := make([]metricData, 0, len(counts))
+	for key, point := range counts {
+		series = append(series, metricData{
+			Metric:    key.name,
+			Points:    [][2]any{{point.time.Unix(), point.value}},
+			Type:      "count",
+			Tags:      key.splitTags(),
+			Common:    true,
+			Namespace: namespaceCIVisibility,
+		})
+	}
+	slices.SortFunc(series, func(a, b metricData) int {
+		if result := strings.Compare(a.Metric, b.Metric); result != 0 {
+			return result
+		}
+		return strings.Compare(strings.Join(a.Tags, ","), strings.Join(b.Tags, ","))
+	})
+	return generateMetrics{Series: series}
+}
+
+type distributionSeries struct {
+	Metric    string    `json:"metric"`
+	Points    []float64 `json:"points"`
+	Tags      []string  `json:"tags,omitempty"`
+	Common    bool      `json:"common"`
+	Namespace string    `json:"namespace"`
+}
+
+type distributions struct {
+	Series []distributionSeries `json:"series"`
+}
+
+func (distributions) requestType() string {
+	return requestTypeDistribution
+}
+
+func distributionsPayload(values map[metricKey][]float64) distributions {
+	series := make([]distributionSeries, 0, len(values))
+	for key, points := range values {
+		series = append(series, distributionSeries{
+			Metric:    key.name,
+			Points:    points,
+			Tags:      key.splitTags(),
+			Common:    true,
+			Namespace: namespaceCIVisibility,
+		})
+	}
+	slices.SortFunc(series, func(a, b distributionSeries) int {
+		if result := strings.Compare(a.Metric, b.Metric); result != 0 {
+			return result
+		}
+		return strings.Compare(strings.Join(a.Tags, ","), strings.Join(b.Tags, ","))
+	})
+	return distributions{Series: series}
+}
+
+type application struct {
+	ServiceName string `json:"service_name"`
+	Environment string `json:"env"`
+	// ServiceVersion is required by the telemetry v2 schema. ddtest does not
+	// have a service version, so it is always empty.
+	ServiceVersion  string `json:"service_version"`
+	LibraryVersion  string `json:"tracer_version"`
+	LanguageName    string `json:"language_name"`
+	LanguageVersion string `json:"language_version"`
+}
+
+type host struct {
+	Hostname      string `json:"hostname"`
+	OS            string `json:"os"`
+	OSVersion     string `json:"os_version"`
+	Architecture  string `json:"architecture"`
+	KernelName    string `json:"kernel_name"`
+	KernelRelease string `json:"kernel_release"`
+	KernelVersion string `json:"kernel_version"`
+}
+
+type body struct {
+	APIVersion  string      `json:"api_version"`
+	RequestType string      `json:"request_type"`
+	TracerTime  int64       `json:"tracer_time"`
+	RuntimeID   string      `json:"runtime_id"`
+	SequenceID  int64       `json:"seq_id"`
+	Payload     payload     `json:"payload"`
+	Application application `json:"application"`
+	Host        host        `json:"host"`
+}
+
+type sender struct {
+	mu          sync.Mutex
+	endpoint    *url.URL
+	apiKey      string
+	httpClient  *http.Client
+	body        body
+	requestTime func() time.Time
+}
+
+func newSender(config Config, endpoint *url.URL) (*sender, error) {
+	runtimeID := config.RuntimeID
+	if runtimeID == "" {
+		var err error
+		runtimeID, err = newRuntimeID()
+		if err != nil {
+			return nil, fmt.Errorf("telemetry: create runtime ID: %w", err)
+		}
+	}
+
+	hostname, err := os.Hostname()
+	if err != nil || hostname == "" {
+		hostname = "unknown"
+	}
+	httpClient := config.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 5 * time.Second}
+	}
+	return &sender{
+		endpoint:    endpoint,
+		apiKey:      config.APIKey,
+		httpClient:  httpClient,
+		requestTime: time.Now,
+		body: body{
+			APIVersion: apiVersion,
+			RuntimeID:  runtimeID,
+			Application: application{
+				ServiceName:     config.ServiceName,
+				Environment:     config.Environment,
+				LibraryVersion:  config.LibraryVersion,
+				LanguageName:    languageName,
+				LanguageVersion: runtime.Version(),
+			},
+			Host: host{
+				Hostname:      hostname,
+				OS:            runtime.GOOS,
+				OSVersion:     osinfo.OSVersion(),
+				Architecture:  runtime.GOARCH,
+				KernelName:    "unknown",
+				KernelRelease: "unknown",
+				KernelVersion: "unknown",
+			},
+		},
+	}, nil
+}
+
+func newRuntimeID() (string, error) {
+	var id [16]byte
+	if _, err := rand.Read(id[:]); err != nil {
+		return "", err
+	}
+	id[6] = (id[6] & 0x0f) | 0x40
+	id[8] = (id[8] & 0x3f) | 0x80
+
+	var encoded [36]byte
+	hex.Encode(encoded[0:8], id[0:4])
+	encoded[8] = '-'
+	hex.Encode(encoded[9:13], id[4:6])
+	encoded[13] = '-'
+	hex.Encode(encoded[14:18], id[6:8])
+	encoded[18] = '-'
+	hex.Encode(encoded[19:23], id[8:10])
+	encoded[23] = '-'
+	hex.Encode(encoded[24:36], id[10:16])
+	return string(encoded[:]), nil
+}
+
+func (s *sender) send(ctx context.Context, metrics payload) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.body.SequenceID++
+	s.body.TracerTime = s.requestTime().Unix()
+	s.body.RequestType = metrics.requestType()
+	s.body.Payload = metrics
+
+	encoded, err := json.Marshal(s.body)
+	if err != nil {
+		return fmt.Errorf("telemetry: encode %s payload: %w", metrics.requestType(), err)
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, s.endpoint.String(), bytes.NewReader(encoded))
+	if err != nil {
+		return fmt.Errorf("telemetry: create %s request: %w", metrics.requestType(), err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("DD-Telemetry-API-Version", apiVersion)
+	request.Header.Set("DD-Telemetry-Request-Type", metrics.requestType())
+	request.Header.Set("DD-Client-Library-Language", s.body.Application.LanguageName)
+	request.Header.Set("DD-Client-Library-Version", s.body.Application.LibraryVersion)
+	request.Header.Set("DD-Agent-Env", s.body.Application.Environment)
+	request.Header.Set("DD-Agent-Hostname", s.body.Host.Hostname)
+	if s.apiKey != "" {
+		request.Header.Set("DD-API-KEY", s.apiKey)
+	}
+
+	response, err := s.httpClient.Do(request)
+	if err != nil {
+		return fmt.Errorf("telemetry: send %s payload: %w", metrics.requestType(), err)
+	}
+	defer func() {
+		_ = response.Body.Close()
+	}()
+
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		responseBody, _ := io.ReadAll(io.LimitReader(response.Body, 256))
+		return fmt.Errorf("telemetry: send %s payload: unexpected status %s: %s", metrics.requestType(), response.Status, responseBody)
+	}
+	return nil
+}

--- a/internal/telemetry/transport.go
+++ b/internal/telemetry/transport.go
@@ -22,12 +22,16 @@ import (
 	"sync"
 	"time"
 
+	"github.com/DataDog/ddtest/internal/httptransport"
 	"github.com/DataDog/ddtest/internal/utils/osinfo"
 )
 
 const (
 	apiVersion              = "v2"
 	languageName            = "ddtest"
+	telemetryAPIPath        = "/api/v2/apmtelemetry"
+	telemetryAgentPath      = "/telemetry/proxy/api/v2/apmtelemetry"
+	telemetryHTTPTimeout    = 5 * time.Second
 	requestTypeMetrics      = "generate-metrics"
 	requestTypeDistribution = "distributions"
 	requestTypeMessageBatch = "message-batch"
@@ -181,28 +185,75 @@ type sender struct {
 	requestTime func() time.Time
 }
 
-func newSender(config Config, endpoint *url.URL) (*sender, error) {
-	runtimeID := config.RuntimeID
-	if runtimeID == "" {
-		var err error
-		runtimeID, err = newRuntimeID()
-		if err != nil {
-			return nil, fmt.Errorf("telemetry: create runtime ID: %w", err)
+type destination struct {
+	endpoint   *url.URL
+	apiKey     string
+	httpClient *http.Client
+}
+
+func resolveDestination() (destination, error) {
+	connection, err := httptransport.ResolveDatadogConnection()
+	if err != nil {
+		return destination{}, err
+	}
+
+	httpClient := httptransport.NewHTTPClient(telemetryHTTPTimeout)
+	if connection.Agentless {
+		baseURL := connection.AgentlessURL
+		if baseURL == "" {
+			baseURL = fmt.Sprintf("https://instrumentation-telemetry-intake.%s", connection.Site)
 		}
+		endpoint, err := url.JoinPath(baseURL, telemetryAPIPath)
+		if err != nil {
+			return destination{}, fmt.Errorf("telemetry: create agentless endpoint: %w", err)
+		}
+		parsedEndpoint, err := parseEndpoint(endpoint)
+		if err != nil {
+			return destination{}, err
+		}
+		return destination{endpoint: parsedEndpoint, apiKey: connection.APIKey, httpClient: httpClient}, nil
+	}
+
+	agentURL, httpClient := httptransport.AgentHTTPTransport(connection.AgentURL, telemetryHTTPTimeout)
+	endpoint, err := url.JoinPath(agentURL.String(), telemetryAgentPath)
+	if err != nil {
+		return destination{}, fmt.Errorf("telemetry: create Agent endpoint: %w", err)
+	}
+	parsedEndpoint, err := parseEndpoint(endpoint)
+	if err != nil {
+		return destination{}, err
+	}
+	return destination{endpoint: parsedEndpoint, httpClient: httpClient}, nil
+}
+
+func parseEndpoint(value string) (*url.URL, error) {
+	endpoint, err := url.Parse(value)
+	if err != nil {
+		return nil, fmt.Errorf("telemetry: parse endpoint: %w", err)
+	}
+	if endpoint.Scheme != "http" && endpoint.Scheme != "https" {
+		return nil, fmt.Errorf("telemetry: endpoint must use HTTP(S): %q", value)
+	}
+	if endpoint.Host == "" {
+		return nil, fmt.Errorf("telemetry: endpoint host must not be empty: %q", value)
+	}
+	return endpoint, nil
+}
+
+func newSender(config Config, destination destination) (*sender, error) {
+	runtimeID, err := newRuntimeID()
+	if err != nil {
+		return nil, fmt.Errorf("telemetry: create runtime ID: %w", err)
 	}
 
 	hostname, err := os.Hostname()
 	if err != nil || hostname == "" {
 		hostname = "unknown"
 	}
-	httpClient := config.HTTPClient
-	if httpClient == nil {
-		httpClient = &http.Client{Timeout: 5 * time.Second}
-	}
 	return &sender{
-		endpoint:    endpoint,
-		apiKey:      config.APIKey,
-		httpClient:  httpClient,
+		endpoint:    destination.endpoint,
+		apiKey:      destination.apiKey,
+		httpClient:  destination.httpClient,
 		requestTime: time.Now,
 		body: body{
 			APIVersion: apiVersion,

--- a/internal/telemetry/transport.go
+++ b/internal/telemetry/transport.go
@@ -117,7 +117,8 @@ type distributionSeries struct {
 }
 
 type distributions struct {
-	Series []distributionSeries `json:"series"`
+	Namespace string               `json:"namespace"`
+	Series    []distributionSeries `json:"series"`
 }
 
 func (distributions) requestType() string {
@@ -141,7 +142,7 @@ func distributionsPayload(values map[metricKey][]float64) distributions {
 		}
 		return strings.Compare(strings.Join(a.Tags, ","), strings.Join(b.Tags, ","))
 	})
-	return distributions{Series: series}
+	return distributions{Namespace: namespaceCIVisibility, Series: series}
 }
 
 type application struct {
@@ -321,6 +322,7 @@ func (s *sender) send(ctx context.Context, metrics payload) error {
 	request.Header.Set("DD-Telemetry-Request-Type", metrics.requestType())
 	request.Header.Set("DD-Client-Library-Language", s.body.Application.LanguageName)
 	request.Header.Set("DD-Client-Library-Version", s.body.Application.LibraryVersion)
+	request.Header.Set("DD-Session-ID", s.body.RuntimeID)
 	request.Header.Set("DD-Agent-Env", s.body.Application.Environment)
 	request.Header.Set("DD-Agent-Hostname", s.body.Host.Hostname)
 	if s.apiKey != "" {

--- a/internal/testoptimization/api/http.go
+++ b/internal/testoptimization/api/http.go
@@ -15,13 +15,13 @@ import (
 	"log/slog"
 	"mime"
 	"mime/multipart"
-	"net"
 	"net/http"
 	"net/textproto"
 	"strconv"
 	"time"
 
 	"github.com/DataDog/ddtest/internal/constants"
+	"github.com/DataDog/ddtest/internal/httptransport"
 	"github.com/tinylib/msgp/msgp"
 )
 
@@ -98,26 +98,7 @@ type RequestHandler struct {
 // This also permits orchestrion to disable tracing on this client.
 // See https://golang.org/pkg/net/http/#DefaultTransport .
 // Except we use a higher timeout for this
-var defaultHTTPClient = createNewHTTPClient()
-
-// createNewHTTPClient creates a new HTTP client with custom transport settings.
-func createNewHTTPClient() *http.Client {
-	return &http.Client{
-		Timeout: 45 * time.Second,
-		Transport: &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-			DialContext: (&net.Dialer{
-				Timeout:   30 * time.Second,
-				KeepAlive: 30 * time.Second,
-			}).DialContext,
-			ForceAttemptHTTP2:     true,
-			MaxIdleConns:          100,
-			IdleConnTimeout:       90 * time.Second,
-			TLSHandshakeTimeout:   10 * time.Second,
-			ExpectContinueTimeout: 1 * time.Second,
-		},
-	}
-}
+var defaultHTTPClient = httptransport.NewHTTPClient(45 * time.Second)
 
 // NewRequestHandler creates a new RequestHandler with a default HTTP client.
 func NewRequestHandler() *RequestHandler {

--- a/internal/testoptimization/api/http.go
+++ b/internal/testoptimization/api/http.go
@@ -61,11 +61,19 @@ type RequestConfig struct {
 
 // Response represents the HTTP response with deserialization capabilities and status code.
 type Response struct {
-	Body         []byte // Response body in raw format
+	Body         []byte // Response body, decompressed when gzip encoded
+	BodySize     int    // Response body size before decompression
 	Format       string // Format of the response (json or msgpack)
 	StatusCode   int    // HTTP status code
 	CanUnmarshal bool   // Whether the response body can be unmarshalled
 	Compressed   bool   // Whether to use gzip compression
+}
+
+func responseStatusCode(response *Response) int {
+	if response == nil {
+		return 0
+	}
+	return response.StatusCode
 }
 
 // Unmarshal deserializes the response body into the provided target based on the response format.
@@ -129,14 +137,16 @@ func (rh *RequestHandler) SendRequest(config RequestConfig) (*Response, error) {
 		return nil, errors.New("URL is required")
 	}
 
+	var response *Response
 	for attempt := 0; attempt <= config.MaxRetries; attempt++ {
 		stopRetries, rs, err := rh.internalSendRequest(&config, attempt)
+		response = rs
 		if stopRetries {
 			return rs, err
 		}
 	}
 
-	return nil, errors.New("max retries exceeded")
+	return response, errors.New("max retries exceeded")
 }
 
 func (rh *RequestHandler) internalSendRequest(config *RequestConfig, attempt int) (stopRetries bool, response *Response, requestError error) {
@@ -233,6 +243,10 @@ func (rh *RequestHandler) internalSendRequest(config *RequestConfig, attempt int
 
 	// Capture the status code
 	statusCode := resp.StatusCode
+	retryResponse := &Response{
+		StatusCode: statusCode,
+		Compressed: resp.Header.Get(HeaderContentEncoding) == ContentEncodingGzip,
+	}
 
 	// Check for rate-limiting (HTTP 429)
 	if resp.StatusCode == HTTPStatusTooManyRequests {
@@ -252,13 +266,13 @@ func (rh *RequestHandler) internalSendRequest(config *RequestConfig, attempt int
 				if waitDuration > 0 {
 					time.Sleep(waitDuration)
 				}
-				return false, nil, nil
+				return false, retryResponse, nil
 			}
 		}
 
 		// Fallback to exponential backoff if header is missing or invalid
 		exponentialBackoff(attempt, config.Backoff)
-		return false, nil, nil
+		return false, retryResponse, nil
 	}
 
 	// Check status code for retries
@@ -266,13 +280,14 @@ func (rh *RequestHandler) internalSendRequest(config *RequestConfig, attempt int
 		// Retry if the status code is >= 406
 		slog.Debug("ciVisibilityHttpClient: response status code", "statusCode", resp.StatusCode)
 		exponentialBackoff(attempt, config.Backoff)
-		return false, nil, nil
+		return false, retryResponse, nil
 	}
 
 	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return true, nil, err
 	}
+	responseBodySize := len(responseBody)
 
 	// Decompress response if it is gzip compressed
 	compressedResponse := false
@@ -299,7 +314,7 @@ func (rh *RequestHandler) internalSendRequest(config *RequestConfig, attempt int
 	canUnmarshal := statusCode >= 200 && statusCode < 300
 
 	// Return the successful response with status code and unmarshal capability
-	return true, &Response{Body: responseBody, Format: responseFormat, StatusCode: statusCode, CanUnmarshal: canUnmarshal, Compressed: compressedResponse}, nil
+	return true, &Response{Body: responseBody, BodySize: responseBodySize, Format: responseFormat, StatusCode: statusCode, CanUnmarshal: canUnmarshal, Compressed: compressedResponse}, nil
 }
 
 // Helper functions for data serialization, compression, and handling multipart form data

--- a/internal/testoptimization/api/known_tests_api.go
+++ b/internal/testoptimization/api/known_tests_api.go
@@ -9,6 +9,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
+
+	"github.com/DataDog/ddtest/internal/telemetry"
 )
 
 const (
@@ -99,11 +101,19 @@ func (c *transport) GetKnownTests() (*KnownTestsResponseData, error) {
 		}
 
 		request := c.getPostRequestConfig(knownTestsURLPath, body)
+		telemetry.KnownTestsRequest(c.telemetryClient, request.Compressed)
+		requestStartTime := time.Now()
 		response, err := c.handler.SendRequest(*request)
+		telemetry.KnownTestsRequestMs(c.telemetryClient, time.Since(requestStartTime))
 
 		if err != nil {
+			telemetry.KnownTestsRequestErrors(c.telemetryClient, 0)
 			return nil, fmt.Errorf("sending known tests request: %s", err)
 		}
+		if response.StatusCode < 200 || response.StatusCode >= 300 {
+			telemetry.KnownTestsRequestErrors(c.telemetryClient, response.StatusCode)
+		}
+		telemetry.KnownTestsResponseBytes(c.telemetryClient, response.Compressed, len(response.Body))
 		pageCount++
 		if pageCount == 1 {
 			firstRawResponse = cloneRawMessage(response.Body)
@@ -131,6 +141,7 @@ func (c *transport) GetKnownTests() (*KnownTestsResponseData, error) {
 		}
 		cursor = allKnownTests.PageInfo.Cursor
 	}
+	telemetry.KnownTestsResponseTests(c.telemetryClient, knownTestsResponseTestCount(&allKnownTests))
 
 	if pageCount == 1 {
 		c.knownTestsRawResponse = firstRawResponse
@@ -144,6 +155,19 @@ func (c *transport) GetKnownTests() (*KnownTestsResponseData, error) {
 	}
 
 	return &allKnownTests, nil
+}
+
+func knownTestsResponseTestCount(response *KnownTestsResponseData) int {
+	if response == nil {
+		return 0
+	}
+	testCount := 0
+	for _, suites := range response.Tests {
+		for _, tests := range suites {
+			testCount += len(tests)
+		}
+	}
+	return testCount
 }
 
 func mergeKnownTests(dst, src KnownTestsResponseDataModules) {

--- a/internal/testoptimization/api/known_tests_api.go
+++ b/internal/testoptimization/api/known_tests_api.go
@@ -107,13 +107,13 @@ func (c *transport) GetKnownTests() (*KnownTestsResponseData, error) {
 		telemetry.KnownTestsRequestMs(c.telemetryClient, time.Since(requestStartTime))
 
 		if err != nil {
-			telemetry.KnownTestsRequestErrors(c.telemetryClient, 0)
+			telemetry.KnownTestsRequestErrors(c.telemetryClient, responseStatusCode(response))
 			return nil, fmt.Errorf("sending known tests request: %s", err)
 		}
 		if response.StatusCode < 200 || response.StatusCode >= 300 {
 			telemetry.KnownTestsRequestErrors(c.telemetryClient, response.StatusCode)
 		}
-		telemetry.KnownTestsResponseBytes(c.telemetryClient, response.Compressed, len(response.Body))
+		telemetry.KnownTestsResponseBytes(c.telemetryClient, response.Compressed, response.BodySize)
 		pageCount++
 		if pageCount == 1 {
 			firstRawResponse = cloneRawMessage(response.Body)

--- a/internal/testoptimization/api/searchcommits_api.go
+++ b/internal/testoptimization/api/searchcommits_api.go
@@ -7,8 +7,10 @@ package api
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/DataDog/ddtest/internal/constants"
+	"github.com/DataDog/ddtest/internal/telemetry"
 )
 
 const (
@@ -49,9 +51,16 @@ func (c *transport) GetCommits(localCommits []string) ([]string, error) {
 	}
 
 	request := c.getPostRequestConfig(searchCommitsURLPath, body)
+	telemetry.GitRequestsSearchCommits(c.telemetryClient, request.Compressed)
+	startTime := time.Now()
 	response, err := c.handler.SendRequest(*request)
 	if err != nil {
+		telemetry.GitRequestsSearchCommitsErrors(c.telemetryClient, 0)
 		return nil, fmt.Errorf("sending search commits request: %s", err.Error())
+	}
+	telemetry.GitRequestsSearchCommitsMs(c.telemetryClient, response.Compressed, time.Since(startTime))
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		telemetry.GitRequestsSearchCommitsErrors(c.telemetryClient, response.StatusCode)
 	}
 
 	var responseObject searchCommits

--- a/internal/testoptimization/api/searchcommits_api.go
+++ b/internal/testoptimization/api/searchcommits_api.go
@@ -54,11 +54,12 @@ func (c *transport) GetCommits(localCommits []string) ([]string, error) {
 	telemetry.GitRequestsSearchCommits(c.telemetryClient, request.Compressed)
 	startTime := time.Now()
 	response, err := c.handler.SendRequest(*request)
+	responseCompressed := response != nil && response.Compressed
+	telemetry.GitRequestsSearchCommitsMs(c.telemetryClient, responseCompressed, time.Since(startTime))
 	if err != nil {
-		telemetry.GitRequestsSearchCommitsErrors(c.telemetryClient, 0)
+		telemetry.GitRequestsSearchCommitsErrors(c.telemetryClient, responseStatusCode(response))
 		return nil, fmt.Errorf("sending search commits request: %s", err.Error())
 	}
-	telemetry.GitRequestsSearchCommitsMs(c.telemetryClient, response.Compressed, time.Since(startTime))
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
 		telemetry.GitRequestsSearchCommitsErrors(c.telemetryClient, response.StatusCode)
 	}

--- a/internal/testoptimization/api/sendpackfiles_api.go
+++ b/internal/testoptimization/api/sendpackfiles_api.go
@@ -89,7 +89,7 @@ func (c *transport) SendPackFiles(commitSha string, packFiles []string) (bytes i
 		telemetry.GitRequestsObjectsPackMs(c.telemetryClient, time.Since(startTime))
 
 		if responseErr != nil {
-			telemetry.GitRequestsObjectsPackErrors(c.telemetryClient, 0)
+			telemetry.GitRequestsObjectsPackErrors(c.telemetryClient, responseStatusCode(response))
 			err = fmt.Errorf("failed to send packfile request: %s", responseErr)
 			return
 		}

--- a/internal/testoptimization/api/sendpackfiles_api.go
+++ b/internal/testoptimization/api/sendpackfiles_api.go
@@ -8,8 +8,10 @@ package api
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/DataDog/ddtest/internal/constants"
+	"github.com/DataDog/ddtest/internal/telemetry"
 )
 
 const (
@@ -80,20 +82,27 @@ func (c *transport) SendPackFiles(commitSha string, packFiles []string) (bytes i
 			MaxRetries: constants.DefaultMaxRetries,
 			Backoff:    constants.DefaultBackoff,
 		}
+		telemetry.GitRequestsObjectsPack(c.telemetryClient, request.Compressed)
 
+		startTime := time.Now()
 		response, responseErr := c.handler.SendRequest(request)
+		telemetry.GitRequestsObjectsPackMs(c.telemetryClient, time.Since(startTime))
 
 		if responseErr != nil {
+			telemetry.GitRequestsObjectsPackErrors(c.telemetryClient, 0)
 			err = fmt.Errorf("failed to send packfile request: %s", responseErr)
 			return
 		}
 
 		if response.StatusCode < 200 || response.StatusCode >= 300 {
+			telemetry.GitRequestsObjectsPackErrors(c.telemetryClient, response.StatusCode)
 			err = fmt.Errorf("unexpected response code %d: %s", response.StatusCode, string(response.Body))
 		}
 
 		bytes += int64(len(fileContent))
 	}
+	telemetry.GitRequestsObjectsPackFiles(c.telemetryClient, len(packFiles))
+	telemetry.GitRequestsObjectsPackBytes(c.telemetryClient, bytes)
 
 	return
 }

--- a/internal/testoptimization/api/settings_api.go
+++ b/internal/testoptimization/api/settings_api.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/DataDog/ddtest/internal/settings"
+	"github.com/DataDog/ddtest/internal/telemetry"
 )
 
 const (
@@ -99,10 +100,17 @@ func (c *transport) GetSettings() (*SettingsResponseData, error) {
 	}
 
 	request := c.getPostRequestConfig(settingsURLPath, body)
+	telemetry.GitRequestsSettings(c.telemetryClient, request.Compressed)
 
+	requestStartTime := time.Now()
 	response, err := c.handler.SendRequest(*request)
+	telemetry.GitRequestsSettingsMs(c.telemetryClient, time.Since(requestStartTime))
 	if err != nil {
+		telemetry.GitRequestsSettingsErrors(c.telemetryClient, 0)
 		return nil, fmt.Errorf("sending get settings request: %s", err)
+	}
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		telemetry.GitRequestsSettingsErrors(c.telemetryClient, response.StatusCode)
 	}
 
 	slog.Debug("testoptimization.settings", "responseBody", string(response.Body))
@@ -113,6 +121,14 @@ func (c *transport) GetSettings() (*SettingsResponseData, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unmarshalling settings response: %s", err)
 	}
+	settings := &responseObject.Data.Attributes
+	telemetry.GitRequestsSettingsResponse(c.telemetryClient, telemetry.SettingsResponse{
+		CodeCoverageEnabled:        settings.CodeCoverage,
+		ITRSkippingEnabled:         settings.TestsSkipping,
+		EarlyFlakeDetectionEnabled: settings.EarlyFlakeDetection.Enabled,
+		FlakyTestRetriesEnabled:    settings.FlakyTestRetriesEnabled,
+		TestManagementEnabled:      settings.TestManagement.Enabled,
+	})
 
-	return &responseObject.Data.Attributes, nil
+	return settings, nil
 }

--- a/internal/testoptimization/api/settings_api.go
+++ b/internal/testoptimization/api/settings_api.go
@@ -106,7 +106,7 @@ func (c *transport) GetSettings() (*SettingsResponseData, error) {
 	response, err := c.handler.SendRequest(*request)
 	telemetry.GitRequestsSettingsMs(c.telemetryClient, time.Since(requestStartTime))
 	if err != nil {
-		telemetry.GitRequestsSettingsErrors(c.telemetryClient, 0)
+		telemetry.GitRequestsSettingsErrors(c.telemetryClient, responseStatusCode(response))
 		return nil, fmt.Errorf("sending get settings request: %s", err)
 	}
 	if response.StatusCode < 200 || response.StatusCode >= 300 {

--- a/internal/testoptimization/api/skippable.go
+++ b/internal/testoptimization/api/skippable.go
@@ -140,7 +140,11 @@ func (c *transport) GetSkippableTests() (correlationID string, skippables Skippa
 	if err != nil {
 		return "", NewSkippables(), fmt.Errorf("unmarshalling skippable tests response: %s", err)
 	}
-	telemetry.ITRSkippableTestsResponseTests(c.telemetryClient, len(responseObject.Data))
+	if c.getTestSkippingLevel() == settings.TestSkippingLevelSuite {
+		telemetry.ITRSkippableTestsResponseSuites(c.telemetryClient, len(responseObject.Data))
+	} else {
+		telemetry.ITRSkippableTestsResponseTests(c.telemetryClient, len(responseObject.Data))
+	}
 
 	skippables = NewSkippables()
 	warnedMissingTestBundle := false

--- a/internal/testoptimization/api/skippable.go
+++ b/internal/testoptimization/api/skippable.go
@@ -126,13 +126,13 @@ func (c *transport) GetSkippableTests() (correlationID string, skippables Skippa
 	telemetry.ITRSkippableTestsRequestMs(c.telemetryClient, time.Since(requestStartTime))
 
 	if err != nil {
-		telemetry.ITRSkippableTestsRequestErrors(c.telemetryClient, 0)
+		telemetry.ITRSkippableTestsRequestErrors(c.telemetryClient, responseStatusCode(response))
 		return "", NewSkippables(), fmt.Errorf("sending skippable tests request: %s", err)
 	}
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
 		telemetry.ITRSkippableTestsRequestErrors(c.telemetryClient, response.StatusCode)
 	}
-	telemetry.ITRSkippableTestsResponseBytes(c.telemetryClient, response.Compressed, len(response.Body))
+	telemetry.ITRSkippableTestsResponseBytes(c.telemetryClient, response.Compressed, response.BodySize)
 	c.skippableTestsRawResponse = cloneRawMessage(response.Body)
 
 	var responseObject skippableResponse

--- a/internal/testoptimization/api/skippable.go
+++ b/internal/testoptimization/api/skippable.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/DataDog/ddtest/internal/settings"
+	"github.com/DataDog/ddtest/internal/telemetry"
 )
 
 const (
@@ -119,11 +120,19 @@ func (c *transport) GetSkippableTests() (correlationID string, skippables Skippa
 	}
 
 	request := c.getPostRequestConfig(skippableURLPath, body)
+	telemetry.ITRSkippableTestsRequest(c.telemetryClient, request.Compressed)
+	requestStartTime := time.Now()
 	response, err := c.handler.SendRequest(*request)
+	telemetry.ITRSkippableTestsRequestMs(c.telemetryClient, time.Since(requestStartTime))
 
 	if err != nil {
+		telemetry.ITRSkippableTestsRequestErrors(c.telemetryClient, 0)
 		return "", NewSkippables(), fmt.Errorf("sending skippable tests request: %s", err)
 	}
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		telemetry.ITRSkippableTestsRequestErrors(c.telemetryClient, response.StatusCode)
+	}
+	telemetry.ITRSkippableTestsResponseBytes(c.telemetryClient, response.Compressed, len(response.Body))
 	c.skippableTestsRawResponse = cloneRawMessage(response.Body)
 
 	var responseObject skippableResponse
@@ -131,6 +140,7 @@ func (c *transport) GetSkippableTests() (correlationID string, skippables Skippa
 	if err != nil {
 		return "", NewSkippables(), fmt.Errorf("unmarshalling skippable tests response: %s", err)
 	}
+	telemetry.ITRSkippableTestsResponseTests(c.telemetryClient, len(responseObject.Data))
 
 	skippables = NewSkippables()
 	warnedMissingTestBundle := false

--- a/internal/testoptimization/api/telemetry_test.go
+++ b/internal/testoptimization/api/telemetry_test.go
@@ -96,7 +96,7 @@ func TestTransportRecordsBackendTelemetry(t *testing.T) {
 		`{"data":{"attributes":{"tests":{"module-a":{"suite-a":["test-a"]}},"page_info":{"cursor":"page-2","has_next":true}}}}`,
 		`{"data":{"attributes":{"tests":{"module-a":{"suite-a":["test-b"]},"module-b":{"suite-b":["test-c"]}},"page_info":{"has_next":false}}}}`,
 	}
-	skippableBody := `{"meta":{"correlation_id":"cid"},"data":[{"type":"test","attributes":{"suite":"suite-a","name":"test-a","configurations":{"test.bundle":"module-a"}}},{"type":"suite","attributes":{"suite":"suite-b","configurations":{"test.bundle":"module-b"}}}]}`
+	skippableBody := `{"meta":{"correlation_id":"cid"},"data":[{"type":"test","attributes":{"suite":"suite-a","name":"test-a","configurations":{"test.bundle":"module-a"}}},{"type":"test","attributes":{"suite":"suite-b","name":"test-b","configurations":{"test.bundle":"module-b"}}}]}`
 	testManagementBody := `{"data":{"attributes":{"modules":{"module-a":{"suites":{"suite-a":{"tests":{"test-a":{"properties":{}},"test-b":{"properties":{}}}}}}}}}}`
 	searchCommitsBody := `{"data":[{"id":"remote-commit","type":"commit"}]}`
 	knownRequests := 0
@@ -171,6 +171,7 @@ func TestTransportRecordsBackendTelemetry(t *testing.T) {
 	recorder.assertSamples(t, "distribution", "itr_skippable_tests.request_ms", nil, 1)
 	recorder.assertValue(t, "distribution", "itr_skippable_tests.response_bytes", nil, float64(len(skippableBody)))
 	recorder.assertValue(t, "count", "itr_skippable_tests.response_tests", nil, 2)
+	recorder.assertSamples(t, "count", "itr_skippable_tests.response_suites", nil, 0)
 	recorder.assertValue(t, "count", "test_management_tests.request", nil, 1)
 	recorder.assertSamples(t, "distribution", "test_management_tests.request_ms", nil, 1)
 	recorder.assertValue(t, "distribution", "test_management_tests.response_bytes", nil, float64(len(testManagementBody)))
@@ -181,6 +182,25 @@ func TestTransportRecordsBackendTelemetry(t *testing.T) {
 	recorder.assertSamples(t, "distribution", "git_requests.objects_pack_ms", nil, 2)
 	recorder.assertValue(t, "distribution", "git_requests.objects_pack_files", nil, 2)
 	recorder.assertValue(t, "distribution", "git_requests.objects_pack_bytes", nil, 3)
+}
+
+func TestTransportRecordsSuiteOnlySkippableResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set(HeaderContentType, constants.ContentTypeJSON)
+		_, _ = io.WriteString(w, `{"meta":{"correlation_id":"cid"},"data":[{"type":"suite","attributes":{"suite":"suite-a","configurations":{"test.bundle":"module-a"}}}]}`)
+	}))
+	defer server.Close()
+
+	recorder := &apiRecordingClient{}
+	client := newRawResponseTestClientWithTestSkippingLevel(server, settings.TestSkippingLevelSuite)
+	client.telemetryClient = recorder
+
+	if _, _, err := client.GetSkippableTests(); err != nil {
+		t.Fatalf("GetSkippableTests() error = %v", err)
+	}
+
+	recorder.assertValue(t, "count", "itr_skippable_tests.response_suites", nil, 1)
+	recorder.assertSamples(t, "count", "itr_skippable_tests.response_tests", nil, 0)
 }
 
 func TestTransportRecordsCompressedResponseWireBytes(t *testing.T) {

--- a/internal/testoptimization/api/telemetry_test.go
+++ b/internal/testoptimization/api/telemetry_test.go
@@ -183,6 +183,72 @@ func TestTransportRecordsBackendTelemetry(t *testing.T) {
 	recorder.assertValue(t, "distribution", "git_requests.objects_pack_bytes", nil, 3)
 }
 
+func TestTransportRecordsCompressedResponseWireBytes(t *testing.T) {
+	responseBodies := map[string]string{
+		knownTestsURLPath:          `{"data":{"attributes":{"tests":{"module-a":{"suite-a":["test-a"]}}}}}`,
+		skippableURLPath:           `{"meta":{"correlation_id":"cid"},"data":[{"type":"test","attributes":{"suite":"suite-a","name":"test-a","configurations":{"test.bundle":"module-a"}}}]}`,
+		testManagementTestsURLPath: `{"data":{"attributes":{"modules":{"module-a":{"suites":{"suite-a":{"tests":{"test-a":{"properties":{}}}}}}}}}}`,
+	}
+	compressedBodies := make(map[string][]byte, len(responseBodies))
+	for path, body := range responseBodies {
+		compressed, err := compressData([]byte(body))
+		if err != nil {
+			t.Fatalf("compress %s response: %v", path, err)
+		}
+		compressedBodies[path] = compressed
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/")
+		body, ok := compressedBodies[path]
+		if !ok {
+			t.Fatalf("unexpected request path %s", r.URL.Path)
+		}
+		w.Header().Set(HeaderContentType, constants.ContentTypeJSON)
+		w.Header().Set(HeaderContentEncoding, ContentEncodingGzip)
+		_, _ = w.Write(body)
+	}))
+	defer server.Close()
+
+	recorder := &apiRecordingClient{}
+	client := newRawResponseTestClient(server)
+	client.telemetryClient = recorder
+
+	if _, err := client.GetKnownTests(); err != nil {
+		t.Fatalf("GetKnownTests() error = %v", err)
+	}
+	if _, _, err := client.GetSkippableTests(); err != nil {
+		t.Fatalf("GetSkippableTests() error = %v", err)
+	}
+	if _, err := client.GetTestManagementTests(); err != nil {
+		t.Fatalf("GetTestManagementTests() error = %v", err)
+	}
+
+	tags := []string{"rs_compressed:true"}
+	recorder.assertValue(t, "distribution", "known_tests.response_bytes", tags, float64(len(compressedBodies[knownTestsURLPath])))
+	recorder.assertValue(t, "distribution", "itr_skippable_tests.response_bytes", tags, float64(len(compressedBodies[skippableURLPath])))
+	recorder.assertValue(t, "distribution", "test_management_tests.response_bytes", tags, float64(len(compressedBodies[testManagementTestsURLPath])))
+}
+
+func TestTransportRecordsTerminalRetryStatusAndFailedSearchCommitsLatency(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unavailable", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	recorder := &apiRecordingClient{}
+	client := newRawResponseTestClient(server)
+	client.telemetryClient = recorder
+
+	if _, err := client.GetCommits([]string{"local-commit"}); err == nil {
+		t.Fatal("GetCommits() should fail after exhausting retries")
+	}
+
+	recorder.assertValue(t, "count", "git_requests.search_commits_errors", []string{"error_type:status_code_5xx_response"}, 1)
+	recorder.assertSamples(t, "count", "git_requests.search_commits_errors", []string{"error_type:network"}, 0)
+	recorder.assertSamples(t, "distribution", "git_requests.search_commits_ms", nil, 1)
+}
+
 func TestTransportRecordsBackendStatusErrors(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "bad request", http.StatusBadRequest)

--- a/internal/testoptimization/api/telemetry_test.go
+++ b/internal/testoptimization/api/telemetry_test.go
@@ -1,0 +1,241 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package api
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/DataDog/ddtest/internal/constants"
+	"github.com/DataDog/ddtest/internal/environment"
+	"github.com/DataDog/ddtest/internal/settings"
+	"github.com/DataDog/ddtest/internal/telemetry"
+)
+
+type apiRecordedMetric struct {
+	kind  string
+	name  string
+	tags  []string
+	value float64
+}
+
+type apiRecordingClient struct {
+	mu      sync.Mutex
+	metrics []apiRecordedMetric
+}
+
+type apiRecordingMetric struct {
+	client *apiRecordingClient
+	kind   string
+	name   string
+	tags   []string
+}
+
+func (c *apiRecordingClient) Count(name string, tags []string) telemetry.Metric {
+	return &apiRecordingMetric{client: c, kind: "count", name: name, tags: slices.Clone(tags)}
+}
+
+func (c *apiRecordingClient) Distribution(name string, tags []string) telemetry.Metric {
+	return &apiRecordingMetric{client: c, kind: "distribution", name: name, tags: slices.Clone(tags)}
+}
+
+func (c *apiRecordingClient) Flush(context.Context) error { return nil }
+
+func (m *apiRecordingMetric) Submit(value float64) {
+	m.client.mu.Lock()
+	defer m.client.mu.Unlock()
+	m.client.metrics = append(m.client.metrics, apiRecordedMetric{
+		kind:  m.kind,
+		name:  m.name,
+		tags:  m.tags,
+		value: value,
+	})
+}
+
+func (c *apiRecordingClient) values(kind, name string, tags []string) []float64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var values []float64
+	for _, metric := range c.metrics {
+		if metric.kind == kind && metric.name == name && slices.Equal(metric.tags, tags) {
+			values = append(values, metric.value)
+		}
+	}
+	return values
+}
+
+func (c *apiRecordingClient) assertValue(t *testing.T, kind, name string, tags []string, want float64) {
+	t.Helper()
+	values := c.values(kind, name, tags)
+	if len(values) != 1 || values[0] != want {
+		t.Errorf("%s %s %v values = %v, want [%v]", kind, name, tags, values, want)
+	}
+}
+
+func (c *apiRecordingClient) assertSamples(t *testing.T, kind, name string, tags []string, want int) {
+	t.Helper()
+	if values := c.values(kind, name, tags); len(values) != want {
+		t.Errorf("%s %s %v sample count = %d, want %d; values=%v", kind, name, tags, len(values), want, values)
+	}
+}
+
+func TestTransportRecordsBackendTelemetry(t *testing.T) {
+	settingsBody := `{"data":{"attributes":{"code_coverage":true,"early_flake_detection":{"enabled":true},"flaky_test_retries_enabled":true,"tests_skipping":true,"test_management":{"enabled":true}}}}`
+	knownBodies := []string{
+		`{"data":{"attributes":{"tests":{"module-a":{"suite-a":["test-a"]}},"page_info":{"cursor":"page-2","has_next":true}}}}`,
+		`{"data":{"attributes":{"tests":{"module-a":{"suite-a":["test-b"]},"module-b":{"suite-b":["test-c"]}},"page_info":{"has_next":false}}}}`,
+	}
+	skippableBody := `{"meta":{"correlation_id":"cid"},"data":[{"type":"test","attributes":{"suite":"suite-a","name":"test-a","configurations":{"test.bundle":"module-a"}}},{"type":"suite","attributes":{"suite":"suite-b","configurations":{"test.bundle":"module-b"}}}]}`
+	testManagementBody := `{"data":{"attributes":{"modules":{"module-a":{"suites":{"suite-a":{"tests":{"test-a":{"properties":{}},"test-b":{"properties":{}}}}}}}}}}`
+	searchCommitsBody := `{"data":[{"id":"remote-commit","type":"commit"}]}`
+	knownRequests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(HeaderContentType, constants.ContentTypeJSON)
+		var body string
+		switch strings.TrimPrefix(r.URL.Path, "/") {
+		case settingsURLPath:
+			body = settingsBody
+		case knownTestsURLPath:
+			body = knownBodies[knownRequests]
+			knownRequests++
+		case skippableURLPath:
+			body = skippableBody
+		case testManagementTestsURLPath:
+			body = testManagementBody
+		case searchCommitsURLPath:
+			body = searchCommitsBody
+		case sendPackFilesURLPath:
+			body = `{}`
+		default:
+			t.Fatalf("unexpected request path %s", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, body)
+	}))
+	defer server.Close()
+
+	recorder := &apiRecordingClient{}
+	client := newRawResponseTestClient(server)
+	client.telemetryClient = recorder
+
+	if _, err := client.GetSettings(); err != nil {
+		t.Fatalf("GetSettings() error = %v", err)
+	}
+	if _, err := client.GetKnownTests(); err != nil {
+		t.Fatalf("GetKnownTests() error = %v", err)
+	}
+	if _, _, err := client.GetSkippableTests(); err != nil {
+		t.Fatalf("GetSkippableTests() error = %v", err)
+	}
+	if _, err := client.GetTestManagementTests(); err != nil {
+		t.Fatalf("GetTestManagementTests() error = %v", err)
+	}
+	if _, err := client.GetCommits([]string{"local-commit"}); err != nil {
+		t.Fatalf("GetCommits() error = %v", err)
+	}
+	packDir := t.TempDir()
+	packFiles := []string{filepath.Join(packDir, "one.pack"), filepath.Join(packDir, "two.pack")}
+	for i, file := range packFiles {
+		if err := os.WriteFile(file, []byte(strings.Repeat("x", i+1)), 0o600); err != nil {
+			t.Fatalf("write packfile: %v", err)
+		}
+	}
+	if _, err := client.SendPackFiles("", packFiles); err != nil {
+		t.Fatalf("SendPackFiles() error = %v", err)
+	}
+
+	recorder.assertValue(t, "count", "git_requests.settings", nil, 1)
+	recorder.assertValue(t, "count", "git_requests.settings_response", []string{
+		"coverage_enabled",
+		"itrskip_enabled",
+		"early_flake_detection_enabled:true",
+		"flaky_test_retries_enabled:true",
+		"test_management_enabled:true",
+	}, 1)
+	recorder.assertSamples(t, "distribution", "git_requests.settings_ms", nil, 1)
+	recorder.assertSamples(t, "count", "known_tests.request", nil, 2)
+	recorder.assertSamples(t, "distribution", "known_tests.request_ms", nil, 2)
+	recorder.assertSamples(t, "distribution", "known_tests.response_bytes", nil, 2)
+	recorder.assertValue(t, "distribution", "known_tests.response_tests", nil, 3)
+	recorder.assertValue(t, "count", "itr_skippable_tests.request", nil, 1)
+	recorder.assertSamples(t, "distribution", "itr_skippable_tests.request_ms", nil, 1)
+	recorder.assertValue(t, "distribution", "itr_skippable_tests.response_bytes", nil, float64(len(skippableBody)))
+	recorder.assertValue(t, "count", "itr_skippable_tests.response_tests", nil, 2)
+	recorder.assertValue(t, "count", "test_management_tests.request", nil, 1)
+	recorder.assertSamples(t, "distribution", "test_management_tests.request_ms", nil, 1)
+	recorder.assertValue(t, "distribution", "test_management_tests.response_bytes", nil, float64(len(testManagementBody)))
+	recorder.assertValue(t, "distribution", "test_management_tests.response_tests", nil, 2)
+	recorder.assertValue(t, "count", "git_requests.search_commits", nil, 1)
+	recorder.assertSamples(t, "distribution", "git_requests.search_commits_ms", nil, 1)
+	recorder.assertSamples(t, "count", "git_requests.objects_pack", nil, 2)
+	recorder.assertSamples(t, "distribution", "git_requests.objects_pack_ms", nil, 2)
+	recorder.assertValue(t, "distribution", "git_requests.objects_pack_files", nil, 2)
+	recorder.assertValue(t, "distribution", "git_requests.objects_pack_bytes", nil, 3)
+}
+
+func TestTransportRecordsBackendStatusErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "bad request", http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	recorder := &apiRecordingClient{}
+	client := newRawResponseTestClient(server)
+	client.telemetryClient = recorder
+	_, _ = client.GetSettings()
+	_, _ = client.GetKnownTests()
+	_, _, _ = client.GetSkippableTests()
+	_, _ = client.GetTestManagementTests()
+	_, _ = client.GetCommits([]string{"local-commit"})
+	packFile := filepath.Join(t.TempDir(), "objects.pack")
+	if err := os.WriteFile(packFile, []byte("pack"), 0o600); err != nil {
+		t.Fatalf("write packfile: %v", err)
+	}
+	_, _ = client.SendPackFiles("", []string{packFile})
+
+	tags := []string{"error_type:status_code_4xx_response", "status_code:400"}
+	for _, name := range []string{
+		"git_requests.settings_errors",
+		"known_tests.request_errors",
+		"itr_skippable_tests.request_errors",
+		"test_management_tests.request_errors",
+		"git_requests.search_commits_errors",
+		"git_requests.objects_pack_errors",
+	} {
+		recorder.assertValue(t, "count", name, tags, 1)
+	}
+}
+
+func TestNewTransportWithTelemetryRetainsClient(t *testing.T) {
+	environment.ResetCITags()
+	t.Cleanup(environment.ResetCITags)
+	environment.AddCITagsMap(map[string]string{
+		constants.GitRepositoryURL: "https://github.com/DataDog/ddtest.git",
+		constants.GitCommitSHA:     "sha",
+	})
+	t.Setenv(constants.TestOptimizationAgentlessEnabledEnvironmentVariable, "true")
+	t.Setenv(constants.TestOptimizationAgentlessURLEnvironmentVariable, "https://example.test")
+	t.Setenv(constants.APIKeyEnvironmentVariable, "api-key")
+
+	recorder := &apiRecordingClient{}
+	created, ok := NewTransportWithTelemetry("service", settings.TestSkippingLevelSuite, recorder).(*transport)
+	if !ok {
+		t.Fatal("NewTransportWithTelemetry() did not return *transport")
+	}
+	if created.telemetryClient != recorder {
+		t.Fatal("NewTransportWithTelemetry() did not retain telemetry client")
+	}
+	if created.testSkippingLevel != settings.TestSkippingLevelSuite {
+		t.Fatalf("test skipping level = %q, want suite", created.testSkippingLevel)
+	}
+}

--- a/internal/testoptimization/api/test_management_tests_api.go
+++ b/internal/testoptimization/api/test_management_tests_api.go
@@ -8,6 +8,8 @@ package api
 import (
 	"fmt"
 	"time"
+
+	"github.com/DataDog/ddtest/internal/telemetry"
 )
 
 const (
@@ -102,11 +104,19 @@ func (c *transport) GetTestManagementTests() (*TestManagementTestsResponseDataMo
 	}
 
 	request := c.getPostRequestConfig(testManagementTestsURLPath, body)
+	telemetry.TestManagementTestsRequest(c.telemetryClient, request.Compressed)
+	requestStartTime := time.Now()
 	response, err := c.handler.SendRequest(*request)
+	telemetry.TestManagementTestsRequestMs(c.telemetryClient, time.Since(requestStartTime))
 
 	if err != nil {
+		telemetry.TestManagementTestsRequestErrors(c.telemetryClient, 0)
 		return nil, fmt.Errorf("sending test management tests request: %s", err)
 	}
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		telemetry.TestManagementTestsRequestErrors(c.telemetryClient, response.StatusCode)
+	}
+	telemetry.TestManagementTestsResponseBytes(c.telemetryClient, response.Compressed, len(response.Body))
 	c.testManagementTestsRawResponse = cloneRawMessage(response.Body)
 
 	var responseObject testManagementTestsResponse
@@ -114,6 +124,21 @@ func (c *transport) GetTestManagementTests() (*TestManagementTestsResponseDataMo
 	if err != nil {
 		return nil, fmt.Errorf("unmarshalling test management tests response: %s", err)
 	}
+	responseData := &responseObject.Data.Attributes
+	telemetry.TestManagementTestsResponseTests(c.telemetryClient, testManagementResponseTestCount(responseData))
 
-	return &responseObject.Data.Attributes, nil
+	return responseData, nil
+}
+
+func testManagementResponseTestCount(response *TestManagementTestsResponseDataModules) int {
+	if response == nil {
+		return 0
+	}
+	testCount := 0
+	for _, module := range response.Modules {
+		for _, suite := range module.Suites {
+			testCount += len(suite.Tests)
+		}
+	}
+	return testCount
 }

--- a/internal/testoptimization/api/test_management_tests_api.go
+++ b/internal/testoptimization/api/test_management_tests_api.go
@@ -110,13 +110,13 @@ func (c *transport) GetTestManagementTests() (*TestManagementTestsResponseDataMo
 	telemetry.TestManagementTestsRequestMs(c.telemetryClient, time.Since(requestStartTime))
 
 	if err != nil {
-		telemetry.TestManagementTestsRequestErrors(c.telemetryClient, 0)
+		telemetry.TestManagementTestsRequestErrors(c.telemetryClient, responseStatusCode(response))
 		return nil, fmt.Errorf("sending test management tests request: %s", err)
 	}
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
 		telemetry.TestManagementTestsRequestErrors(c.telemetryClient, response.StatusCode)
 	}
-	telemetry.TestManagementTestsResponseBytes(c.telemetryClient, response.Compressed, len(response.Body))
+	telemetry.TestManagementTestsResponseBytes(c.telemetryClient, response.Compressed, response.BodySize)
 	c.testManagementTestsRawResponse = cloneRawMessage(response.Body)
 
 	var responseObject testManagementTestsResponse

--- a/internal/testoptimization/api/transport.go
+++ b/internal/testoptimization/api/transport.go
@@ -6,30 +6,24 @@
 package api
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
 	"math"
 	"math/rand/v2"
-	"net"
-	"net/http"
-	"net/url"
 	"os"
 	"strings"
 	"time"
 
 	"github.com/DataDog/ddtest/internal/constants"
 	"github.com/DataDog/ddtest/internal/environment"
+	"github.com/DataDog/ddtest/internal/httptransport"
 	"github.com/DataDog/ddtest/internal/runmetadata"
 	"github.com/DataDog/ddtest/internal/settings"
-	"github.com/DataDog/ddtest/internal/utils"
 )
 
 const (
-	defaultAgentHostname  = "localhost"
-	defaultTraceAgentPort = "8126"
-	ddTagsDelimiter       = ":"
+	ddTagsDelimiter = ":"
 )
 
 type (
@@ -100,8 +94,6 @@ var (
 	_ Transport = &transport{}
 )
 
-var defaultTraceAgentUDSPath = "/var/run/datadog/apm.socket"
-
 // NewTransportWithServiceNameAndSubdomain creates a new transport with the given service name and subdomain.
 func NewTransportWithServiceNameAndSubdomain(serviceName, subdomain string) Transport {
 	return newTransportWithServiceNameAndSubdomain(serviceName, subdomain, settings.TestSkippingLevelTest)
@@ -144,31 +136,26 @@ func newTransportWithServiceNameAndSubdomain(serviceName, subdomain string, test
 	defaultHeaders := map[string]string{}
 	var baseURL string
 	var requestHandler *RequestHandler
-	var agentURL *url.URL
 	var apiKeyValue string
 
-	agentlessEnabled := utils.BoolEnv(constants.TestOptimizationAgentlessEnabledEnvironmentVariable, false)
+	connection, err := httptransport.ResolveDatadogConnection()
+	if err != nil {
+		slog.Error("Failed to resolve Datadog connection", "error", err)
+		return nil
+	}
+	agentlessEnabled := connection.Agentless
 	if agentlessEnabled {
 		// Agentless mode is enabled.
-		apiKeyValue = os.Getenv(constants.APIKeyEnvironmentVariable)
-		if apiKeyValue == "" {
-			slog.Error("An API key is required for agentless mode. Use the DD_API_KEY env variable to set it")
-			return nil
-		}
+		apiKeyValue = connection.APIKey
 
 		defaultHeaders["dd-api-key"] = apiKeyValue
 
 		// Check for a custom agentless URL.
-		agentlessURL := os.Getenv(constants.TestOptimizationAgentlessURLEnvironmentVariable)
+		agentlessURL := connection.AgentlessURL
 
 		if agentlessURL == "" {
 			// Use the standard agentless URL format.
-			site := "datadoghq.com"
-			if v := os.Getenv("DD_SITE"); v != "" {
-				site = v
-			}
-
-			baseURL = fmt.Sprintf("https://%s.%s", subdomain, site)
+			baseURL = fmt.Sprintf("https://%s.%s", subdomain, connection.Site)
 		} else {
 			// Use the custom agentless URL.
 			baseURL = agentlessURL
@@ -179,41 +166,17 @@ func newTransportWithServiceNameAndSubdomain(serviceName, subdomain string, test
 		// Use agent mode with the EVP proxy.
 		defaultHeaders["X-Datadog-EVP-Subdomain"] = subdomain
 
-		agentURL = traceAgentURLFromEnv()
+		agentURL := connection.AgentURL
 		if agentURL.Scheme == "unix" {
 			// If we're connecting over UDS we can just rely on the agent to provide the hostname
 			slog.Debug("connecting to agent over unix, do not set hostname on any traces")
-			dialer := &net.Dialer{
-				Timeout:   30 * time.Second,
-				KeepAlive: 30 * time.Second,
-				DualStack: true,
-			}
-			requestHandler = NewRequestHandlerWithClient(&http.Client{
-				Transport: &http.Transport{
-					Proxy: http.ProxyFromEnvironment,
-					DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
-						return dialer.DialContext(ctx, "unix", (&net.UnixAddr{
-							Name: agentURL.Path,
-							Net:  "unix",
-						}).String())
-					},
-					MaxIdleConns:          100,
-					IdleConnTimeout:       90 * time.Second,
-					TLSHandshakeTimeout:   10 * time.Second,
-					ExpectContinueTimeout: 1 * time.Second,
-				},
-				Timeout: 10 * time.Second,
-			})
-			// TODO(darccio): use internal.UnixDataSocketURL instead
-			agentURL = &url.URL{
-				Scheme: "http",
-				Host:   fmt.Sprintf("UDS_%s", strings.NewReplacer(":", "_", "/", "_", `\`, "_").Replace(agentURL.Path)),
-			}
+			agentURL, client := httptransport.AgentHTTPTransport(agentURL, 10*time.Second)
+			requestHandler = NewRequestHandlerWithClient(client)
+			baseURL = agentURL.String()
 		} else {
 			requestHandler = NewRequestHandler()
+			baseURL = agentURL.String()
 		}
-
-		baseURL = agentURL.String()
 	}
 
 	// create random id (the backend associate all transactions with the client request)
@@ -265,50 +228,6 @@ func newTransportWithServiceNameAndSubdomain(serviceName, subdomain string, test
 // NewTransportWithServiceName creates a new transport with the given service name.
 func NewTransportWithServiceName(serviceName string) Transport {
 	return NewTransportWithServiceNameAndSubdomain(serviceName, "api")
-}
-
-// traceAgentURLFromEnv resolves the URL for the trace agent based on
-// the default host/port and UDS path, and via standard environment variables.
-func traceAgentURLFromEnv() *url.URL {
-	if agentURL := os.Getenv("DD_TRACE_AGENT_URL"); agentURL != "" {
-		u, err := url.Parse(agentURL)
-		if err != nil {
-			slog.Warn("Failed to parse DD_TRACE_AGENT_URL", "error", err.Error())
-		} else {
-			switch u.Scheme {
-			case "unix", "http", "https":
-				return u
-			default:
-				slog.Warn("Unsupported protocol in Agent URL. Must be one of: http, https, unix.", "scheme", u.Scheme, "url", agentURL)
-			}
-		}
-	}
-
-	host, providedHost := os.LookupEnv("DD_AGENT_HOST")
-	port, providedPort := os.LookupEnv("DD_TRACE_AGENT_PORT")
-	if host == "" {
-		providedHost = false
-		host = defaultAgentHostname
-	}
-	if port == "" {
-		providedPort = false
-		port = defaultTraceAgentPort
-	}
-	httpURL := &url.URL{
-		Scheme: "http",
-		Host:   net.JoinHostPort(host, port),
-	}
-	if providedHost || providedPort {
-		return httpURL
-	}
-
-	if _, err := os.Stat(defaultTraceAgentUDSPath); err == nil {
-		return &url.URL{
-			Scheme: "unix",
-			Path:   defaultTraceAgentUDSPath,
-		}
-	}
-	return httpURL
 }
 
 func parseTagString(str string) map[string]string {

--- a/internal/testoptimization/api/transport.go
+++ b/internal/testoptimization/api/transport.go
@@ -20,6 +20,7 @@ import (
 	"github.com/DataDog/ddtest/internal/httptransport"
 	"github.com/DataDog/ddtest/internal/runmetadata"
 	"github.com/DataDog/ddtest/internal/settings"
+	"github.com/DataDog/ddtest/internal/telemetry"
 )
 
 const (
@@ -69,6 +70,7 @@ type (
 		testSkippingLevel  settings.TestSkippingLevel
 		headers            map[string]string
 		handler            *RequestHandler
+		telemetryClient    telemetry.Client
 
 		settingsRawResponse            json.RawMessage
 		knownTestsRawResponse          json.RawMessage
@@ -96,14 +98,20 @@ var (
 
 // NewTransportWithServiceNameAndSubdomain creates a new transport with the given service name and subdomain.
 func NewTransportWithServiceNameAndSubdomain(serviceName, subdomain string) Transport {
-	return newTransportWithServiceNameAndSubdomain(serviceName, subdomain, settings.TestSkippingLevelTest)
+	return newTransportWithServiceNameAndSubdomain(serviceName, subdomain, settings.TestSkippingLevelTest, telemetry.NoopClient())
 }
 
 func NewTransportWithServiceNameAndTestSkippingLevel(serviceName string, testSkippingLevel settings.TestSkippingLevel) Transport {
-	return newTransportWithServiceNameAndSubdomain(serviceName, "api", testSkippingLevel)
+	return NewTransportWithTelemetry(serviceName, testSkippingLevel, telemetry.NoopClient())
 }
 
-func newTransportWithServiceNameAndSubdomain(serviceName, subdomain string, testSkippingLevel settings.TestSkippingLevel) Transport {
+// NewTransportWithTelemetry creates a transport that reports CI Visibility
+// backend request metrics through telemetryClient.
+func NewTransportWithTelemetry(serviceName string, testSkippingLevel settings.TestSkippingLevel, telemetryClient telemetry.Client) Transport {
+	return newTransportWithServiceNameAndSubdomain(serviceName, "api", testSkippingLevel, telemetryClient)
+}
+
+func newTransportWithServiceNameAndSubdomain(serviceName, subdomain string, testSkippingLevel settings.TestSkippingLevel, telemetryClient telemetry.Client) Transport {
 	ciTags := environment.GetCITags()
 
 	// get the environment
@@ -220,8 +228,9 @@ func newTransportWithServiceNameAndSubdomain(serviceName, subdomain string, test
 			RuntimeVersion: ciTags[constants.RuntimeVersion],
 			Custom:         customConfiguration,
 		},
-		headers: defaultHeaders,
-		handler: requestHandler,
+		headers:         defaultHeaders,
+		handler:         requestHandler,
+		telemetryClient: telemetryClient,
 	}
 }
 

--- a/internal/testoptimization/api/transport_test.go
+++ b/internal/testoptimization/api/transport_test.go
@@ -10,8 +10,6 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -385,63 +383,6 @@ func TestTransportConstructorAgentlessAndURLBranches(t *testing.T) {
 	if custom.baseURL != "https://custom.example" || custom.serviceName != "explicit-service" {
 		t.Fatalf("unexpected custom agentless transport: baseURL=%q service=%q", custom.baseURL, custom.serviceName)
 	}
-}
-
-func TestTraceAgentURLFromEnv(t *testing.T) {
-	originalUDSPath := defaultTraceAgentUDSPath
-	t.Cleanup(func() {
-		defaultTraceAgentUDSPath = originalUDSPath
-	})
-
-	clearTraceAgentEnv := func(t *testing.T) {
-		t.Helper()
-		t.Setenv("DD_TRACE_AGENT_URL", "")
-		t.Setenv("DD_AGENT_HOST", "")
-		t.Setenv("DD_TRACE_AGENT_PORT", "")
-	}
-
-	t.Run("defaults to localhost http url", func(t *testing.T) {
-		clearTraceAgentEnv(t)
-		defaultTraceAgentUDSPath = filepath.Join(t.TempDir(), "missing.sock")
-
-		if got := traceAgentURLFromEnv().String(); got != "http://localhost:8126" {
-			t.Fatalf("traceAgentURLFromEnv() = %q, want %q", got, "http://localhost:8126")
-		}
-	})
-
-	t.Run("uses explicit trace agent url", func(t *testing.T) {
-		clearTraceAgentEnv(t)
-		t.Setenv("DD_TRACE_AGENT_URL", "https://agent.example:8127")
-		defaultTraceAgentUDSPath = filepath.Join(t.TempDir(), "missing.sock")
-
-		if got := traceAgentURLFromEnv().String(); got != "https://agent.example:8127" {
-			t.Fatalf("traceAgentURLFromEnv() = %q, want %q", got, "https://agent.example:8127")
-		}
-	})
-
-	t.Run("uses host and port env", func(t *testing.T) {
-		clearTraceAgentEnv(t)
-		t.Setenv("DD_AGENT_HOST", "agent.internal")
-		t.Setenv("DD_TRACE_AGENT_PORT", "9126")
-		defaultTraceAgentUDSPath = filepath.Join(t.TempDir(), "missing.sock")
-
-		if got := traceAgentURLFromEnv().String(); got != "http://agent.internal:9126" {
-			t.Fatalf("traceAgentURLFromEnv() = %q, want %q", got, "http://agent.internal:9126")
-		}
-	})
-
-	t.Run("uses UDS when no env is set", func(t *testing.T) {
-		clearTraceAgentEnv(t)
-		defaultTraceAgentUDSPath = filepath.Join(t.TempDir(), "apm.socket")
-		if err := os.WriteFile(defaultTraceAgentUDSPath, nil, 0o600); err != nil {
-			t.Fatalf("write UDS placeholder: %v", err)
-		}
-
-		got := traceAgentURLFromEnv()
-		if got.Scheme != "unix" || got.Path != defaultTraceAgentUDSPath {
-			t.Fatalf("traceAgentURLFromEnv() = %#v, want unix path %q", got, defaultTraceAgentUDSPath)
-		}
-	})
 }
 
 func TestParseTagString(t *testing.T) {

--- a/internal/testoptimization/api/transport_test.go
+++ b/internal/testoptimization/api/transport_test.go
@@ -47,6 +47,12 @@ func TestResponseUnmarshalBranches(t *testing.T) {
 	if err := (&Response{CanUnmarshal: true, Format: FormatMessagePack}).Unmarshal(&failingMsgpUnmarshaler{}); err == nil {
 		t.Fatal("expected msgpack unmarshal error")
 	}
+	if got := responseStatusCode(nil); got != 0 {
+		t.Fatalf("nil response status code = %d, want 0", got)
+	}
+	if got := responseStatusCode(&Response{StatusCode: http.StatusTeapot}); got != http.StatusTeapot {
+		t.Fatalf("response status code = %d, want %d", got, http.StatusTeapot)
+	}
 }
 
 func TestRequestHandlerValidationAndRetryBranches(t *testing.T) {
@@ -84,6 +90,11 @@ func TestRequestHandlerValidationAndRetryBranches(t *testing.T) {
 }
 
 func TestRequestHandlerJSONCompressionAndGzipResponse(t *testing.T) {
+	var encodedResponse bytes.Buffer
+	gzipWriter := gzip.NewWriter(&encodedResponse)
+	_, _ = gzipWriter.Write([]byte(`{"ok":"yes"}`))
+	_ = gzipWriter.Close()
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("X-Test"); got != "custom" {
 			t.Fatalf("expected custom header, got %q", got)
@@ -115,14 +126,9 @@ func TestRequestHandlerJSONCompressionAndGzipResponse(t *testing.T) {
 			t.Fatalf("unexpected request body: %#v", request)
 		}
 
-		var response bytes.Buffer
-		gzipWriter := gzip.NewWriter(&response)
-		_, _ = gzipWriter.Write([]byte(`{"ok":"yes"}`))
-		_ = gzipWriter.Close()
-
 		w.Header().Set(HeaderContentType, ContentTypeJSONAlternative)
 		w.Header().Set(HeaderContentEncoding, ContentEncodingGzip)
-		_, _ = w.Write(response.Bytes())
+		_, _ = w.Write(encodedResponse.Bytes())
 	}))
 	defer server.Close()
 
@@ -139,6 +145,9 @@ func TestRequestHandlerJSONCompressionAndGzipResponse(t *testing.T) {
 	}
 	if !response.Compressed || response.Format != constants.FormatJSON {
 		t.Fatalf("unexpected response metadata: %#v", response)
+	}
+	if response.BodySize != encodedResponse.Len() {
+		t.Fatalf("response body size = %d, want compressed size %d", response.BodySize, encodedResponse.Len())
 	}
 	var decoded map[string]string
 	if err := response.Unmarshal(&decoded); err != nil {
@@ -217,8 +226,8 @@ func TestRequestHandlerStatusRetryAndRateLimitBranches(t *testing.T) {
 			MaxRetries: 1,
 			Backoff:    time.Nanosecond,
 		})
-		if err == nil || response != nil {
-			t.Fatalf("expected retry exhaustion, got response=%v err=%v", response, err)
+		if err == nil || response == nil || response.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("expected retry exhaustion with status %d, got response=%v err=%v", http.StatusInternalServerError, response, err)
 		}
 		if attempts != 2 {
 			t.Fatalf("expected 2 attempts, got %d", attempts)
@@ -240,8 +249,8 @@ func TestRequestHandlerStatusRetryAndRateLimitBranches(t *testing.T) {
 			MaxRetries: 1,
 			Backoff:    time.Nanosecond,
 		})
-		if err == nil || response != nil {
-			t.Fatalf("expected rate-limit retry exhaustion, got response=%v err=%v", response, err)
+		if err == nil || response == nil || response.StatusCode != HTTPStatusTooManyRequests {
+			t.Fatalf("expected rate-limit retry exhaustion with status %d, got response=%v err=%v", HTTPStatusTooManyRequests, response, err)
 		}
 		if attempts != 2 {
 			t.Fatalf("expected 2 attempts, got %d", attempts)
@@ -260,8 +269,8 @@ func TestRequestHandlerStatusRetryAndRateLimitBranches(t *testing.T) {
 			MaxRetries: 0,
 			Backoff:    time.Nanosecond,
 		})
-		if err == nil || response != nil {
-			t.Fatalf("expected rate-limit fallback exhaustion, got response=%v err=%v", response, err)
+		if err == nil || response == nil || response.StatusCode != HTTPStatusTooManyRequests {
+			t.Fatalf("expected rate-limit fallback exhaustion with status %d, got response=%v err=%v", HTTPStatusTooManyRequests, response, err)
 		}
 	})
 }

--- a/internal/testoptimization/telemetry_test.go
+++ b/internal/testoptimization/telemetry_test.go
@@ -17,11 +17,13 @@ import (
 	"github.com/DataDog/ddtest/internal/git/gittest"
 	"github.com/DataDog/ddtest/internal/settings"
 	"github.com/DataDog/ddtest/internal/telemetry"
+	"github.com/DataDog/ddtest/internal/testoptimization/api"
 )
 
 type optimizationTelemetryClient struct {
 	mu      sync.Mutex
 	metrics map[string]float64
+	flushes int
 }
 
 type optimizationTelemetryMetric struct {
@@ -37,7 +39,12 @@ func (c *optimizationTelemetryClient) Distribution(name string, _ []string) tele
 	return &optimizationTelemetryMetric{client: c, name: name}
 }
 
-func (c *optimizationTelemetryClient) Flush(context.Context) error { return nil }
+func (c *optimizationTelemetryClient) Flush(context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.flushes++
+	return nil
+}
 
 func (m *optimizationTelemetryMetric) Submit(value float64) {
 	m.client.mu.Lock()
@@ -49,6 +56,12 @@ func (c *optimizationTelemetryClient) value(name string) float64 {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.metrics[name]
+}
+
+func (c *optimizationTelemetryClient) flushCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.flushes
 }
 
 func TestNewTestOptimizationClientWithTelemetryWiresBackendTransport(t *testing.T) {
@@ -101,5 +114,20 @@ func TestNewTestOptimizationClientWithTelemetryWiresBackendTransport(t *testing.
 	}
 	if _, ok := recorder.metrics["git.command_ms"]; !ok {
 		t.Error("Git command duration was not recorded")
+	}
+}
+
+func TestTestOptimizationClientHandleSignalFlushesTelemetry(t *testing.T) {
+	recorder := &optimizationTelemetryClient{metrics: make(map[string]float64)}
+	client := newTestOptimizationClient(nil, nil, nil, false)
+	client.telemetryClient = recorder
+	client.settingsOnce.Do(func() {
+		client.settings = &api.SettingsResponseData{}
+	})
+
+	client.handleSignal()
+
+	if got := recorder.flushCount(); got != 1 {
+		t.Fatalf("telemetry flush count = %d, want 1", got)
 	}
 }

--- a/internal/testoptimization/telemetry_test.go
+++ b/internal/testoptimization/telemetry_test.go
@@ -1,0 +1,105 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package testoptimization
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/DataDog/ddtest/internal/constants"
+	"github.com/DataDog/ddtest/internal/environment"
+	"github.com/DataDog/ddtest/internal/git/gittest"
+	"github.com/DataDog/ddtest/internal/settings"
+	"github.com/DataDog/ddtest/internal/telemetry"
+)
+
+type optimizationTelemetryClient struct {
+	mu      sync.Mutex
+	metrics map[string]float64
+}
+
+type optimizationTelemetryMetric struct {
+	client *optimizationTelemetryClient
+	name   string
+}
+
+func (c *optimizationTelemetryClient) Count(name string, _ []string) telemetry.Metric {
+	return &optimizationTelemetryMetric{client: c, name: name}
+}
+
+func (c *optimizationTelemetryClient) Distribution(name string, _ []string) telemetry.Metric {
+	return &optimizationTelemetryMetric{client: c, name: name}
+}
+
+func (c *optimizationTelemetryClient) Flush(context.Context) error { return nil }
+
+func (m *optimizationTelemetryMetric) Submit(value float64) {
+	m.client.mu.Lock()
+	defer m.client.mu.Unlock()
+	m.client.metrics[m.name] += value
+}
+
+func (c *optimizationTelemetryClient) value(name string) float64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.metrics[name]
+}
+
+func TestNewTestOptimizationClientWithTelemetryWiresBackendTransport(t *testing.T) {
+	repo := gittest.NewRepository(t)
+	t.Chdir(repo.Path)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/libraries/tests/services/setting" {
+			t.Fatalf("request path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", constants.ContentTypeJSON)
+		_, _ = w.Write([]byte(`{"data":{"attributes":{"tests_skipping":true}}}`))
+	}))
+	defer server.Close()
+
+	environment.ResetCITags()
+	t.Cleanup(environment.ResetCITags)
+	environment.AddCITagsMap(map[string]string{
+		constants.GitRepositoryURL: "https://github.com/DataDog/ddtest.git",
+		constants.GitCommitSHA:     "sha",
+		constants.GitBranch:        "main",
+	})
+	t.Setenv(constants.TestOptimizationAgentlessEnabledEnvironmentVariable, "true")
+	t.Setenv(constants.TestOptimizationAgentlessURLEnvironmentVariable, server.URL)
+	t.Setenv(constants.APIKeyEnvironmentVariable, "api-key")
+
+	recorder := &optimizationTelemetryClient{metrics: make(map[string]float64)}
+	client := NewTestOptimizationClientWithTelemetry(settings.TestSkippingLevelSuite, recorder)
+	transport := client.newAPITransport("service", settings.TestSkippingLevelSuite)
+	if transport == nil {
+		t.Fatal("telemetry constructor returned a nil backend transport")
+	}
+	if _, err := transport.GetSettings(); err != nil {
+		t.Fatalf("GetSettings() error = %v", err)
+	}
+
+	if got := recorder.value("git_requests.settings"); got != 1 {
+		t.Errorf("settings request count = %v, want 1", got)
+	}
+	if got := recorder.value("git_requests.settings_response"); got != 1 {
+		t.Errorf("settings response count = %v, want 1", got)
+	}
+	if _, ok := recorder.metrics["git_requests.settings_ms"]; !ok {
+		t.Error("settings request duration was not recorded")
+	}
+	if commits := client.gitCommands.GetLastLocalGitCommitShas(); len(commits) == 0 {
+		t.Fatal("telemetry-aware Git runner returned no commits")
+	}
+	if got := recorder.value("git.command"); got != 1 {
+		t.Errorf("Git command count = %v, want 1", got)
+	}
+	if _, ok := recorder.metrics["git.command_ms"]; !ok {
+		t.Error("Git command duration was not recorded")
+	}
+}

--- a/internal/testoptimization/testoptimization.go
+++ b/internal/testoptimization/testoptimization.go
@@ -1,6 +1,7 @@
 package testoptimization
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -39,6 +40,7 @@ type TestOptimizationClient struct {
 	gitCommands               *git.CommandRunner
 	repositoryChangesUploader func() (int64, error)
 	enableSignalHandler       bool
+	telemetryClient           telemetry.Client
 
 	initializationOnce   sync.Once
 	settingsOnce         sync.Once
@@ -64,11 +66,15 @@ func NewTestOptimizationClientWithTestSkippingLevel(testSkippingLevel settings.T
 // NewTestOptimizationClientWithTelemetry creates a Test Optimization client
 // whose backend transport reports internal metrics through telemetryClient.
 func NewTestOptimizationClientWithTelemetry(testSkippingLevel settings.TestSkippingLevel, telemetryClient telemetry.Client) *TestOptimizationClient {
+	if telemetryClient == nil {
+		telemetryClient = telemetry.NoopClient()
+	}
 	newAPITransport := func(serviceName string, level settings.TestSkippingLevel) api.Transport {
 		return api.NewTransportWithTelemetry(serviceName, level, telemetryClient)
 	}
 	client := newTestOptimizationClientWithTestSkippingLevel(nil, newAPITransport, nil, true, testSkippingLevel)
 	client.gitCommands = git.NewCommandRunner(telemetry.NewGitCommandTelemetry(telemetryClient))
+	client.telemetryClient = telemetryClient
 	return client
 }
 
@@ -109,6 +115,7 @@ func newTestOptimizationClientWithTestSkippingLevel(
 		gitCommands:               git.NewCommandRunner(nil),
 		repositoryChangesUploader: repositoryChangesUploader,
 		enableSignalHandler:       enableSignalHandler,
+		telemetryClient:           telemetry.NoopClient(),
 		testSkippingLevel:         testSkippingLevel,
 	}
 }
@@ -430,9 +437,16 @@ func (c *TestOptimizationClient) registerSignalHandler() {
 	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		<-signals
-		c.StoreCacheAndExit()
+		c.handleSignal()
 		os.Exit(1)
 	}()
+}
+
+func (c *TestOptimizationClient) handleSignal() {
+	c.StoreCacheAndExit()
+	if err := c.telemetryClient.Flush(context.Background()); err != nil {
+		slog.Debug("Failed to flush telemetry metrics during shutdown", "error", err)
+	}
 }
 
 func (c *TestOptimizationClient) uploadRepositoryChangesAsync() chan struct{} {

--- a/internal/testoptimization/testoptimization.go
+++ b/internal/testoptimization/testoptimization.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/ddtest/internal/environment"
 	"github.com/DataDog/ddtest/internal/git"
 	"github.com/DataDog/ddtest/internal/settings"
+	"github.com/DataDog/ddtest/internal/telemetry"
 	"github.com/DataDog/ddtest/internal/testoptimization/api"
 	"github.com/DataDog/ddtest/internal/utils"
 )
@@ -35,6 +36,7 @@ type TestOptimizationClient struct {
 	apiTransport              api.Transport
 	newAPITransport           func(serviceName string, testSkippingLevel settings.TestSkippingLevel) api.Transport
 	cacheManager              *CacheManager
+	gitCommands               *git.CommandRunner
 	repositoryChangesUploader func() (int64, error)
 	enableSignalHandler       bool
 
@@ -56,7 +58,18 @@ func NewTestOptimizationClient() *TestOptimizationClient {
 }
 
 func NewTestOptimizationClientWithTestSkippingLevel(testSkippingLevel settings.TestSkippingLevel) *TestOptimizationClient {
-	return newTestOptimizationClientWithTestSkippingLevel(nil, api.NewTransportWithServiceNameAndTestSkippingLevel, nil, true, testSkippingLevel)
+	return NewTestOptimizationClientWithTelemetry(testSkippingLevel, telemetry.NoopClient())
+}
+
+// NewTestOptimizationClientWithTelemetry creates a Test Optimization client
+// whose backend transport reports internal metrics through telemetryClient.
+func NewTestOptimizationClientWithTelemetry(testSkippingLevel settings.TestSkippingLevel, telemetryClient telemetry.Client) *TestOptimizationClient {
+	newAPITransport := func(serviceName string, level settings.TestSkippingLevel) api.Transport {
+		return api.NewTransportWithTelemetry(serviceName, level, telemetryClient)
+	}
+	client := newTestOptimizationClientWithTestSkippingLevel(nil, newAPITransport, nil, true, testSkippingLevel)
+	client.gitCommands = git.NewCommandRunner(telemetry.NewGitCommandTelemetry(telemetryClient))
+	return client
 }
 
 func NewTestOptimizationClientWithDependencies(apiTransport api.Transport) *TestOptimizationClient {
@@ -93,6 +106,7 @@ func newTestOptimizationClientWithTestSkippingLevel(
 		apiTransport:              apiTransport,
 		newAPITransport:           newAPITransport,
 		cacheManager:              NewCacheManager(),
+		gitCommands:               git.NewCommandRunner(nil),
 		repositoryChangesUploader: repositoryChangesUploader,
 		enableSignalHandler:       enableSignalHandler,
 		testSkippingLevel:         testSkippingLevel,
@@ -463,7 +477,7 @@ func (c *TestOptimizationClient) uploadRepositoryChangesFromGit() (bytes int64, 
 		return 0, nil
 	}
 
-	hasBeenUnshallowed, err := git.UnshallowGitRepository()
+	hasBeenUnshallowed, err := c.gitCommands.UnshallowGitRepository()
 	if err != nil || !hasBeenUnshallowed {
 		if err != nil {
 			slog.Warn(err.Error())
@@ -484,7 +498,7 @@ func (c *TestOptimizationClient) uploadRepositoryChangesFromGit() (bytes int64, 
 }
 
 func (c *TestOptimizationClient) getSearchCommits() (*searchCommitsResponse, error) {
-	localCommits := git.GetLastLocalGitCommitShas()
+	localCommits := c.gitCommands.GetLastLocalGitCommitShas()
 	if len(localCommits) == 0 {
 		slog.Debug("testoptimization: no local commits found")
 		return newSearchCommitsResponse(nil, nil, false), nil
@@ -523,7 +537,7 @@ func (r *searchCommitsResponse) missingCommits() []string {
 }
 
 func (c *TestOptimizationClient) sendObjectsPackFile(commitSha string, commitsToInclude []string, commitsToExclude []string) (bytes int64, err error) {
-	packFiles := git.CreatePackFiles(commitsToInclude, commitsToExclude)
+	packFiles := c.gitCommands.CreatePackFiles(commitsToInclude, commitsToExclude)
 	if len(packFiles) == 0 {
 		slog.Debug("testoptimization: no pack files to send")
 		return 0, nil


### PR DESCRIPTION
## What

- Added a narrow, metrics-only `internal/telemetry` package based on the CI Visibility telemetry implementation in `dd-trace-go`.
  - Supports count and distribution metrics with deterministic tag handling.
  - Aggregates concurrent submissions and restores buffered values after failed or cancelled flushes.
  - Sends count and distribution payloads together using the telemetry v2 `message-batch` request type when both are present.
  - Sends no `app-started`, lifecycle, configuration, dependency, integration, log, or heartbeat events.
- Added the telemetry v2 request envelope and headers with a per-process runtime ID, sequence IDs, host/runtime metadata, the configured ddtest service name, `DD_ENV`, the ddtest build version, and the constant language name `ddtest`.
- Added Agent and agentless telemetry delivery.
  - Agent mode uses `/telemetry/proxy/api/v2/apmtelemetry` and supports HTTP(S) and Unix-socket Agent URLs.
  - Agentless mode uses the instrumentation telemetry intake for `DD_SITE`, or `DD_CIVISIBILITY_AGENTLESS_URL` when a test intake override is configured.
  - API keys are attached only for agentless requests.
- Extracted shared Datadog connection discovery and HTTP transport construction into `internal/httptransport`, then reused it from both Test Optimization and telemetry to keep Agent URL, Unix socket, site, API key, and agentless test URL handling consistent.
- Created one telemetry client per `plan` or `test` command, passed the same client through the runner, planner, Test Optimization API transport, and Git command runner, and flushed it after the command completes. Client creation and flush failures remain best-effort and do not replace the command result.
- Added CI Visibility metrics matching the current `dd-trace-go` names and tags where they apply to ddtest:
  - Search-commits, object-pack, settings, skippable-tests, known-tests, and test-management request counts, errors, durations, response sizes, and response item counts.
  - Settings response feature flags.
  - Aggregate `itr_skipped` counts tagged as `event_type:test` or `event_type:suite`. ddtest does not emit `itr_unskippable` or `itr_forced_run`.
  - Low-level Git command counts, errors, and durations for the Git operations used by repository upload, with canonical command and exit-code tags. Existing package-level Git functions retain their non-telemetry behavior.
- Added unit and integration-style coverage for metric aggregation, batching, request metadata, Agent/agentless routing, retries, concurrency, API metrics, planner counts, Git metrics, and end-to-end dependency wiring.

## Why

ddtest performs Test Optimization API requests, repository uploads, TIA planning, and supporting Git operations in its own process. Those operations need internal CI Visibility metrics so their volume, latency, response sizes, and failures can be monitored independently of the language tracer running the tests.

The implementation intentionally copies only the metrics functionality needed by ddtest. It uses the optional telemetry [`message-batch`](https://github.com/DataDog/instrumentation-telemetry-api-docs/blob/main/GeneratedDocumentation/ApiDocs/v2/SchemaDocumentation/Schemas/message_batch.md) envelope to avoid duplicating the common request header when flushing both count and distribution payloads, while excluding unrelated application lifecycle events.

Sharing connection discovery with the existing Test Optimization transport also prevents the telemetry and API clients from resolving Agent, Unix-socket, site, API-key, and test-intake configuration differently.

## E2E testing

- Ran `make test` successfully.
- Ran `make lint` successfully with zero issues.
- Manual scenario:
  1. Start a local mock intake that implements the Test Optimization settings/skippables responses and records telemetry POST requests.
  2. Set `DD_CIVISIBILITY_AGENTLESS_ENABLED=true`, `DD_API_KEY=test`, `DD_CIVISIBILITY_AGENTLESS_URL=http://127.0.0.1:<port>`, `DD_SERVICE=<service>`, and `DD_ENV=e2e`.
  3. Run `go run . plan` in a supported test project.
  4. Verify a request reaches `/api/v2/apmtelemetry`, uses `language_name: ddtest` and the configured service, contains only `generate-metrics`/`distributions` payloads (wrapped in `message-batch` when both exist), and includes the expected API, ITR, and Git metrics.
