### PR TITLE
Upgrade Go to 1.26.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v5
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.5"
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -30,9 +30,9 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.26.3-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-1.26.5-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-1.26.3-
+            ${{ runner.os }}-go-1.26.5-
 
       - name: Download dependencies
         run: go mod download
@@ -91,7 +91,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v5
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.5"
 
       - name: Test Mocha adapter
         run: |
@@ -108,7 +108,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v5
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.5"
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v6

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v5
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.5'
 
       - name: Build binaries
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v5
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.5'
 
       - name: Build binaries
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ go test -v ./...           # Verbose testing
 ## Development
 
 - Uses `dd-trace-go/v2` for Datadog tracing and CI Visibility
-- Use go 1.26.3
+- Use go 1.26.5
 - Use `strings` and `slices` packages, don't write your own string manipulation functions
 - Always run `make test` after any change. Any new functionality must be covered by test.
 - Always run `make lint` after any change. Address any linting issues found.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Go 1.26.3 or later
+- Go 1.26.5 or later
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Before using DDTest, you must have **Datadog Test Optimization** already set up 
 
 Minimum supported library and runtime requirements:
 
+- Building DDTest from source requires Go **1.26.5**.
 - Ruby requires the `datadog-ci` gem **1.31.0** or higher.
 - Python requires the `ddtrace` package **4.11.0** or higher and `pytest`.
 - JavaScript requires the `dd-trace` package **5.111.0** or higher and Node.js.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/ddtest
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0


### PR DESCRIPTION
## What

Upgrade DDTest from Go 1.26.3 to Go 1.26.5 in `go.mod`, CI, prerelease, and release workflows. Update Go cache keys and document the source-build requirement in README.

## Why

Go 1.26.5 remediates [GO-2026-5942](https://pkg.go.dev/vuln/GO-2026-5942) (CVE-2026-46600), where parsing an invalid SVCB or HTTPS resource record can panic in `golang.org/x/net/dns/dnsmessage`. Keeping workflow pins aligned with `go.mod` ensures CI and release artifacts use the fixed standard library.

## E2E testing

1. Check out this branch with Go 1.26.5 installed.
2. Run `go mod verify` and confirm all modules are verified.
3. Run `go build ./...` and confirm the repository builds.
4. Run `make test` and confirm all packages pass.
5. Run `make lint` and confirm golangci-lint reports 0 issues.