### PR TITLE
fix: prevent planning hangs during discovery cancellation

### DIFF
--- a/docs/running.md
+++ b/docs/running.md
@@ -62,6 +62,11 @@ For JavaScript/Cucumber:
 ddtest run --platform javascript --framework cucumber
 ```
 
+DDTest streams test stdout and stderr, but test execution is non-interactive.
+Worker stdin is connected to the null device, so accidental reads receive EOF.
+Prompts, interactive debuggers, and other commands that require stdin are not
+supported.
+
 On one CI node, the default `--min-parallelism` and `--max-parallelism` equal
 the available physical CPU core count, so DDTest can start one worker per
 physical core without defaulting to one worker per hyperthread.

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 
@@ -218,8 +219,51 @@ func runWithTelemetry(ctx context.Context, commandType telemetry.CLICommandType,
 	return operationErr
 }
 
+type commandSignalCancellation struct {
+	signal os.Signal
+}
+
+func (c commandSignalCancellation) Error() string {
+	return fmt.Sprintf("command cancelled by %s", c.signal)
+}
+
+func (c commandSignalCancellation) Signal() os.Signal {
+	return c.signal
+}
+
+func commandSignalContext(parent context.Context) (context.Context, func()) {
+	ctx, cancel := context.WithCancelCause(parent)
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+
+	var stopSignalsOnce sync.Once
+	stopSignals := func() {
+		stopSignalsOnce.Do(func() {
+			signal.Stop(signals)
+		})
+	}
+	stop := func() {
+		stopSignals()
+		cancel(context.Canceled)
+	}
+
+	go func() {
+		select {
+		case receivedSignal := <-signals:
+			stopSignals()
+			cancel(commandSignalCancellation{signal: receivedSignal})
+		case <-parent.Done():
+			stopSignals()
+			cancel(context.Cause(parent))
+		case <-ctx.Done():
+		}
+	}()
+
+	return ctx, stop
+}
+
 func Execute() error {
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	ctx, stop := commandSignalContext(context.Background())
 	defer stop()
 	return rootCmd.ExecuteContext(ctx)
 }

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/signal"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/DataDog/ddtest/internal/buildinfo"
@@ -234,7 +233,7 @@ func (c commandSignalCancellation) Signal() os.Signal {
 func commandSignalContext(parent context.Context) (context.Context, func()) {
 	ctx, cancel := context.WithCancelCause(parent)
 	signals := make(chan os.Signal, 1)
-	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(signals, commandCancellationSignals()...)
 
 	var stopSignalsOnce sync.Once
 	stopSignals := func() {

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/DataDog/ddtest/internal/buildinfo"
@@ -134,7 +136,7 @@ func runPersistentPreRun(cmd *cobra.Command, _ []string) error {
 		if !ok {
 			return err
 		}
-		return runWithTelemetry(context.Background(), commandType, func(telemetry.Client) error {
+		return runWithTelemetry(commandContext(cmd), commandType, func(telemetry.Client) error {
 			return errcode.WithCode(errorCode, err)
 		})
 	}
@@ -153,7 +155,7 @@ func gitAvailabilityTelemetryContext(cmd *cobra.Command) (telemetry.CLICommandTy
 }
 
 func runPlanCommand(cmd *cobra.Command, args []string) {
-	ctx := context.Background()
+	ctx := commandContext(cmd)
 	err := runWithTelemetry(ctx, telemetry.CLICommandPlan, func(telemetryClient telemetry.Client) error {
 		return planCommand(ctx, telemetryClient)
 	})
@@ -165,7 +167,7 @@ func runPlanCommand(cmd *cobra.Command, args []string) {
 }
 
 func runTestCommand(cmd *cobra.Command, args []string) {
-	ctx := context.Background()
+	ctx := commandContext(cmd)
 	err := runWithTelemetry(ctx, telemetry.CLICommandRun, func(telemetryClient telemetry.Client) error {
 		return newRunner(telemetryClient).Run(ctx)
 	})
@@ -174,6 +176,13 @@ func runTestCommand(cmd *cobra.Command, args []string) {
 		exitProcess(1)
 		return
 	}
+}
+
+func commandContext(cmd *cobra.Command) context.Context {
+	if ctx := cmd.Context(); ctx != nil {
+		return ctx
+	}
+	return context.Background()
 }
 
 func createTelemetryClient() (telemetry.Client, error) {
@@ -210,5 +219,7 @@ func runWithTelemetry(ctx context.Context, commandType telemetry.CLICommandType,
 }
 
 func Execute() error {
-	return rootCmd.Execute()
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	return rootCmd.ExecuteContext(ctx)
 }

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -233,9 +233,16 @@ func TestRunPlanCommand(t *testing.T) {
 
 	telemetryClient := &fakeTelemetryClient{}
 	newTelemetryClient = func() (telemetry.Client, error) { return telemetryClient, nil }
+	commandContext, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	command := &cobra.Command{}
+	command.SetContext(commandContext)
 	calls := 0
 	planCommand = func(ctx context.Context, got telemetry.Client) error {
 		calls++
+		if ctx != commandContext {
+			t.Fatal("plan command did not receive the Cobra command context")
+		}
 		telemetry.RecordCLICommandAttributes(got, attributes)
 		return nil
 	}
@@ -243,7 +250,7 @@ func TestRunPlanCommand(t *testing.T) {
 		t.Fatalf("exitProcess(%d) should not be called", code)
 	}
 
-	runPlanCommand(&cobra.Command{}, nil)
+	runPlanCommand(command, nil)
 
 	if calls != 1 {
 		t.Fatalf("expected plan command to be called once, got %d", calls)
@@ -309,6 +316,10 @@ func TestRunTestCommand(t *testing.T) {
 
 	telemetryClient := &fakeTelemetryClient{}
 	newTelemetryClient = func() (telemetry.Client, error) { return telemetryClient, nil }
+	commandContext, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	command := &cobra.Command{}
+	command.SetContext(commandContext)
 	fake := &fakeCommandRunner{}
 	newRunner = func(got telemetry.Client) runnerpkg.Runner {
 		telemetry.RecordCLICommandAttributes(got, attributes)
@@ -318,10 +329,13 @@ func TestRunTestCommand(t *testing.T) {
 		t.Fatalf("exitProcess(%d) should not be called", code)
 	}
 
-	runTestCommand(&cobra.Command{}, nil)
+	runTestCommand(command, nil)
 
 	if fake.calls != 1 {
 		t.Fatalf("expected runner to be called once, got %d", fake.calls)
+	}
+	if fake.ctx != commandContext {
+		t.Fatal("test runner did not receive the Cobra command context")
 	}
 	if telemetryClient.flushCalls != 1 {
 		t.Fatalf("telemetry flush calls = %d, want 1", telemetryClient.flushCalls)
@@ -680,6 +694,7 @@ func TestInitFunction(t *testing.T) {
 type fakeCommandRunner struct {
 	calls int
 	err   error
+	ctx   context.Context
 }
 
 func detectedCLICommandAttributes() telemetry.CLICommandAttributes {
@@ -711,6 +726,7 @@ func cliMetricTags(command, exitCode string, errorCode errcode.Code, attributes 
 
 func (f *fakeCommandRunner) Run(ctx context.Context) error {
 	f.calls++
+	f.ctx = ctx
 	return f.err
 }
 

--- a/internal/cmd/command_signals_other.go
+++ b/internal/cmd/command_signals_other.go
@@ -1,0 +1,9 @@
+//go:build js || plan9 || wasip1
+
+package cmd
+
+import "os"
+
+func commandCancellationSignals() []os.Signal {
+	return []os.Signal{os.Interrupt}
+}

--- a/internal/cmd/command_signals_unix.go
+++ b/internal/cmd/command_signals_unix.go
@@ -1,0 +1,12 @@
+//go:build aix || android || darwin || dragonfly || freebsd || illumos || ios || linux || netbsd || openbsd || solaris
+
+package cmd
+
+import (
+	"os"
+	"syscall"
+)
+
+func commandCancellationSignals() []os.Signal {
+	return []os.Signal{syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP, syscall.SIGQUIT}
+}

--- a/internal/cmd/command_signals_unix_test.go
+++ b/internal/cmd/command_signals_unix_test.go
@@ -1,0 +1,43 @@
+//go:build darwin || linux
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestCommandSignalContextHandlesUnixCancellationSignals(t *testing.T) {
+	for _, sig := range []os.Signal{syscall.SIGHUP, syscall.SIGQUIT} {
+		t.Run(sig.String(), func(t *testing.T) {
+			ctx, stop := commandSignalContext(context.Background())
+			defer stop()
+
+			process, err := os.FindProcess(os.Getpid())
+			if err != nil {
+				t.Fatalf("find current process: %v", err)
+			}
+			if err := process.Signal(sig); err != nil {
+				t.Fatalf("send %s: %v", sig, err)
+			}
+
+			select {
+			case <-ctx.Done():
+			case <-time.After(time.Second):
+				t.Fatalf("context was not cancelled by %s", sig)
+			}
+
+			var cancellation commandSignalCancellation
+			if !errors.As(context.Cause(ctx), &cancellation) {
+				t.Fatalf("context cause = %v, want commandSignalCancellation", context.Cause(ctx))
+			}
+			if cancellation.Signal() != sig {
+				t.Fatalf("cancellation signal = %v, want %v", cancellation.Signal(), sig)
+			}
+		})
+	}
+}

--- a/internal/cmd/command_signals_windows.go
+++ b/internal/cmd/command_signals_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package cmd
+
+import "os"
+
+func commandCancellationSignals() []os.Signal {
+	return []os.Signal{os.Interrupt}
+}

--- a/internal/ext/command.go
+++ b/internal/ext/command.go
@@ -118,9 +118,10 @@ func (e *DefaultCommandExecutor) Run(ctx context.Context, name string, args []st
 	applyEnvMap(cmd, envMap)
 	configureCommandProcessGroup(cmd)
 
-	// Connect command's stdin/stdout/stderr to parent's stdin/stdout/stderr for proper streaming
-	// stdin is needed even for non-interactive commands because some gems (like reline) check terminal properties
-	cmd.Stdin = os.Stdin
+	// Stream test output while keeping execution non-interactive. With a nil
+	// Stdin, os/exec connects the command to the null device, so accidental
+	// reads receive EOF instead of blocking on a pipe or background terminal.
+	cmd.Stdin = nil
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 

--- a/internal/ext/command.go
+++ b/internal/ext/command.go
@@ -7,7 +7,10 @@ import (
 	"os/exec"
 	"os/signal"
 	"syscall"
+	"time"
 )
+
+const commandWaitDelay = time.Second
 
 type CommandExecutor interface {
 	CombinedOutput(ctx context.Context, name string, args []string, envMap map[string]string) ([]byte, error)
@@ -51,10 +54,18 @@ func applyEnvMap(cmd *exec.Cmd, envMap map[string]string) {
 	}
 }
 
+func prepareCommand(cmd *exec.Cmd) {
+	configureCommandProcess(cmd)
+	// Bound the time spent waiting for inherited output pipes after cancellation.
+	// A detached descendant can otherwise keep CombinedOutput blocked indefinitely.
+	cmd.WaitDelay = commandWaitDelay
+}
+
 func (e *DefaultCommandExecutor) CombinedOutput(ctx context.Context, name string, args []string, envMap map[string]string) ([]byte, error) {
 	// no-dd-sa:go-security/command-injection
 	cmd := exec.CommandContext(ctx, name, args...)
 	applyEnvMap(cmd, envMap)
+	prepareCommand(cmd)
 
 	return cmd.CombinedOutput()
 }
@@ -63,6 +74,7 @@ func (e *DefaultCommandExecutor) Output(ctx context.Context, name string, args [
 	// no-dd-sa:go-security/command-injection
 	cmd := exec.CommandContext(ctx, name, args...)
 	applyEnvMap(cmd, envMap)
+	prepareCommand(cmd)
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer

--- a/internal/ext/command.go
+++ b/internal/ext/command.go
@@ -3,6 +3,7 @@ package ext
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -11,6 +12,7 @@ import (
 )
 
 const commandWaitDelay = time.Second
+const commandTerminationGracePeriod = 5 * time.Second
 
 type CommandExecutor interface {
 	CombinedOutput(ctx context.Context, name string, args []string, envMap map[string]string) ([]byte, error)
@@ -33,7 +35,8 @@ func (n osSignalNotifier) Stop(c chan<- os.Signal) {
 }
 
 type DefaultCommandExecutor struct {
-	signalNotifier signalNotifier
+	signalNotifier         signalNotifier
+	terminationGracePeriod time.Duration
 }
 
 func (e *DefaultCommandExecutor) notifier() signalNotifier {
@@ -42,6 +45,27 @@ func (e *DefaultCommandExecutor) notifier() signalNotifier {
 	}
 
 	return osSignalNotifier{}
+}
+
+func (e *DefaultCommandExecutor) gracePeriod() time.Duration {
+	if e.terminationGracePeriod > 0 {
+		return e.terminationGracePeriod
+	}
+
+	return commandTerminationGracePeriod
+}
+
+type signalCancellation interface {
+	Signal() os.Signal
+}
+
+func contextCancellationSignal(ctx context.Context) os.Signal {
+	var cancellation signalCancellation
+	if errors.As(context.Cause(ctx), &cancellation) {
+		return cancellation.Signal()
+	}
+
+	return syscall.SIGTERM
 }
 
 // applyEnvMap applies environment variables from envMap to the command
@@ -85,20 +109,20 @@ func (e *DefaultCommandExecutor) Output(ctx context.Context, name string, args [
 }
 
 func (e *DefaultCommandExecutor) Run(ctx context.Context, name string, args []string, envMap map[string]string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	// no-dd-sa:go-security/command-injection
-	cmd := exec.CommandContext(ctx, name, args...)
+	cmd := exec.Command(name, args...)
 	applyEnvMap(cmd, envMap)
+	configureCommandProcessGroup(cmd)
 
 	// Connect command's stdin/stdout/stderr to parent's stdin/stdout/stderr for proper streaming
 	// stdin is needed even for non-interactive commands because some gems (like reline) check terminal properties
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-
-	// Start the command
-	if err := cmd.Start(); err != nil {
-		return err
-	}
 
 	// Set up signal forwarding for common termination signals used by CI systems
 	// SIGTERM - standard graceful termination (most common in CI)
@@ -109,6 +133,17 @@ func (e *DefaultCommandExecutor) Run(ctx context.Context, name string, args []st
 	notifier := e.notifier()
 	notifier.Notify(sigChan, syscall.SIGTERM, syscall.SIGINT, syscall.SIGHUP, syscall.SIGQUIT)
 	defer notifier.Stop(sigChan)
+	// Close the gap between the initial context check and process startup. Once
+	// signals are registered, any cancellation racing Start is retained in
+	// sigChan and forwarded after the process is running.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	// Start the command
+	if err := cmd.Start(); err != nil {
+		return err
+	}
 
 	// Wait for command completion in a goroutine
 	errChan := make(chan error, 1)
@@ -116,16 +151,52 @@ func (e *DefaultCommandExecutor) Run(ctx context.Context, name string, args []st
 		errChan <- cmd.Wait()
 	}()
 
-	// Wait for either signals or command completion
+	ctxDone := ctx.Done()
+	var graceTimer *time.Timer
+	var graceExpired <-chan time.Time
+	terminationRequested := false
+	signalCount := 0
+	requestTermination := func(sig os.Signal) {
+		terminationRequested = true
+		_ = signalCommand(cmd, sig)
+		graceTimer = time.NewTimer(e.gracePeriod())
+		graceExpired = graceTimer.C
+	}
+	forceTermination := func() {
+		_ = signalCommand(cmd, os.Kill)
+	}
+	defer func() {
+		if graceTimer != nil {
+			graceTimer.Stop()
+		}
+	}()
+
+	// Gracefully forward the first cancellation request. A second signal or an
+	// expired grace period forcefully terminates the wrapper.
 	for {
 		select {
 		case sig := <-sigChan:
-			// Forward the signal to the child process
-			if cmd.Process != nil {
-				_ = cmd.Process.Signal(sig)
+			signalCount++
+			if signalCount > 1 {
+				forceTermination()
+				continue
 			}
+			if !terminationRequested {
+				requestTermination(sig)
+			}
+		case <-ctxDone:
+			ctxDone = nil
+			if !terminationRequested {
+				requestTermination(contextCancellationSignal(ctx))
+			}
+		case <-graceExpired:
+			graceExpired = nil
+			forceTermination()
 		case err := <-errChan:
 			// Command finished
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
 			return err
 		}
 	}

--- a/internal/ext/command.go
+++ b/internal/ext/command.go
@@ -131,7 +131,7 @@ func (e *DefaultCommandExecutor) Run(ctx context.Context, name string, args []st
 	// SIGQUIT - quit signal
 	sigChan := make(chan os.Signal, 1)
 	notifier := e.notifier()
-	notifier.Notify(sigChan, syscall.SIGTERM, syscall.SIGINT, syscall.SIGHUP, syscall.SIGQUIT)
+	notifier.Notify(sigChan, commandSignals()...)
 	defer notifier.Stop(sigChan)
 	// Close the gap between the initial context check and process startup. Once
 	// signals are registered, any cancellation racing Start is retained in
@@ -194,6 +194,12 @@ func (e *DefaultCommandExecutor) Run(ctx context.Context, name string, args []st
 			forceTermination()
 		case err := <-errChan:
 			// Command finished
+			// A wrapper can exit after handling the graceful signal while one of
+			// its ordinary descendants remains alive in the process group. Do not
+			// leave those descendants behind once cancellation has been requested.
+			if terminationRequested || ctx.Err() != nil {
+				forceTermination()
+			}
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}

--- a/internal/ext/command_process_other.go
+++ b/internal/ext/command_process_other.go
@@ -1,0 +1,7 @@
+//go:build js || plan9 || wasip1
+
+package ext
+
+import "os/exec"
+
+func configureCommandProcess(cmd *exec.Cmd) {}

--- a/internal/ext/command_process_other.go
+++ b/internal/ext/command_process_other.go
@@ -2,6 +2,18 @@
 
 package ext
 
-import "os/exec"
+import (
+	"os"
+	"os/exec"
+)
 
 func configureCommandProcess(cmd *exec.Cmd) {}
+
+func configureCommandProcessGroup(cmd *exec.Cmd) {}
+
+func signalCommand(cmd *exec.Cmd, signal os.Signal) error {
+	if cmd.Process == nil {
+		return os.ErrProcessDone
+	}
+	return cmd.Process.Signal(signal)
+}

--- a/internal/ext/command_process_other.go
+++ b/internal/ext/command_process_other.go
@@ -11,6 +11,10 @@ func configureCommandProcess(cmd *exec.Cmd) {}
 
 func configureCommandProcessGroup(cmd *exec.Cmd) {}
 
+func commandSignals() []os.Signal {
+	return []os.Signal{os.Interrupt}
+}
+
 func signalCommand(cmd *exec.Cmd, signal os.Signal) error {
 	if cmd.Process == nil {
 		return os.ErrProcessDone

--- a/internal/ext/command_process_unix.go
+++ b/internal/ext/command_process_unix.go
@@ -22,6 +22,10 @@ func configureCommandProcessGroup(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 }
 
+func commandSignals() []os.Signal {
+	return []os.Signal{syscall.SIGTERM, syscall.SIGINT, syscall.SIGHUP, syscall.SIGQUIT}
+}
+
 func signalCommand(cmd *exec.Cmd, signal os.Signal) error {
 	if cmd.Process == nil {
 		return os.ErrProcessDone

--- a/internal/ext/command_process_unix.go
+++ b/internal/ext/command_process_unix.go
@@ -1,0 +1,38 @@
+//go:build darwin || linux
+
+package ext
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+func configureCommandProcess(cmd *exec.Cmd) {
+	// Start each command in its own process group so context cancellation also
+	// terminates framework wrappers and their descendants.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		return signalCommand(cmd, os.Kill)
+	}
+}
+
+func signalCommand(cmd *exec.Cmd, signal os.Signal) error {
+	if cmd.Process == nil {
+		return os.ErrProcessDone
+	}
+
+	sysSignal, ok := signal.(syscall.Signal)
+	if !ok {
+		return cmd.Process.Signal(signal)
+	}
+
+	if err := syscall.Kill(-cmd.Process.Pid, sysSignal); err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			return os.ErrProcessDone
+		}
+		return err
+	}
+	return nil
+}

--- a/internal/ext/command_process_unix.go
+++ b/internal/ext/command_process_unix.go
@@ -10,12 +10,16 @@ import (
 )
 
 func configureCommandProcess(cmd *exec.Cmd) {
-	// Start each command in its own process group so context cancellation also
-	// terminates framework wrappers and their descendants.
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	configureCommandProcessGroup(cmd)
 	cmd.Cancel = func() error {
 		return signalCommand(cmd, os.Kill)
 	}
+}
+
+func configureCommandProcessGroup(cmd *exec.Cmd) {
+	// Start each command in its own process group so cancellation signals can
+	// terminate framework wrappers and their ordinary descendants together.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 }
 
 func signalCommand(cmd *exec.Cmd, signal os.Signal) error {

--- a/internal/ext/command_process_unix.go
+++ b/internal/ext/command_process_unix.go
@@ -1,4 +1,4 @@
-//go:build darwin || linux
+//go:build aix || android || darwin || dragonfly || freebsd || illumos || ios || linux || netbsd || openbsd || solaris
 
 package ext
 

--- a/internal/ext/command_process_unix_test.go
+++ b/internal/ext/command_process_unix_test.go
@@ -16,6 +16,185 @@ import (
 	"time"
 )
 
+type manualSignalNotifier struct {
+	registered chan chan<- os.Signal
+}
+
+func (n *manualSignalNotifier) Notify(c chan<- os.Signal, _ ...os.Signal) {
+	n.registered <- c
+}
+
+func (n *manualSignalNotifier) Stop(chan<- os.Signal) {}
+
+type testSignalCancellation struct {
+	signal os.Signal
+}
+
+func (c testSignalCancellation) Error() string {
+	return "test signal cancellation"
+}
+
+func (c testSignalCancellation) Signal() os.Signal {
+	return c.signal
+}
+
+func TestDefaultCommandExecutor_Run_ContextAndSignalCancellationShareGracePeriod(t *testing.T) {
+	readyFile := filepath.Join(t.TempDir(), "ready")
+	handledFile := filepath.Join(t.TempDir(), "handled")
+	ctx, cancel := context.WithCancelCause(context.Background())
+	notifier := &manualSignalNotifier{registered: make(chan chan<- os.Signal, 1)}
+	executor := &DefaultCommandExecutor{
+		signalNotifier:         notifier,
+		terminationGracePeriod: 2 * time.Second,
+	}
+	result := make(chan error, 1)
+	go func() {
+		result <- executor.Run(ctx, "sh", []string{
+			"-c",
+			`trap 'echo handled > "$DDTEST_HANDLED_FILE"' TERM; echo ready > "$DDTEST_READY_FILE"; while :; do sleep 0.05; done`,
+		}, map[string]string{
+			"DDTEST_READY_FILE":   readyFile,
+			"DDTEST_HANDLED_FILE": handledFile,
+		})
+	}()
+
+	signalChannel := <-notifier.registered
+	waitForFile(t, readyFile)
+	cancel(testSignalCancellation{signal: syscall.SIGTERM})
+	// The executor also receives the OS signal that caused root cancellation.
+	// It is the same first cancellation request, not a force-kill request.
+	signalChannel <- syscall.SIGTERM
+	waitForFile(t, handledFile)
+	select {
+	case err := <-result:
+		t.Fatalf("duplicate first-signal delivery skipped the grace period: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	signalChannel <- syscall.SIGTERM
+	select {
+	case err := <-result:
+		if err == nil {
+			t.Fatal("expected context cancellation error")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("second signal did not force termination")
+	}
+}
+
+func TestDefaultCommandExecutor_Run_AllowsGracefulSignalHandling(t *testing.T) {
+	readyFile := filepath.Join(t.TempDir(), "ready")
+	handledFile := filepath.Join(t.TempDir(), "handled")
+	notifier := &manualSignalNotifier{registered: make(chan chan<- os.Signal, 1)}
+	executor := &DefaultCommandExecutor{
+		signalNotifier:         notifier,
+		terminationGracePeriod: 2 * time.Second,
+	}
+	result := make(chan error, 1)
+	go func() {
+		result <- executor.Run(context.Background(), "sh", []string{
+			"-c",
+			`trap 'echo handled > "$DDTEST_HANDLED_FILE"; exit 0' TERM; echo ready > "$DDTEST_READY_FILE"; while :; do sleep 0.05; done`,
+		}, map[string]string{
+			"DDTEST_READY_FILE":   readyFile,
+			"DDTEST_HANDLED_FILE": handledFile,
+		})
+	}()
+
+	signalChannel := <-notifier.registered
+	waitForFile(t, readyFile)
+	signalChannel <- syscall.SIGTERM
+
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("gracefully handled command returned error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("command did not exit after gracefully handling SIGTERM")
+	}
+	waitForFile(t, handledFile)
+}
+
+func TestDefaultCommandExecutor_Run_SecondSignalForcesTermination(t *testing.T) {
+	readyFile := filepath.Join(t.TempDir(), "ready")
+	handledFile := filepath.Join(t.TempDir(), "handled")
+	notifier := &manualSignalNotifier{registered: make(chan chan<- os.Signal, 1)}
+	executor := &DefaultCommandExecutor{
+		signalNotifier:         notifier,
+		terminationGracePeriod: 5 * time.Second,
+	}
+	result := make(chan error, 1)
+	go func() {
+		result <- executor.Run(context.Background(), "sh", []string{
+			"-c",
+			`trap 'echo handled > "$DDTEST_HANDLED_FILE"' TERM; echo ready > "$DDTEST_READY_FILE"; while :; do sleep 0.05; done`,
+		}, map[string]string{
+			"DDTEST_READY_FILE":   readyFile,
+			"DDTEST_HANDLED_FILE": handledFile,
+		})
+	}()
+
+	signalChannel := <-notifier.registered
+	waitForFile(t, readyFile)
+	signalChannel <- syscall.SIGTERM
+	waitForFile(t, handledFile)
+	forcedAt := time.Now()
+	signalChannel <- syscall.SIGTERM
+
+	select {
+	case err := <-result:
+		if err == nil {
+			t.Fatal("expected forced termination error")
+		}
+		if elapsed := time.Since(forcedAt); elapsed >= time.Second {
+			t.Fatalf("second signal took %v to force termination", elapsed)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("second signal did not force termination")
+	}
+}
+
+func TestDefaultCommandExecutor_Run_GracePeriodForcesTermination(t *testing.T) {
+	readyFile := filepath.Join(t.TempDir(), "ready")
+	childPIDFile := filepath.Join(t.TempDir(), "child.pid")
+	notifier := &manualSignalNotifier{registered: make(chan chan<- os.Signal, 1)}
+	gracePeriod := 150 * time.Millisecond
+	executor := &DefaultCommandExecutor{
+		signalNotifier:         notifier,
+		terminationGracePeriod: gracePeriod,
+	}
+	result := make(chan error, 1)
+	go func() {
+		result <- executor.Run(context.Background(), "sh", []string{
+			"-c",
+			`trap '' TERM; sh -c 'trap "" TERM; echo "$$" > "$DDTEST_CHILD_PID_FILE"; while :; do sleep 0.05; done' & echo ready > "$DDTEST_READY_FILE"; wait`,
+		}, map[string]string{
+			"DDTEST_READY_FILE":     readyFile,
+			"DDTEST_CHILD_PID_FILE": childPIDFile,
+		})
+	}()
+
+	signalChannel := <-notifier.registered
+	waitForFile(t, readyFile)
+	childPID := waitForChildPID(t, childPIDFile)
+	signalledAt := time.Now()
+	signalChannel <- syscall.SIGTERM
+
+	select {
+	case err := <-result:
+		if err == nil {
+			t.Fatal("expected forced termination error")
+		}
+		if elapsed := time.Since(signalledAt); elapsed < gracePeriod/2 {
+			t.Fatalf("command was killed before its grace period: %v", elapsed)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("command was not killed after its grace period")
+	}
+	waitForProcessExit(t, childPID)
+}
+
 func TestDefaultCommandExecutor_CombinedOutput_CancellationTerminatesDescendants(t *testing.T) {
 	pidFile := filepath.Join(t.TempDir(), "child.pid")
 	ctx, cancel := context.WithCancel(context.Background())
@@ -51,6 +230,8 @@ func TestDefaultCommandExecutor_CombinedOutput_CancellationTerminatesDescendants
 }
 
 func TestDefaultCommandExecutor_CombinedOutput_CancellationIsBoundedForDetachedDescendant(t *testing.T) {
+	// A descendant that creates a new session is intentionally outside DDTest's
+	// process-tree cancellation contract. WaitDelay must still bound our exit.
 	setsidPath, err := exec.LookPath("setsid")
 	if err != nil {
 		t.Skip("setsid is required to test a detached descendant")
@@ -143,6 +324,20 @@ func waitForChildPID(t *testing.T, pidFile string) int {
 	}
 	t.Fatal("child process did not start")
 	return 0
+}
+
+func waitForFile(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		} else if !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("stat %s: %v", path, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("file %s was not created", path)
 }
 
 func waitForProcessExit(t *testing.T, pid int) {

--- a/internal/ext/command_process_unix_test.go
+++ b/internal/ext/command_process_unix_test.go
@@ -8,16 +8,12 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
 	"testing"
 	"time"
-)
-
-const (
-	detachedHelperModeEnv = "DDTEST_DETACHED_HELPER_MODE"
-	detachedHelperPIDEnv  = "DDTEST_DETACHED_HELPER_PID_FILE"
 )
 
 func TestDefaultCommandExecutor_CombinedOutput_CancellationTerminatesDescendants(t *testing.T) {
@@ -55,17 +51,23 @@ func TestDefaultCommandExecutor_CombinedOutput_CancellationTerminatesDescendants
 }
 
 func TestDefaultCommandExecutor_CombinedOutput_CancellationIsBoundedForDetachedDescendant(t *testing.T) {
+	setsidPath, err := exec.LookPath("setsid")
+	if err != nil {
+		t.Skip("setsid is required to test a detached descendant")
+	}
+
 	pidFile := filepath.Join(t.TempDir(), "detached-child.pid")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	result := make(chan error, 1)
 	go func() {
-		_, err := (&DefaultCommandExecutor{}).CombinedOutput(ctx, os.Args[0], []string{
-			"-test.run=^TestCommandExecutorDetachedDescendantHelper$",
+		_, err := (&DefaultCommandExecutor{}).CombinedOutput(ctx, "sh", []string{
+			"-c",
+			`"$DDTEST_SETSID" sh -c 'echo "$$" > "$DDTEST_CHILD_PID_FILE"; exec sleep 30' & wait`,
 		}, map[string]string{
-			detachedHelperModeEnv: "wait",
-			detachedHelperPIDEnv:  pidFile,
+			"DDTEST_SETSID":         setsidPath,
+			"DDTEST_CHILD_PID_FILE": pidFile,
 		})
 		result <- err
 	}()
@@ -88,15 +90,15 @@ func TestDefaultCommandExecutor_CombinedOutput_CancellationIsBoundedForDetachedD
 	assertProcessRunning(t, childPID)
 }
 
-func TestDefaultCommandExecutor_CombinedOutput_ExitIsBoundedForDetachedDescendant(t *testing.T) {
-	pidFile := filepath.Join(t.TempDir(), "detached-child.pid")
+func TestDefaultCommandExecutor_CombinedOutput_ExitIsBoundedWhenDescendantKeepsPipesOpen(t *testing.T) {
+	pidFile := filepath.Join(t.TempDir(), "child.pid")
 	started := time.Now()
-	_, err := (&DefaultCommandExecutor{}).CombinedOutput(context.Background(), os.Args[0], []string{
-		"-test.run=^TestCommandExecutorDetachedDescendantHelper$",
-	}, map[string]string{
-		detachedHelperModeEnv: "exit",
-		detachedHelperPIDEnv:  pidFile,
-	})
+	_, err := (&DefaultCommandExecutor{}).CombinedOutput(
+		context.Background(),
+		"sh",
+		[]string{"-c", `sleep 30 & echo "$!" > "$DDTEST_CHILD_PID_FILE"`},
+		map[string]string{"DDTEST_CHILD_PID_FILE": pidFile},
+	)
 	if !errors.Is(err, exec.ErrWaitDelay) {
 		t.Fatalf("expected ErrWaitDelay, got %v", err)
 	}
@@ -107,36 +109,10 @@ func TestDefaultCommandExecutor_CombinedOutput_ExitIsBoundedForDetachedDescendan
 	assertProcessRunning(t, childPID)
 }
 
-func TestCommandExecutorDetachedDescendantHelper(t *testing.T) {
-	mode := os.Getenv(detachedHelperModeEnv)
-	if mode == "" {
-		return
-	}
-	if mode == "child" {
-		time.Sleep(30 * time.Second)
-		return
-	}
-
-	child := exec.Command(os.Args[0], "-test.run=^TestCommandExecutorDetachedDescendantHelper$")
-	child.Env = append(os.Environ(), detachedHelperModeEnv+"=child")
-	child.Stdout = os.Stdout
-	child.Stderr = os.Stderr
-	child.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
-	if err := child.Start(); err != nil {
-		t.Fatalf("start detached child: %v", err)
-	}
-	if err := os.WriteFile(os.Getenv(detachedHelperPIDEnv), []byte(strconv.Itoa(child.Process.Pid)), 0o644); err != nil {
-		t.Fatalf("write detached child PID: %v", err)
-	}
-	if mode == "wait" {
-		_ = child.Wait()
-	}
-}
-
 func assertBoundedPipeWait(t *testing.T, elapsed time.Duration) {
 	t.Helper()
 	if elapsed < commandWaitDelay/2 {
-		t.Fatalf("command returned after %v; detached descendant did not exercise WaitDelay", elapsed)
+		t.Fatalf("command returned after %v; descendant did not exercise WaitDelay", elapsed)
 	}
 	if elapsed >= 3*commandWaitDelay {
 		t.Fatalf("command returned after %v; WaitDelay did not bound the inherited pipe wait", elapsed)
@@ -149,7 +125,12 @@ func waitForChildPID(t *testing.T, pidFile string) int {
 	for time.Now().Before(deadline) {
 		contents, err := os.ReadFile(pidFile)
 		if err == nil {
-			pid, parseErr := strconv.Atoi(strings.TrimSpace(string(contents)))
+			pidText := strings.TrimSpace(string(contents))
+			if pidText == "" {
+				time.Sleep(10 * time.Millisecond)
+				continue
+			}
+			pid, parseErr := strconv.Atoi(pidText)
 			if parseErr != nil {
 				t.Fatalf("parse child PID: %v", parseErr)
 			}
@@ -168,12 +149,12 @@ func waitForProcessExit(t *testing.T, pid int) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		err := syscall.Kill(pid, 0)
-		if errors.Is(err, syscall.ESRCH) {
-			return
-		}
+		running, err := processIsRunning(pid)
 		if err != nil {
 			t.Fatalf("check child process %d: %v", pid, err)
+		}
+		if !running {
+			return
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
@@ -182,9 +163,39 @@ func waitForProcessExit(t *testing.T, pid int) {
 
 func assertProcessRunning(t *testing.T, pid int) {
 	t.Helper()
-	if err := syscall.Kill(pid, 0); err != nil {
+	running, err := processIsRunning(pid)
+	if err != nil {
 		t.Fatalf("detached child process %d was not running: %v", pid, err)
 	}
+	if !running {
+		t.Fatalf("detached child process %d was not running", pid)
+	}
+}
+
+func processIsRunning(pid int) (bool, error) {
+	err := syscall.Kill(pid, 0)
+	if errors.Is(err, syscall.ESRCH) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if runtime.GOOS != "linux" {
+		return true, nil
+	}
+
+	stat, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "stat"))
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	closingParenthesis := strings.LastIndex(string(stat), ") ")
+	if closingParenthesis == -1 || closingParenthesis+2 >= len(stat) {
+		return false, errors.New("unexpected process stat format")
+	}
+	return stat[closingParenthesis+2] != 'Z', nil
 }
 
 func killProcess(t *testing.T, pid int) {

--- a/internal/ext/command_process_unix_test.go
+++ b/internal/ext/command_process_unix_test.go
@@ -1,0 +1,200 @@
+//go:build darwin || linux
+
+package ext
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+const (
+	detachedHelperModeEnv = "DDTEST_DETACHED_HELPER_MODE"
+	detachedHelperPIDEnv  = "DDTEST_DETACHED_HELPER_PID_FILE"
+)
+
+func TestDefaultCommandExecutor_CombinedOutput_CancellationTerminatesDescendants(t *testing.T) {
+	pidFile := filepath.Join(t.TempDir(), "child.pid")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	executor := &DefaultCommandExecutor{}
+	result := make(chan error, 1)
+	started := time.Now()
+	go func() {
+		_, err := executor.CombinedOutput(ctx, "sh", []string{
+			"-c",
+			`sleep 30 & child=$!; echo "$child" > "$DDTEST_CHILD_PID_FILE"; wait`,
+		}, map[string]string{"DDTEST_CHILD_PID_FILE": pidFile})
+		result <- err
+	}()
+
+	childPID := waitForChildPID(t, pidFile)
+	cancel()
+
+	select {
+	case err := <-result:
+		if err == nil {
+			t.Fatal("expected cancellation error")
+		}
+		if elapsed := time.Since(started); elapsed >= 2*time.Second {
+			t.Fatalf("command cancellation took %v; descendant likely kept an output pipe open", elapsed)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("command did not return after cancellation")
+	}
+
+	waitForProcessExit(t, childPID)
+}
+
+func TestDefaultCommandExecutor_CombinedOutput_CancellationIsBoundedForDetachedDescendant(t *testing.T) {
+	pidFile := filepath.Join(t.TempDir(), "detached-child.pid")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	result := make(chan error, 1)
+	go func() {
+		_, err := (&DefaultCommandExecutor{}).CombinedOutput(ctx, os.Args[0], []string{
+			"-test.run=^TestCommandExecutorDetachedDescendantHelper$",
+		}, map[string]string{
+			detachedHelperModeEnv: "wait",
+			detachedHelperPIDEnv:  pidFile,
+		})
+		result <- err
+	}()
+
+	childPID := waitForChildPID(t, pidFile)
+	t.Cleanup(func() { killProcess(t, childPID) })
+	cancelledAt := time.Now()
+	cancel()
+
+	select {
+	case err := <-result:
+		if err == nil {
+			t.Fatal("expected cancellation error")
+		}
+		assertBoundedPipeWait(t, time.Since(cancelledAt))
+	case <-time.After(3 * commandWaitDelay):
+		t.Fatal("command did not return after cancelling a wrapper with a detached descendant")
+	}
+
+	assertProcessRunning(t, childPID)
+}
+
+func TestDefaultCommandExecutor_CombinedOutput_ExitIsBoundedForDetachedDescendant(t *testing.T) {
+	pidFile := filepath.Join(t.TempDir(), "detached-child.pid")
+	started := time.Now()
+	_, err := (&DefaultCommandExecutor{}).CombinedOutput(context.Background(), os.Args[0], []string{
+		"-test.run=^TestCommandExecutorDetachedDescendantHelper$",
+	}, map[string]string{
+		detachedHelperModeEnv: "exit",
+		detachedHelperPIDEnv:  pidFile,
+	})
+	if !errors.Is(err, exec.ErrWaitDelay) {
+		t.Fatalf("expected ErrWaitDelay, got %v", err)
+	}
+	assertBoundedPipeWait(t, time.Since(started))
+
+	childPID := waitForChildPID(t, pidFile)
+	t.Cleanup(func() { killProcess(t, childPID) })
+	assertProcessRunning(t, childPID)
+}
+
+func TestCommandExecutorDetachedDescendantHelper(t *testing.T) {
+	mode := os.Getenv(detachedHelperModeEnv)
+	if mode == "" {
+		return
+	}
+	if mode == "child" {
+		time.Sleep(30 * time.Second)
+		return
+	}
+
+	child := exec.Command(os.Args[0], "-test.run=^TestCommandExecutorDetachedDescendantHelper$")
+	child.Env = append(os.Environ(), detachedHelperModeEnv+"=child")
+	child.Stdout = os.Stdout
+	child.Stderr = os.Stderr
+	child.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := child.Start(); err != nil {
+		t.Fatalf("start detached child: %v", err)
+	}
+	if err := os.WriteFile(os.Getenv(detachedHelperPIDEnv), []byte(strconv.Itoa(child.Process.Pid)), 0o644); err != nil {
+		t.Fatalf("write detached child PID: %v", err)
+	}
+	if mode == "wait" {
+		_ = child.Wait()
+	}
+}
+
+func assertBoundedPipeWait(t *testing.T, elapsed time.Duration) {
+	t.Helper()
+	if elapsed < commandWaitDelay/2 {
+		t.Fatalf("command returned after %v; detached descendant did not exercise WaitDelay", elapsed)
+	}
+	if elapsed >= 3*commandWaitDelay {
+		t.Fatalf("command returned after %v; WaitDelay did not bound the inherited pipe wait", elapsed)
+	}
+}
+
+func waitForChildPID(t *testing.T, pidFile string) int {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		contents, err := os.ReadFile(pidFile)
+		if err == nil {
+			pid, parseErr := strconv.Atoi(strings.TrimSpace(string(contents)))
+			if parseErr != nil {
+				t.Fatalf("parse child PID: %v", parseErr)
+			}
+			return pid
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("read child PID: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("child process did not start")
+	return 0
+}
+
+func waitForProcessExit(t *testing.T, pid int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		err := syscall.Kill(pid, 0)
+		if errors.Is(err, syscall.ESRCH) {
+			return
+		}
+		if err != nil {
+			t.Fatalf("check child process %d: %v", pid, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("child process %d was still running after cancellation", pid)
+}
+
+func assertProcessRunning(t *testing.T, pid int) {
+	t.Helper()
+	if err := syscall.Kill(pid, 0); err != nil {
+		t.Fatalf("detached child process %d was not running: %v", pid, err)
+	}
+}
+
+func killProcess(t *testing.T, pid int) {
+	t.Helper()
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		t.Fatalf("find detached child process %d: %v", pid, err)
+	}
+	if err := process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		t.Fatalf("kill detached child process %d: %v", pid, err)
+	}
+	waitForProcessExit(t, pid)
+}

--- a/internal/ext/command_process_unix_test.go
+++ b/internal/ext/command_process_unix_test.go
@@ -195,6 +195,42 @@ func TestDefaultCommandExecutor_Run_GracePeriodForcesTermination(t *testing.T) {
 	waitForProcessExit(t, childPID)
 }
 
+func TestDefaultCommandExecutor_Run_CancellationCleansUpDescendantsAfterWrapperExits(t *testing.T) {
+	readyFile := filepath.Join(t.TempDir(), "ready")
+	childPIDFile := filepath.Join(t.TempDir(), "child.pid")
+	notifier := &manualSignalNotifier{registered: make(chan chan<- os.Signal, 1)}
+	executor := &DefaultCommandExecutor{
+		signalNotifier:         notifier,
+		terminationGracePeriod: 2 * time.Second,
+	}
+	result := make(chan error, 1)
+	go func() {
+		result <- executor.Run(context.Background(), "sh", []string{
+			"-c",
+			`trap 'exit 0' TERM; sh -c 'trap "" TERM; echo "$$" > "$DDTEST_CHILD_PID_FILE"; while :; do sleep 0.05; done' & echo ready > "$DDTEST_READY_FILE"; wait`,
+		}, map[string]string{
+			"DDTEST_READY_FILE":     readyFile,
+			"DDTEST_CHILD_PID_FILE": childPIDFile,
+		})
+	}()
+
+	signalChannel := <-notifier.registered
+	waitForFile(t, readyFile)
+	childPID := waitForChildPID(t, childPIDFile)
+	signalChannel <- syscall.SIGTERM
+
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("gracefully handled command returned error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("command did not exit after gracefully handling SIGTERM")
+	}
+
+	waitForProcessExit(t, childPID)
+}
+
 func TestDefaultCommandExecutor_CombinedOutput_CancellationTerminatesDescendants(t *testing.T) {
 	pidFile := filepath.Join(t.TempDir(), "child.pid")
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/ext/command_process_windows.go
+++ b/internal/ext/command_process_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package ext
+
+import (
+	"os/exec"
+)
+
+func configureCommandProcess(cmd *exec.Cmd) {}

--- a/internal/ext/command_process_windows.go
+++ b/internal/ext/command_process_windows.go
@@ -11,9 +11,16 @@ func configureCommandProcess(cmd *exec.Cmd) {}
 
 func configureCommandProcessGroup(cmd *exec.Cmd) {}
 
-func signalCommand(cmd *exec.Cmd, signal os.Signal) error {
+func commandSignals() []os.Signal {
+	return []os.Signal{os.Interrupt}
+}
+
+func signalCommand(cmd *exec.Cmd, _ os.Signal) error {
 	if cmd.Process == nil {
 		return os.ErrProcessDone
 	}
-	return cmd.Process.Signal(signal)
+	// Windows cannot deliver Unix-style graceful signals through os.Process;
+	// every signal except os.Kill returns syscall.EWINDOWS. Kill immediately
+	// instead of waiting through a grace period that cannot succeed.
+	return cmd.Process.Kill()
 }

--- a/internal/ext/command_process_windows.go
+++ b/internal/ext/command_process_windows.go
@@ -3,7 +3,17 @@
 package ext
 
 import (
+	"os"
 	"os/exec"
 )
 
 func configureCommandProcess(cmd *exec.Cmd) {}
+
+func configureCommandProcessGroup(cmd *exec.Cmd) {}
+
+func signalCommand(cmd *exec.Cmd, signal os.Signal) error {
+	if cmd.Process == nil {
+		return os.ErrProcessDone
+	}
+	return cmd.Process.Signal(signal)
+}

--- a/internal/ext/command_test.go
+++ b/internal/ext/command_test.go
@@ -3,6 +3,7 @@ package ext
 import (
 	"context"
 	"os"
+	"os/exec"
 	"strings"
 	"syscall"
 	"testing"
@@ -207,6 +208,47 @@ func TestDefaultCommandExecutor_Run_WithEnvMap(t *testing.T) {
 	}
 }
 
+func TestDefaultCommandExecutor_Run_DoesNotInheritStdin(t *testing.T) {
+	replaceStdin(t, "unexpected input\n")
+
+	err := (&DefaultCommandExecutor{}).Run(
+		context.Background(),
+		"sh",
+		[]string{"-c", `if IFS= read -r line; then exit 1; fi`},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("expected disconnected stdin to return EOF, got %v", err)
+	}
+}
+
+func TestDefaultCommandExecutor_Run_RelineHandlesDisconnectedStdin(t *testing.T) {
+	rubyPath, err := exec.LookPath("ruby")
+	if err != nil {
+		t.Skip("Ruby is required to test Reline")
+	}
+	if err := exec.Command(rubyPath, "-rreline", "-e", "exit").Run(); err != nil {
+		t.Skipf("Reline is unavailable: %v", err)
+	}
+
+	replaceStdin(t, "unexpected input\n")
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	err = (&DefaultCommandExecutor{}).Run(
+		ctx,
+		rubyPath,
+		[]string{
+			"-rreline",
+			"-e",
+			`Reline.output = File.open(File::NULL, "w"); abort "expected Reline to receive EOF" unless Reline.readline("", false).nil?`,
+		},
+		map[string]string{"TERM": "xterm-256color"},
+	)
+	if err != nil {
+		t.Fatalf("Reline did not handle disconnected stdin: %v", err)
+	}
+}
+
 func TestDefaultCommandExecutor_Run_ProcessCompletesNormally(t *testing.T) {
 	executor := &DefaultCommandExecutor{}
 
@@ -337,4 +379,29 @@ func TestDefaultCommandExecutor_Run_SignalForwardingSIGTERM(t *testing.T) {
 	}
 
 	t.Logf("Process correctly terminated with: %v", err)
+}
+
+func replaceStdin(t *testing.T, contents string) {
+	t.Helper()
+
+	stdin, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stdin pipe: %v", err)
+	}
+	if _, err := writer.WriteString(contents); err != nil {
+		_ = stdin.Close()
+		_ = writer.Close()
+		t.Fatalf("write stdin pipe: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		_ = stdin.Close()
+		t.Fatalf("close stdin writer: %v", err)
+	}
+
+	originalStdin := os.Stdin
+	os.Stdin = stdin
+	t.Cleanup(func() {
+		os.Stdin = originalStdin
+		_ = stdin.Close()
+	})
 }

--- a/internal/framework/command_override_test.go
+++ b/internal/framework/command_override_test.go
@@ -2,6 +2,7 @@ package framework
 
 import (
 	"bytes"
+	"context"
 	"log/slog"
 	"slices"
 	"strings"
@@ -297,7 +298,7 @@ func TestLoadCommandOverride_Integration(t *testing.T) {
 				}
 			case "minitest":
 				minitest := NewMinitest()
-				command, args, _ := minitest.getMinitestCommand()
+				command, args, _ := minitest.getMinitestCommand(context.Background())
 
 				if command != tt.expectedCommand {
 					t.Errorf("expected command %q, got %q", tt.expectedCommand, command)

--- a/internal/framework/minitest.go
+++ b/internal/framework/minitest.go
@@ -54,7 +54,7 @@ func (m *Minitest) DiscoverTests(ctx context.Context, testFiles discovery.TestFi
 		return []testoptimization.Test{}, nil
 	}
 
-	executable, args, isRails := m.getMinitestCommand()
+	executable, args, isRails := m.getMinitestCommand(ctx)
 
 	envMap := make(map[string]string)
 	maps.Copy(envMap, m.platformEnv)
@@ -90,7 +90,7 @@ func (m *Minitest) DiscoverTestFiles(ctx context.Context, testFiles discovery.Te
 }
 
 func (m *Minitest) RunTests(ctx context.Context, testFiles []string, envMap map[string]string) error {
-	command, args, isRails := m.getMinitestCommand()
+	command, args, isRails := m.getMinitestCommand(ctx)
 	slog.Info("Running tests with command", "command", command, "args", args)
 
 	// Add test files if provided
@@ -114,9 +114,9 @@ func (m *Minitest) RunTests(ctx context.Context, testFiles []string, envMap map[
 }
 
 // isRailsApplication determines if the current project is a Rails application
-func (m *Minitest) isRailsApplication() bool {
+func (m *Minitest) isRailsApplication(ctx context.Context) bool {
 	// Check if rails gem is installed
-	output, err := m.executor.CombinedOutput(context.Background(), "bundle", []string{"show", "rails"}, nil)
+	output, err := m.executor.CombinedOutput(ctx, "bundle", []string{"show", "rails"}, nil)
 	if err != nil {
 		slog.Debug("Not a Rails application: bundle show rails failed", "output", string(output), "error", err)
 		return false
@@ -134,7 +134,7 @@ func (m *Minitest) isRailsApplication() bool {
 	}
 
 	// Check if rails command works
-	output, err = m.executor.CombinedOutput(context.Background(), "bundle", []string{"exec", "rails", "version"}, nil)
+	output, err = m.executor.CombinedOutput(ctx, "bundle", []string{"exec", "rails", "version"}, nil)
 	if err != nil {
 		slog.Debug("Not a Rails application: bundle exec rails version failed", "output", string(output), "error", err)
 		return false
@@ -153,8 +153,8 @@ func (m *Minitest) isRailsApplication() bool {
 
 // getMinitestCommand determines whether to use rails test or rake test
 // Returns: command, args, isRails
-func (m *Minitest) getMinitestCommand() (string, []string, bool) {
-	isRails := m.isRailsApplication()
+func (m *Minitest) getMinitestCommand(ctx context.Context) (string, []string, bool) {
+	isRails := m.isRailsApplication(ctx)
 	if len(m.commandOverride) > 0 {
 		return m.commandOverride[0], m.commandOverride[1:], isRails
 	}

--- a/internal/framework/minitest_test.go
+++ b/internal/framework/minitest_test.go
@@ -109,7 +109,7 @@ func TestMinitest_getMinitestCommand(t *testing.T) {
 	}
 
 	minitest := newTestMinitestWithExecutor(mockExecutor)
-	command, args, isRails := minitest.getMinitestCommand()
+	command, args, isRails := minitest.getMinitestCommand(context.Background())
 
 	// Verify command structure: bundle exec rake test (non-Rails)
 	if command != "bundle" {
@@ -134,7 +134,7 @@ func TestMinitest_getMinitestCommand(t *testing.T) {
 func TestMinitest_getMinitestCommand_WithOverride(t *testing.T) {
 	mockExecutor := &mockRailsCommandExecutor{isRails: false}
 	minitest := newTestMinitestWithExecutorAndOverride(mockExecutor, []string{"./custom-minitest", "--flag"})
-	command, args, isRails := minitest.getMinitestCommand()
+	command, args, isRails := minitest.getMinitestCommand(context.Background())
 
 	if command != "./custom-minitest" {
 		t.Errorf("expected command to be './custom-minitest', got %q", command)
@@ -478,7 +478,7 @@ func TestMinitest_isRailsApplication_RailsDetected(t *testing.T) {
 	}
 
 	minitest := newTestMinitestWithExecutor(mockExecutor)
-	isRails := minitest.isRailsApplication()
+	isRails := minitest.isRailsApplication(context.Background())
 
 	if !isRails {
 		t.Error("expected Rails to be detected")
@@ -491,7 +491,7 @@ func TestMinitest_isRailsApplication_NoRails(t *testing.T) {
 	}
 
 	minitest := newTestMinitestWithExecutor(mockExecutor)
-	isRails := minitest.isRailsApplication()
+	isRails := minitest.isRailsApplication(context.Background())
 
 	if isRails {
 		t.Error("expected Rails not to be detected")
@@ -555,7 +555,7 @@ func TestMinitest_getMinitestCommand_RailsApplication(t *testing.T) {
 	}
 
 	minitest := newTestMinitestWithExecutor(mockExecutor)
-	command, args, isRails := minitest.getMinitestCommand()
+	command, args, isRails := minitest.getMinitestCommand(context.Background())
 
 	// Verify command structure: bundle exec rails test (Rails)
 	if command != "bundle" {
@@ -1290,7 +1290,7 @@ func TestMinitest_getMinitestCommand_WithBinRails(t *testing.T) {
 	}
 
 	minitest := newTestMinitestWithExecutor(mockExecutor)
-	command, args, isRails := minitest.getMinitestCommand()
+	command, args, isRails := minitest.getMinitestCommand(context.Background())
 
 	if !isRails {
 		t.Error("expected Rails to be detected")
@@ -1328,7 +1328,7 @@ func TestMinitest_getMinitestCommand_WithNonExecutableBinRails(t *testing.T) {
 	}
 
 	minitest := newTestMinitestWithExecutor(mockExecutor)
-	command, args, isRails := minitest.getMinitestCommand()
+	command, args, isRails := minitest.getMinitestCommand(context.Background())
 
 	if !isRails {
 		t.Error("expected Rails to be detected")
@@ -1356,7 +1356,7 @@ func TestMinitest_getMinitestCommand_WithoutBinRails(t *testing.T) {
 	}
 
 	minitest := newTestMinitestWithExecutor(mockExecutor)
-	command, args, isRails := minitest.getMinitestCommand()
+	command, args, isRails := minitest.getMinitestCommand(context.Background())
 
 	if !isRails {
 		t.Error("expected Rails to be detected")
@@ -1452,7 +1452,7 @@ func TestMinitest_getMinitestCommand_RailsApplication_WithBinRails(t *testing.T)
 	}
 
 	minitest := newTestMinitestWithExecutor(mockExecutor)
-	command, args, isRails := minitest.getMinitestCommand()
+	command, args, isRails := minitest.getMinitestCommand(context.Background())
 
 	// Verify command structure: bin/rails test (Rails with bin/rails)
 	if command != "bin/rails" {

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -452,6 +452,9 @@ func (tp *TestPlanner) PreparePlanningData(ctx context.Context) error {
 	if err := g.Wait(); err != nil {
 		return err
 	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 
 	// Full discovery starts optimistically in parallel. If it finishes before
 	// backend data cancels it, use it even when TIA has no skips: full discovery

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -264,13 +264,13 @@ func (tp *TestPlanner) Plan(ctx context.Context) error {
 }
 
 func (tp *TestPlanner) PreparePlanningData(ctx context.Context) error {
-	detectedPlatform, err := tp.platformDetector.DetectPlatform()
+	detectedPlatform, err := tp.platformDetector.DetectPlatform(ctx)
 	if err != nil {
 		return errcode.WithCode(errcode.PlanPlatformDetectionFailed, fmt.Errorf("failed to detect platform: %w", err))
 	}
 
 	// Get platform-detected tags first
-	tags, err := detectedPlatform.CreateTagsMap()
+	tags, err := detectedPlatform.CreateTagsMap(ctx)
 	if err != nil {
 		return errcode.WithCode(errcode.PlanPlatformTagsCreationFailed, fmt.Errorf("failed to create platform tags: %w", err))
 	}

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -2718,6 +2718,33 @@ func TestTestPlanner_PreparePlanningData_CancelsFullDiscoveryWhenNoTIASkippableT
 	}
 }
 
+func TestTestPlanner_PreparePlanningData_ReturnsParentContextCancellation(t *testing.T) {
+	t.Chdir(t.TempDir())
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	mockFramework := &longRunningDiscoveryFramework{
+		MockFramework: MockFramework{
+			FrameworkName: "rspec",
+			TestFiles:     []string{"spec/local_spec.rb"},
+		},
+	}
+	mockPlatform := &MockPlatform{
+		PlatformName: "ruby",
+		Tags:         map[string]string{"platform": "ruby"},
+		Framework:    mockFramework,
+	}
+	runner := NewWithDependencies(
+		&MockPlatformDetector{Platform: mockPlatform},
+		testOptimizationClientRequiringFullDiscovery(),
+		newDefaultMockCIProviderDetector(),
+	)
+
+	if err := runner.PreparePlanningData(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("PreparePlanningData() error = %v, want context cancellation", err)
+	}
+}
+
 func TestTestPlanner_PreparePlanningData_RunsFullDiscoveryInParallelWithBackend(t *testing.T) {
 	t.Chdir(t.TempDir())
 	ctx := context.Background()

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -82,7 +82,7 @@ func (c *plannerTelemetryClient) has(name string, tags ...string) bool {
 	return ok
 }
 
-func (m *MockPlatformDetector) DetectPlatform() (platform.Platform, error) {
+func (m *MockPlatformDetector) DetectPlatform(context.Context) (platform.Platform, error) {
 	return m.Platform, m.Err
 }
 
@@ -101,7 +101,7 @@ func (m *MockPlatform) Name() string {
 	return m.PlatformName
 }
 
-func (m *MockPlatform) CreateTagsMap() (map[string]string, error) {
+func (m *MockPlatform) CreateTagsMap(context.Context) (map[string]string, error) {
 	return m.Tags, m.TagsErr
 }
 
@@ -109,7 +109,7 @@ func (m *MockPlatform) DetectFramework() (framework.Framework, error) {
 	return m.Framework, m.FrameworkErr
 }
 
-func (m *MockPlatform) SanityCheck() error {
+func (m *MockPlatform) SanityCheck(context.Context) error {
 	return m.SanityErr
 }
 

--- a/internal/platform/javascript.go
+++ b/internal/platform/javascript.go
@@ -83,7 +83,7 @@ func addNodeImport(platformEnv map[string]string, module string) map[string]stri
 	return platformEnv
 }
 
-func (j *JavaScript) CreateTagsMap() (map[string]string, error) {
+func (j *JavaScript) CreateTagsMap(ctx context.Context) (map[string]string, error) {
 	tags := make(map[string]string)
 	tags["language"] = j.Name()
 
@@ -97,7 +97,7 @@ func (j *JavaScript) CreateTagsMap() (map[string]string, error) {
 	defer func() { _ = os.Remove(tempFile) }()
 
 	// Execute the embedded JavaScript script to get runtime tags
-	if err := j.executor.Run(context.Background(), "node", []string{"-e", javascriptEnvScript, tempFile}, nil); err != nil {
+	if _, err := j.executor.CombinedOutput(ctx, "node", []string{"-e", javascriptEnvScript, tempFile}, nil); err != nil {
 		return nil, fmt.Errorf("failed to execute JavaScript script: %w", err)
 	}
 
@@ -150,8 +150,8 @@ func (j *JavaScript) DetectFramework() (framework.Framework, error) {
 
 // Confirm that Node.js is installed by running 'node --version'
 // and confirm that the dd-trace package is resolvable
-func (j *JavaScript) SanityCheck() error {
-	if output, err := j.executor.CombinedOutput(context.Background(), "node", []string{"--version"}, nil); err != nil {
+func (j *JavaScript) SanityCheck(ctx context.Context) error {
+	if output, err := j.executor.CombinedOutput(ctx, "node", []string{"--version"}, nil); err != nil {
 		message := strings.TrimSpace(string(output))
 		if message == "" {
 			return fmt.Errorf("node --version command failed: %w", err)
@@ -159,7 +159,7 @@ func (j *JavaScript) SanityCheck() error {
 		return fmt.Errorf("node --version command failed: %s", message)
 	}
 
-	output, err := j.executor.CombinedOutput(context.Background(), "node", []string{"-e", fmt.Sprintf("require.resolve(%q)", ddTraceCIInitModule)}, nil)
+	output, err := j.executor.CombinedOutput(ctx, "node", []string{"-e", fmt.Sprintf("require.resolve(%q)", ddTraceCIInitModule)}, nil)
 	if err != nil {
 		message := strings.TrimSpace(string(output))
 		if message == "" {

--- a/internal/platform/javascript.go
+++ b/internal/platform/javascript.go
@@ -97,8 +97,8 @@ func (j *JavaScript) CreateTagsMap(ctx context.Context) (map[string]string, erro
 	defer func() { _ = os.Remove(tempFile) }()
 
 	// Execute the embedded JavaScript script to get runtime tags
-	if _, err := j.executor.CombinedOutput(ctx, "node", []string{"-e", javascriptEnvScript, tempFile}, nil); err != nil {
-		return nil, fmt.Errorf("failed to execute JavaScript script: %w", err)
+	if output, err := j.executor.CombinedOutput(ctx, "node", []string{"-e", javascriptEnvScript, tempFile}, nil); err != nil {
+		return nil, runtimeTagProbeError("failed to execute JavaScript script", output, err)
 	}
 
 	// Read the JSON output from the temp file

--- a/internal/platform/javascript_test.go
+++ b/internal/platform/javascript_test.go
@@ -3,6 +3,7 @@ package platform
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"os/exec"
 	"strings"
@@ -158,8 +159,12 @@ func TestJavaScript_CreateTagsMap_CommandFailure(t *testing.T) {
 		_ = os.RemoveAll(constants.PlanDirectory)
 	}()
 
+	probeErr := errors.New("probe failed")
 	javascript := &JavaScript{
-		executor: &mockCommandExecutor{combinedOutputErr: &exec.ExitError{}},
+		executor: &mockCommandExecutor{
+			combinedOutput:    []byte(" Invalid NODE_OPTIONS\n"),
+			combinedOutputErr: probeErr,
+		},
 	}
 
 	tags, err := javascript.CreateTagsMap(context.Background())
@@ -171,6 +176,12 @@ func TestJavaScript_CreateTagsMap_CommandFailure(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "failed to execute JavaScript script") {
 		t.Errorf("expected JavaScript execution error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "Invalid NODE_OPTIONS") {
+		t.Errorf("expected error to include probe output, got %q", err.Error())
+	}
+	if !errors.Is(err, probeErr) {
+		t.Errorf("expected error to wrap probe failure, got %v", err)
 	}
 }
 

--- a/internal/platform/javascript_test.go
+++ b/internal/platform/javascript_test.go
@@ -117,7 +117,7 @@ func TestJavaScript_CreateTagsMap_Success(t *testing.T) {
 	}
 
 	mockExecutor := &mockCommandExecutor{
-		onRun: func(name string, args []string, envMap map[string]string) {
+		onCombinedOutput: func(name string, args []string, envMap map[string]string) {
 			if name != "node" {
 				t.Errorf("expected command to be 'node', got %q", name)
 			}
@@ -138,7 +138,7 @@ func TestJavaScript_CreateTagsMap_Success(t *testing.T) {
 	}
 
 	javascript := &JavaScript{executor: mockExecutor}
-	tags, err := javascript.CreateTagsMap()
+	tags, err := javascript.CreateTagsMap(context.Background())
 	if err != nil {
 		t.Fatalf("CreateTagsMap failed: %v", err)
 	}
@@ -159,10 +159,10 @@ func TestJavaScript_CreateTagsMap_CommandFailure(t *testing.T) {
 	}()
 
 	javascript := &JavaScript{
-		executor: &mockCommandExecutor{runErr: &exec.ExitError{}},
+		executor: &mockCommandExecutor{combinedOutputErr: &exec.ExitError{}},
 	}
 
-	tags, err := javascript.CreateTagsMap()
+	tags, err := javascript.CreateTagsMap(context.Background())
 	if err == nil {
 		t.Fatal("expected error when node command fails")
 	}
@@ -180,7 +180,7 @@ func TestJavaScript_CreateTagsMap_InvalidJSON(t *testing.T) {
 	}()
 
 	mockExecutor := &mockCommandExecutor{
-		onRun: func(name string, args []string, envMap map[string]string) {
+		onCombinedOutput: func(name string, args []string, envMap map[string]string) {
 			if err := os.WriteFile(args[2], []byte("{invalid json}"), 0644); err != nil {
 				t.Errorf("failed to write temp file: %v", err)
 			}
@@ -188,7 +188,7 @@ func TestJavaScript_CreateTagsMap_InvalidJSON(t *testing.T) {
 	}
 
 	javascript := &JavaScript{executor: mockExecutor}
-	tags, err := javascript.CreateTagsMap()
+	tags, err := javascript.CreateTagsMap(context.Background())
 	if err == nil {
 		t.Fatal("expected error when JSON is invalid")
 	}
@@ -414,7 +414,7 @@ func TestJavaScript_SanityCheck_Passes(t *testing.T) {
 	}
 
 	javascript := &JavaScript{executor: mockExecutor}
-	if err := javascript.SanityCheck(); err != nil {
+	if err := javascript.SanityCheck(context.Background()); err != nil {
 		t.Fatalf("SanityCheck() unexpected error: %v", err)
 	}
 	if calls != 2 {
@@ -430,7 +430,7 @@ func TestJavaScript_SanityCheck_FailsWhenNodeMissing(t *testing.T) {
 		},
 	}
 
-	err := javascript.SanityCheck()
+	err := javascript.SanityCheck(context.Background())
 	if err == nil {
 		t.Fatal("expected sanity check error")
 	}
@@ -469,7 +469,7 @@ func TestJavaScript_SanityCheck_FailsWhenDDTraceMissing(t *testing.T) {
 	}
 
 	javascript := &JavaScript{executor: mockExecutor}
-	err := javascript.SanityCheck()
+	err := javascript.SanityCheck(context.Background())
 	if err == nil {
 		t.Fatal("expected sanity check error when dd-trace is missing")
 	}
@@ -527,7 +527,7 @@ func TestJavaScript_SanityCheck_NodeFailsEmptyOutput(t *testing.T) {
 		},
 	}
 
-	err := javascript.SanityCheck()
+	err := javascript.SanityCheck(context.Background())
 	if err == nil {
 		t.Fatal("expected sanity check error")
 	}
@@ -548,7 +548,7 @@ func TestJavaScript_SanityCheck_DDTraceFailsEmptyOutput(t *testing.T) {
 	}
 
 	javascript := &JavaScript{executor: mockExecutor}
-	err := javascript.SanityCheck()
+	err := javascript.SanityCheck(context.Background())
 	if err == nil {
 		t.Fatal("expected sanity check error when dd-trace resolve fails with empty output")
 	}
@@ -566,7 +566,7 @@ func TestDetectPlatform_JavaScript(t *testing.T) {
 		settings.Init()
 	}()
 
-	platform, err := DetectPlatform()
+	platform, err := DetectPlatform(context.Background())
 	if err != nil {
 		// SanityCheck failed — verify the error names the javascript platform
 		if !strings.Contains(err.Error(), "javascript") {

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -1,6 +1,7 @@
 package platform
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/DataDog/ddtest/internal/framework"
@@ -9,24 +10,24 @@ import (
 
 type Platform interface {
 	Name() string
-	CreateTagsMap() (map[string]string, error)
+	CreateTagsMap(ctx context.Context) (map[string]string, error)
 	DetectFramework() (framework.Framework, error)
-	SanityCheck() error
+	SanityCheck(ctx context.Context) error
 	TestSkippingLevel() settings.TestSkippingLevel
 }
 
 // PlatformDetector defines interface for detecting platforms - needed to allow mocking in tests
 type PlatformDetector interface {
-	DetectPlatform() (Platform, error)
+	DetectPlatform(ctx context.Context) (Platform, error)
 }
 
 type DatadogPlatformDetector struct{}
 
-func (d *DatadogPlatformDetector) DetectPlatform() (Platform, error) {
-	return DetectPlatform()
+func (d *DatadogPlatformDetector) DetectPlatform(ctx context.Context) (Platform, error) {
+	return DetectPlatform(ctx)
 }
 
-func DetectPlatform() (Platform, error) {
+func DetectPlatform(ctx context.Context) (Platform, error) {
 	platformName := settings.GetPlatform()
 
 	var platform Platform
@@ -41,7 +42,7 @@ func DetectPlatform() (Platform, error) {
 		return nil, fmt.Errorf("unsupported platform: %s", platformName)
 	}
 
-	if err := platform.SanityCheck(); err != nil {
+	if err := platform.SanityCheck(ctx); err != nil {
 		return nil, fmt.Errorf("sanity check failed for platform %s: %w", platform.Name(), err)
 	}
 

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -3,6 +3,7 @@ package platform
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/DataDog/ddtest/internal/framework"
 	"github.com/DataDog/ddtest/internal/settings"
@@ -22,6 +23,13 @@ type PlatformDetector interface {
 }
 
 type DatadogPlatformDetector struct{}
+
+func runtimeTagProbeError(message string, output []byte, err error) error {
+	if diagnostic := strings.TrimSpace(string(output)); diagnostic != "" {
+		return fmt.Errorf("%s: %s: %w", message, diagnostic, err)
+	}
+	return fmt.Errorf("%s: %w", message, err)
+}
 
 func (d *DatadogPlatformDetector) DetectPlatform(ctx context.Context) (Platform, error) {
 	return DetectPlatform(ctx)

--- a/internal/platform/platform_test.go
+++ b/internal/platform/platform_test.go
@@ -1,6 +1,7 @@
 package platform
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -14,6 +15,53 @@ import (
 func TestNewPlatformDetector(t *testing.T) {
 	if _, ok := NewPlatformDetector().(*DatadogPlatformDetector); !ok {
 		t.Fatal("expected NewPlatformDetector to return DatadogPlatformDetector")
+	}
+}
+
+func TestPlatformSanityChecksPropagateContext(t *testing.T) {
+	type contextKey struct{}
+	ctx := context.WithValue(context.Background(), contextKey{}, "sanity-check")
+
+	tests := []struct {
+		name   string
+		output []byte
+	}{
+		{name: "ruby", output: []byte("  * datadog-ci (1.31.0)\n")},
+		{name: "python", output: []byte("4.10.3\n")},
+		{name: "javascript", output: []byte("v24.0.0\n")},
+	}
+
+	for i := range tests {
+		t.Run(tests[i].name, func(t *testing.T) {
+			executor := &mockCommandExecutor{combinedOutput: tests[i].output}
+			var check func(context.Context) error
+			switch tests[i].name {
+			case "ruby":
+				platform := NewRuby(settings.TestSkippingLevelTest)
+				platform.executor = executor
+				check = platform.SanityCheck
+			case "python":
+				platform := NewPython()
+				platform.executor = executor
+				check = platform.SanityCheck
+			case "javascript":
+				platform := NewJavaScript()
+				platform.executor = executor
+				check = platform.SanityCheck
+			}
+
+			if err := check(ctx); err != nil {
+				t.Fatalf("SanityCheck() failed: %v", err)
+			}
+			if len(executor.combinedOutputCtx) == 0 {
+				t.Fatal("SanityCheck() did not execute a command")
+			}
+			for _, got := range executor.combinedOutputCtx {
+				if got != ctx {
+					t.Fatal("SanityCheck() did not propagate its context")
+				}
+			}
+		})
 	}
 }
 
@@ -38,7 +86,7 @@ func TestDetectPlatformPythonWithFakeInterpreter(t *testing.T) {
 	viper.Set("platform", "python")
 	settings.Init()
 
-	detectedPlatform, err := DetectPlatform()
+	detectedPlatform, err := DetectPlatform(context.Background())
 	if err != nil {
 		t.Fatalf("DetectPlatform() unexpected error: %v", err)
 	}
@@ -59,13 +107,13 @@ func TestDetectPlatformUnsupported(t *testing.T) {
 	t.Setenv("DD_TEST_OPTIMIZATION_RUNNER_PLATFORM", "node")
 	settings.Init()
 
-	_, err := DetectPlatform()
+	_, err := DetectPlatform(context.Background())
 	if err == nil || !strings.Contains(err.Error(), "unsupported platform: node") {
 		t.Fatalf("DetectPlatform() error = %v, want unsupported platform", err)
 	}
 
 	detector := &DatadogPlatformDetector{}
-	_, err = detector.DetectPlatform()
+	_, err = detector.DetectPlatform(context.Background())
 	if err == nil || !strings.Contains(err.Error(), "unsupported platform: node") {
 		t.Fatalf("DatadogPlatformDetector.DetectPlatform() error = %v, want unsupported platform", err)
 	}

--- a/internal/platform/python.go
+++ b/internal/platform/python.go
@@ -72,7 +72,7 @@ func (p *Python) GetPlatformEnv() map[string]string {
 	return envMap
 }
 
-func (p *Python) CreateTagsMap() (map[string]string, error) {
+func (p *Python) CreateTagsMap(ctx context.Context) (map[string]string, error) {
 	tags := make(map[string]string)
 	tags["language"] = p.Name()
 
@@ -87,7 +87,7 @@ func (p *Python) CreateTagsMap() (map[string]string, error) {
 
 	// Execute the embedded Python script to get runtime tags
 	args := []string{"-c", pythonEnvScript, tempFile}
-	if err := p.executor.Run(context.Background(), "python", args, nil); err != nil {
+	if _, err := p.executor.CombinedOutput(ctx, "python", args, nil); err != nil {
 		return nil, fmt.Errorf("failed to execute Python script: %w", err)
 	}
 
@@ -125,7 +125,7 @@ func (p *Python) DetectFramework() (framework.Framework, error) {
 	return fw, nil
 }
 
-func (p *Python) SanityCheck() error {
+func (p *Python) SanityCheck(ctx context.Context) error {
 	// Use importlib.metadata to query the installed version — works with any
 	// package manager (pip, uv, poetry, conda), unlike `pip show`.
 	args := []string{
@@ -133,7 +133,7 @@ func (p *Python) SanityCheck() error {
 		"import importlib.metadata, sys; print(importlib.metadata.version(sys.argv[1]))",
 		requiredPackageName,
 	}
-	output, err := p.executor.CombinedOutput(context.Background(), "python", args, nil)
+	output, err := p.executor.CombinedOutput(ctx, "python", args, nil)
 	if err != nil {
 		return fmt.Errorf("%s is not installed: %w", requiredPackageName, err)
 	}

--- a/internal/platform/python.go
+++ b/internal/platform/python.go
@@ -87,8 +87,8 @@ func (p *Python) CreateTagsMap(ctx context.Context) (map[string]string, error) {
 
 	// Execute the embedded Python script to get runtime tags
 	args := []string{"-c", pythonEnvScript, tempFile}
-	if _, err := p.executor.CombinedOutput(ctx, "python", args, nil); err != nil {
-		return nil, fmt.Errorf("failed to execute Python script: %w", err)
+	if output, err := p.executor.CombinedOutput(ctx, "python", args, nil); err != nil {
+		return nil, runtimeTagProbeError("failed to execute Python script", output, err)
 	}
 
 	// Read the JSON output from the temp file

--- a/internal/platform/python_test.go
+++ b/internal/platform/python_test.go
@@ -1,6 +1,7 @@
 package platform
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"os/exec"
@@ -49,7 +50,7 @@ func TestPython_SanityCheck_SuccessWithPreRelease(t *testing.T) {
 	}
 	python := NewPython()
 	python.executor = mockExecutor
-	if err := python.SanityCheck(); err != nil {
+	if err := python.SanityCheck(context.Background()); err != nil {
 		t.Fatalf("SanityCheck() unexpected error for pre-release version: %v", err)
 	}
 }
@@ -72,7 +73,7 @@ func TestPython_SanityCheck_Success(t *testing.T) {
 
 	python := NewPython()
 	python.executor = mockExecutor
-	if err := python.SanityCheck(); err != nil {
+	if err := python.SanityCheck(context.Background()); err != nil {
 		t.Fatalf("SanityCheck() unexpected error: %v", err)
 	}
 }
@@ -85,7 +86,7 @@ func TestPython_SanityCheck_NotInstalled(t *testing.T) {
 
 	python := NewPython()
 	python.executor = mockExecutor
-	err := python.SanityCheck()
+	err := python.SanityCheck(context.Background())
 	if err == nil {
 		t.Fatal("SanityCheck() expected error when package is not installed")
 	}
@@ -102,7 +103,7 @@ func TestPython_SanityCheck_VersionTooOld(t *testing.T) {
 
 	python := NewPython()
 	python.executor = mockExecutor
-	err := python.SanityCheck()
+	err := python.SanityCheck(context.Background())
 	if err == nil {
 		t.Fatal("SanityCheck() expected error for outdated ddtrace version")
 	}
@@ -122,7 +123,7 @@ func TestPython_SanityCheck_InvalidVersion(t *testing.T) {
 
 	python := NewPython()
 	python.executor = mockExecutor
-	err := python.SanityCheck()
+	err := python.SanityCheck(context.Background())
 	if err == nil {
 		t.Fatal("SanityCheck() expected error for unparseable version")
 	}
@@ -185,7 +186,7 @@ func TestPython_CreateTagsMap_Success(t *testing.T) {
 	}
 
 	mockExecutor := &mockCommandExecutor{
-		onRun: func(name string, args []string, envMap map[string]string) {
+		onCombinedOutput: func(name string, args []string, envMap map[string]string) {
 			if name != "python" {
 				t.Errorf("expected command 'python', got %q", name)
 			}
@@ -210,7 +211,7 @@ func TestPython_CreateTagsMap_Success(t *testing.T) {
 	}
 
 	python := &Python{executor: mockExecutor}
-	tags, err := python.CreateTagsMap()
+	tags, err := python.CreateTagsMap(context.Background())
 	if err != nil {
 		t.Fatalf("CreateTagsMap failed: %v", err)
 	}
@@ -232,11 +233,11 @@ func TestPython_CreateTagsMap_CommandFailure(t *testing.T) {
 	defer func() { _ = os.RemoveAll(constants.PlanDirectory) }()
 
 	mockExecutor := &mockCommandExecutor{
-		runErr: &exec.ExitError{},
+		combinedOutputErr: &exec.ExitError{},
 	}
 
 	python := &Python{executor: mockExecutor}
-	tags, err := python.CreateTagsMap()
+	tags, err := python.CreateTagsMap(context.Background())
 
 	if err == nil {
 		t.Error("expected error when python command fails")
@@ -256,7 +257,7 @@ func TestPython_CreateTagsMap_InvalidJSON(t *testing.T) {
 
 	invalidJSON := `{invalid json}`
 	mockExecutor := &mockCommandExecutor{
-		onRun: func(name string, args []string, envMap map[string]string) {
+		onCombinedOutput: func(name string, args []string, envMap map[string]string) {
 			if len(args) < 3 {
 				t.Errorf("expected at least 3 args, got %d", len(args))
 				return
@@ -269,7 +270,7 @@ func TestPython_CreateTagsMap_InvalidJSON(t *testing.T) {
 	}
 
 	python := &Python{executor: mockExecutor}
-	tags, err := python.CreateTagsMap()
+	tags, err := python.CreateTagsMap(context.Background())
 
 	if err == nil {
 		t.Error("expected error when JSON is invalid")
@@ -382,7 +383,7 @@ func TestDetectPlatform_Python(t *testing.T) {
 		settings.Init()
 	}()
 
-	platform, err := DetectPlatform()
+	platform, err := DetectPlatform(context.Background())
 	if err != nil {
 		t.Fatalf("DetectPlatform() unexpected error: %v", err)
 	}

--- a/internal/platform/python_test.go
+++ b/internal/platform/python_test.go
@@ -3,6 +3,7 @@ package platform
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"os/exec"
 	"strings"
@@ -232,8 +233,10 @@ func TestPython_CreateTagsMap_Success(t *testing.T) {
 func TestPython_CreateTagsMap_CommandFailure(t *testing.T) {
 	defer func() { _ = os.RemoveAll(constants.PlanDirectory) }()
 
+	probeErr := errors.New("probe failed")
 	mockExecutor := &mockCommandExecutor{
-		combinedOutputErr: &exec.ExitError{},
+		combinedOutput:    []byte(" Python startup hook failed\n"),
+		combinedOutputErr: probeErr,
 	}
 
 	python := &Python{executor: mockExecutor}
@@ -249,6 +252,12 @@ func TestPython_CreateTagsMap_CommandFailure(t *testing.T) {
 	expectedPrefix := "failed to execute Python script"
 	if !strings.HasPrefix(err.Error(), expectedPrefix) {
 		t.Errorf("expected error to start with %q, got %q", expectedPrefix, err.Error())
+	}
+	if !strings.Contains(err.Error(), "Python startup hook failed") {
+		t.Errorf("expected error to include probe output, got %q", err.Error())
+	}
+	if !errors.Is(err, probeErr) {
+		t.Errorf("expected error to wrap probe failure, got %v", err)
 	}
 }
 

--- a/internal/platform/ruby.go
+++ b/internal/platform/ruby.go
@@ -63,7 +63,7 @@ func (r *Ruby) GetPlatformEnv() map[string]string {
 	return envMap
 }
 
-func (r *Ruby) CreateTagsMap() (map[string]string, error) {
+func (r *Ruby) CreateTagsMap(ctx context.Context) (map[string]string, error) {
 	tags := make(map[string]string)
 	tags["language"] = r.Name()
 
@@ -78,7 +78,7 @@ func (r *Ruby) CreateTagsMap() (map[string]string, error) {
 
 	// Execute the embedded Ruby script to get runtime tags
 	args := []string{"exec", "ruby", "-e", rubyEnvScript, tempFile}
-	if err := r.executor.Run(context.Background(), "bundle", args, nil); err != nil {
+	if _, err := r.executor.CombinedOutput(ctx, "bundle", args, nil); err != nil {
 		return nil, fmt.Errorf("failed to execute Ruby script: %w", err)
 	}
 
@@ -118,9 +118,9 @@ func (r *Ruby) DetectFramework() (framework.Framework, error) {
 	return fw, nil
 }
 
-func (r *Ruby) SanityCheck() error {
+func (r *Ruby) SanityCheck(ctx context.Context) error {
 	args := []string{"info", requiredGemName}
-	output, err := r.executor.CombinedOutput(context.Background(), "bundle", args, nil)
+	output, err := r.executor.CombinedOutput(ctx, "bundle", args, nil)
 	if err != nil {
 		message := strings.TrimSpace(string(output))
 		if message == "" {

--- a/internal/platform/ruby.go
+++ b/internal/platform/ruby.go
@@ -78,8 +78,8 @@ func (r *Ruby) CreateTagsMap(ctx context.Context) (map[string]string, error) {
 
 	// Execute the embedded Ruby script to get runtime tags
 	args := []string{"exec", "ruby", "-e", rubyEnvScript, tempFile}
-	if _, err := r.executor.CombinedOutput(ctx, "bundle", args, nil); err != nil {
-		return nil, fmt.Errorf("failed to execute Ruby script: %w", err)
+	if output, err := r.executor.CombinedOutput(ctx, "bundle", args, nil); err != nil {
+		return nil, runtimeTagProbeError("failed to execute Ruby script", output, err)
 	}
 
 	// Read the JSON output from the temp file

--- a/internal/platform/ruby_test.go
+++ b/internal/platform/ruby_test.go
@@ -3,6 +3,7 @@ package platform
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"os/exec"
 	"strings"
@@ -329,8 +330,10 @@ func TestRuby_CreateTagsMap_CommandFailure(t *testing.T) {
 		_ = os.RemoveAll(constants.PlanDirectory)
 	}()
 
+	probeErr := errors.New("probe failed")
 	mockExecutor := &mockCommandExecutor{
-		combinedOutputErr: &exec.ExitError{},
+		combinedOutput:    []byte(" Bundler setup failed\n"),
+		combinedOutputErr: probeErr,
 		onCombinedOutput: func(name string, args []string, envMap map[string]string) {
 			// Command fails, don't create any file
 		},
@@ -352,6 +355,12 @@ func TestRuby_CreateTagsMap_CommandFailure(t *testing.T) {
 	expectedErrorMsg := "failed to execute Ruby script"
 	if err == nil || len(err.Error()) < len(expectedErrorMsg) || err.Error()[:len(expectedErrorMsg)] != expectedErrorMsg {
 		t.Errorf("expected error to start with %q, got %q", expectedErrorMsg, err.Error())
+	}
+	if !strings.Contains(err.Error(), "Bundler setup failed") {
+		t.Errorf("expected error to include probe output, got %q", err.Error())
+	}
+	if !errors.Is(err, probeErr) {
+		t.Errorf("expected error to wrap probe failure, got %v", err)
 	}
 }
 

--- a/internal/platform/ruby_test.go
+++ b/internal/platform/ruby_test.go
@@ -17,11 +17,13 @@ type mockCommandExecutor struct {
 	runErr            error
 	combinedOutput    []byte
 	combinedOutputErr error
+	combinedOutputCtx []context.Context
 	onRun             func(name string, args []string, envMap map[string]string)
 	onCombinedOutput  func(name string, args []string, envMap map[string]string)
 }
 
 func (m *mockCommandExecutor) CombinedOutput(ctx context.Context, name string, args []string, envMap map[string]string) ([]byte, error) {
+	m.combinedOutputCtx = append(m.combinedOutputCtx, ctx)
 	if m.onCombinedOutput != nil {
 		m.onCombinedOutput(name, args, envMap)
 	}
@@ -83,7 +85,7 @@ func TestRuby_SanityCheck_Passes(t *testing.T) {
 
 	ruby := newTestRuby()
 	ruby.executor = mockExecutor
-	if err := ruby.SanityCheck(); err != nil {
+	if err := ruby.SanityCheck(context.Background()); err != nil {
 		t.Fatalf("SanityCheck() unexpected error: %v", err)
 	}
 }
@@ -96,7 +98,7 @@ func TestRuby_SanityCheck_FailsWhenBundleInfoFails(t *testing.T) {
 
 	ruby := newTestRuby()
 	ruby.executor = mockExecutor
-	err := ruby.SanityCheck()
+	err := ruby.SanityCheck(context.Background())
 	if err == nil {
 		t.Fatal("SanityCheck() expected error when bundle info fails")
 	}
@@ -113,7 +115,7 @@ func TestRuby_SanityCheck_FailsWhenVersionTooLow(t *testing.T) {
 
 	ruby := newTestRuby()
 	ruby.executor = mockExecutor
-	err := ruby.SanityCheck()
+	err := ruby.SanityCheck(context.Background())
 	if err == nil {
 		t.Fatal("SanityCheck() expected error for outdated datadog-ci version")
 	}
@@ -133,7 +135,7 @@ func TestRuby_SanityCheck_FailsWhenVersionNotFound(t *testing.T) {
 
 	ruby := newTestRuby()
 	ruby.executor = mockExecutor
-	err := ruby.SanityCheck()
+	err := ruby.SanityCheck(context.Background())
 	if err == nil {
 		t.Fatal("SanityCheck() expected error when version is not found")
 	}
@@ -158,7 +160,7 @@ func TestRuby_SanityCheck_SucceedsWithDebugLogs(t *testing.T) {
 
 	ruby := newTestRuby()
 	ruby.executor = mockExecutor
-	if err := ruby.SanityCheck(); err != nil {
+	if err := ruby.SanityCheck(context.Background()); err != nil {
 		t.Fatalf("SanityCheck() unexpected error: %v", err)
 	}
 }
@@ -260,7 +262,7 @@ func TestRuby_CreateTagsMap_Success(t *testing.T) {
 	}
 
 	mockExecutor := &mockCommandExecutor{
-		onRun: func(name string, args []string, envMap map[string]string) {
+		onCombinedOutput: func(name string, args []string, envMap map[string]string) {
 			// Verify the command is correct
 			if name != "bundle" {
 				t.Errorf("expected command to be 'bundle', got %q", name)
@@ -302,7 +304,7 @@ func TestRuby_CreateTagsMap_Success(t *testing.T) {
 		executor: mockExecutor,
 	}
 
-	tags, err := ruby.CreateTagsMap()
+	tags, err := ruby.CreateTagsMap(context.Background())
 	if err != nil {
 		t.Fatalf("CreateTagsMap failed: %v", err)
 	}
@@ -328,8 +330,8 @@ func TestRuby_CreateTagsMap_CommandFailure(t *testing.T) {
 	}()
 
 	mockExecutor := &mockCommandExecutor{
-		runErr: &exec.ExitError{},
-		onRun: func(name string, args []string, envMap map[string]string) {
+		combinedOutputErr: &exec.ExitError{},
+		onCombinedOutput: func(name string, args []string, envMap map[string]string) {
 			// Command fails, don't create any file
 		},
 	}
@@ -338,7 +340,7 @@ func TestRuby_CreateTagsMap_CommandFailure(t *testing.T) {
 		executor: mockExecutor,
 	}
 
-	tags, err := ruby.CreateTagsMap()
+	tags, err := ruby.CreateTagsMap(context.Background())
 	if err == nil {
 		t.Error("expected error when ruby command fails")
 	}
@@ -361,7 +363,7 @@ func TestRuby_CreateTagsMap_InvalidJSON(t *testing.T) {
 
 	invalidJSON := `{invalid json}`
 	mockExecutor := &mockCommandExecutor{
-		onRun: func(name string, args []string, envMap map[string]string) {
+		onCombinedOutput: func(name string, args []string, envMap map[string]string) {
 			// Get the temp file path from the last argument
 			if len(args) < 5 {
 				t.Errorf("expected at least 5 args, got %d", len(args))
@@ -380,7 +382,7 @@ func TestRuby_CreateTagsMap_InvalidJSON(t *testing.T) {
 		executor: mockExecutor,
 	}
 
-	tags, err := ruby.CreateTagsMap()
+	tags, err := ruby.CreateTagsMap(context.Background())
 	if err == nil {
 		t.Error("expected error when JSON is invalid")
 	}
@@ -421,7 +423,7 @@ func TestDetectPlatform_Ruby(t *testing.T) {
 	viper.Reset()
 	viper.Set("platform", "ruby")
 
-	platform, err := DetectPlatform()
+	platform, err := DetectPlatform(context.Background())
 	if err == nil {
 		t.Errorf("expected error for SanityCheck failure, but got platform: %v", platform)
 	} else if platform != nil {
@@ -443,7 +445,7 @@ func TestDetectPlatform_Unsupported(t *testing.T) {
 		settings.Init()
 	}()
 
-	platform, err := DetectPlatform()
+	platform, err := DetectPlatform(context.Background())
 	if err == nil {
 		t.Errorf("expected error for unsupported platform, but got platform: %v", platform)
 		return

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -99,7 +99,7 @@ func (tr *TestRunner) Run(ctx context.Context) error {
 	slog.Info("Worker environment variables", "workerEnvKeys", workerEnvKeys(workerEnvMap))
 
 	// Detect platform and framework
-	detectedPlatform, err := tr.platformDetector.DetectPlatform()
+	detectedPlatform, err := tr.platformDetector.DetectPlatform(ctx)
 	if err != nil {
 		return errcode.WithCode(errcode.RunPlatformDetectionFailed, fmt.Errorf("failed to detect platform: %w", err))
 	}

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -145,6 +145,34 @@ func TestTestRunner_Run_UsesExistingArtifactsWithoutPlanning(t *testing.T) {
 	}
 }
 
+func TestTestRunner_Run_PropagatesContextForGracefulTestCancellation(t *testing.T) {
+	withRunnerTestSettings(t)
+	chdirTemp(t)
+	writeRunnerTestFile(t, constants.ParallelRunnersOutputPath, "1")
+	writeRunnerTestFile(t, constants.TestFilesOutputPath, "spec/existing_spec.rb\n")
+
+	type contextKey struct{}
+	ctx := context.WithValue(context.Background(), contextKey{}, "test-run")
+	framework := &MockFramework{FrameworkName: "rspec"}
+	platform := &MockPlatform{PlatformName: "ruby", Framework: framework}
+	runner := NewWithDependencies(&MockPlatformDetector{Platform: platform}, &fakePlanner{})
+
+	if err := runner.Run(ctx); err != nil {
+		t.Fatalf("Run() returned error: %v", err)
+	}
+
+	calls := framework.GetRunTestsCalls()
+	if len(calls) != 1 {
+		t.Fatalf("RunTests() calls = %d, want 1", len(calls))
+	}
+	if got := calls[0].Context.Value(contextKey{}); got != "test-run" {
+		t.Fatalf("test context value = %v, want test-run", got)
+	}
+	if calls[0].Context != ctx {
+		t.Fatal("test command did not receive the runner context")
+	}
+}
+
 func TestTestRunner_Run_ReturnsErrorWhenPlanUnavailable(t *testing.T) {
 	withRunnerTestSettings(t)
 	chdirTemp(t)

--- a/internal/runner/test_helpers_test.go
+++ b/internal/runner/test_helpers_test.go
@@ -33,7 +33,7 @@ type MockPlatformDetector struct {
 	Err      error
 }
 
-func (m *MockPlatformDetector) DetectPlatform() (platform.Platform, error) {
+func (m *MockPlatformDetector) DetectPlatform(context.Context) (platform.Platform, error) {
 	return m.Platform, m.Err
 }
 
@@ -51,7 +51,7 @@ func (m *MockPlatform) Name() string {
 	return m.PlatformName
 }
 
-func (m *MockPlatform) CreateTagsMap() (map[string]string, error) {
+func (m *MockPlatform) CreateTagsMap(context.Context) (map[string]string, error) {
 	return m.Tags, m.TagsErr
 }
 
@@ -59,7 +59,7 @@ func (m *MockPlatform) DetectFramework() (framework.Framework, error) {
 	return m.Framework, m.FrameworkErr
 }
 
-func (m *MockPlatform) SanityCheck() error {
+func (m *MockPlatform) SanityCheck(context.Context) error {
 	return m.SanityErr
 }
 
@@ -86,6 +86,7 @@ type MockFramework struct {
 type RunTestsCall struct {
 	TestFiles []string
 	EnvMap    map[string]string
+	Context   context.Context
 }
 
 func (m *MockFramework) Name() string {
@@ -119,6 +120,7 @@ func (m *MockFramework) RunTests(ctx context.Context, testFiles []string, envMap
 	m.RunTestsCalls = append(m.RunTestsCalls, RunTestsCall{
 		TestFiles: slices.Clone(testFiles),
 		EnvMap:    maps.Clone(envMap),
+		Context:   ctx,
 	})
 	return m.Err
 }

--- a/internal/testoptimization/telemetry_test.go
+++ b/internal/testoptimization/telemetry_test.go
@@ -17,13 +17,11 @@ import (
 	"github.com/DataDog/ddtest/internal/git/gittest"
 	"github.com/DataDog/ddtest/internal/settings"
 	"github.com/DataDog/ddtest/internal/telemetry"
-	"github.com/DataDog/ddtest/internal/testoptimization/api"
 )
 
 type optimizationTelemetryClient struct {
 	mu      sync.Mutex
 	metrics map[string]float64
-	flushes int
 }
 
 type optimizationTelemetryMetric struct {
@@ -40,9 +38,6 @@ func (c *optimizationTelemetryClient) Distribution(name string, _ []string) tele
 }
 
 func (c *optimizationTelemetryClient) Flush(context.Context) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.flushes++
 	return nil
 }
 
@@ -56,12 +51,6 @@ func (c *optimizationTelemetryClient) value(name string) float64 {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.metrics[name]
-}
-
-func (c *optimizationTelemetryClient) flushCount() int {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.flushes
 }
 
 func TestNewTestOptimizationClientWithTelemetryWiresBackendTransport(t *testing.T) {
@@ -114,20 +103,5 @@ func TestNewTestOptimizationClientWithTelemetryWiresBackendTransport(t *testing.
 	}
 	if _, ok := recorder.metrics["git.command_ms"]; !ok {
 		t.Error("Git command duration was not recorded")
-	}
-}
-
-func TestTestOptimizationClientHandleSignalFlushesTelemetry(t *testing.T) {
-	recorder := &optimizationTelemetryClient{metrics: make(map[string]float64)}
-	client := newTestOptimizationClient(nil, nil, nil, false)
-	client.telemetryClient = recorder
-	client.settingsOnce.Do(func() {
-		client.settings = &api.SettingsResponseData{}
-	})
-
-	client.handleSignal()
-
-	if got := recorder.flushCount(); got != 1 {
-		t.Fatalf("telemetry flush count = %d, want 1", got)
 	}
 }

--- a/internal/testoptimization/testoptimization.go
+++ b/internal/testoptimization/testoptimization.go
@@ -72,7 +72,9 @@ func NewTestOptimizationClientWithTelemetry(testSkippingLevel settings.TestSkipp
 	newAPITransport := func(serviceName string, level settings.TestSkippingLevel) api.Transport {
 		return api.NewTransportWithTelemetry(serviceName, level, telemetryClient)
 	}
-	client := newTestOptimizationClientWithTestSkippingLevel(nil, newAPITransport, nil, true, testSkippingLevel)
+	// The CLI owns signal cancellation so in-flight discovery commands can stop
+	// their process groups before the process exits.
+	client := newTestOptimizationClientWithTestSkippingLevel(nil, newAPITransport, nil, false, testSkippingLevel)
 	client.gitCommands = git.NewCommandRunner(telemetry.NewGitCommandTelemetry(telemetryClient))
 	client.telemetryClient = telemetryClient
 	return client

--- a/internal/testoptimization/testoptimization.go
+++ b/internal/testoptimization/testoptimization.go
@@ -1,15 +1,12 @@
 package testoptimization
 
 import (
-	"context"
 	"fmt"
 	"log/slog"
 	"os"
-	"os/signal"
 	"path/filepath"
 	"slices"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/DataDog/ddtest/internal/constants"
@@ -39,8 +36,6 @@ type TestOptimizationClient struct {
 	cacheManager              *CacheManager
 	gitCommands               *git.CommandRunner
 	repositoryChangesUploader func() (int64, error)
-	enableSignalHandler       bool
-	telemetryClient           telemetry.Client
 
 	initializationOnce   sync.Once
 	settingsOnce         sync.Once
@@ -72,29 +67,24 @@ func NewTestOptimizationClientWithTelemetry(testSkippingLevel settings.TestSkipp
 	newAPITransport := func(serviceName string, level settings.TestSkippingLevel) api.Transport {
 		return api.NewTransportWithTelemetry(serviceName, level, telemetryClient)
 	}
-	// The CLI owns signal cancellation so in-flight discovery commands can stop
-	// their process groups before the process exits.
-	client := newTestOptimizationClientWithTestSkippingLevel(nil, newAPITransport, nil, false, testSkippingLevel)
+	client := newTestOptimizationClientWithTestSkippingLevel(nil, newAPITransport, nil, testSkippingLevel)
 	client.gitCommands = git.NewCommandRunner(telemetry.NewGitCommandTelemetry(telemetryClient))
-	client.telemetryClient = telemetryClient
 	return client
 }
 
 func NewTestOptimizationClientWithDependencies(apiTransport api.Transport) *TestOptimizationClient {
-	return newTestOptimizationClient(apiTransport, nil, func() (int64, error) { return 0, nil }, false)
+	return newTestOptimizationClient(apiTransport, nil, func() (int64, error) { return 0, nil })
 }
 
 func newTestOptimizationClient(
 	apiTransport api.Transport,
 	newAPITransport func(serviceName string, testSkippingLevel settings.TestSkippingLevel) api.Transport,
 	repositoryChangesUploader func() (int64, error),
-	enableSignalHandler bool,
 ) *TestOptimizationClient {
 	return newTestOptimizationClientWithTestSkippingLevel(
 		apiTransport,
 		newAPITransport,
 		repositoryChangesUploader,
-		enableSignalHandler,
 		settings.TestSkippingLevelTest,
 	)
 }
@@ -103,7 +93,6 @@ func newTestOptimizationClientWithTestSkippingLevel(
 	apiTransport api.Transport,
 	newAPITransport func(serviceName string, testSkippingLevel settings.TestSkippingLevel) api.Transport,
 	repositoryChangesUploader func() (int64, error),
-	enableSignalHandler bool,
 	testSkippingLevel settings.TestSkippingLevel,
 ) *TestOptimizationClient {
 	if apiTransport == nil && newAPITransport == nil {
@@ -116,8 +105,6 @@ func newTestOptimizationClientWithTestSkippingLevel(
 		cacheManager:              NewCacheManager(),
 		gitCommands:               git.NewCommandRunner(nil),
 		repositoryChangesUploader: repositoryChangesUploader,
-		enableSignalHandler:       enableSignalHandler,
-		telemetryClient:           telemetry.NoopClient(),
 		testSkippingLevel:         testSkippingLevel,
 	}
 }
@@ -240,10 +227,6 @@ func (c *TestOptimizationClient) ensureTestOptimizationSessionInitialized() {
 		ciTags := environment.GetCITags()
 		if _, ok := ciTags[constants.GitRepositoryURL]; !ok {
 			slog.Debug("testoptimization: git repository URL tag was not detected")
-		}
-
-		if c.enableSignalHandler {
-			c.registerSignalHandler()
 		}
 	})
 }
@@ -431,23 +414,6 @@ func (c *TestOptimizationClient) exitTestOptimization() {
 	}()
 	for _, action := range c.closeActions {
 		action()
-	}
-}
-
-func (c *TestOptimizationClient) registerSignalHandler() {
-	signals := make(chan os.Signal, 1)
-	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
-	go func() {
-		<-signals
-		c.handleSignal()
-		os.Exit(1)
-	}()
-}
-
-func (c *TestOptimizationClient) handleSignal() {
-	c.StoreCacheAndExit()
-	if err := c.telemetryClient.Flush(context.Background()); err != nil {
-		slog.Debug("Failed to flush telemetry metrics during shutdown", "error", err)
 	}
 }
 

--- a/internal/testoptimization/testoptimization_lifecycle_test.go
+++ b/internal/testoptimization/testoptimization_lifecycle_test.go
@@ -4,11 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
-	"os/signal"
 	"path/filepath"
 	"slices"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 
@@ -110,7 +108,6 @@ func TestNewTestOptimizationClientWithTestSkippingLevelPropagatesToTransportFact
 			return mockTransport
 		},
 		func() (int64, error) { return 0, nil },
-		false,
 		settings.TestSkippingLevelSuite,
 	)
 
@@ -153,7 +150,6 @@ func TestEnsureSettingsInitializationRequireGitRetriesAfterUpload(t *testing.T) 
 		transport,
 		nil,
 		func() (int64, error) { return 42, nil },
-		false,
 	)
 
 	settings := client.GetSettings()
@@ -166,7 +162,7 @@ func TestEnsureSettingsInitializationRequireGitRetriesAfterUpload(t *testing.T) 
 }
 
 func TestEnsureSettingsInitializationHandlesMissingTransportAndErrors(t *testing.T) {
-	client := newTestOptimizationClient(nil, func(string, settings.TestSkippingLevel) api.Transport { return nil }, nil, false)
+	client := newTestOptimizationClient(nil, func(string, settings.TestSkippingLevel) api.Transport { return nil }, nil)
 	if settings := client.GetSettings(); settings != nil {
 		t.Fatalf("expected nil settings without transport, got %#v", settings)
 	}
@@ -174,7 +170,7 @@ func TestEnsureSettingsInitializationHandlesMissingTransportAndErrors(t *testing
 	transport := &settingsSequenceTransport{
 		errors: []error{errors.New("settings failed")},
 	}
-	client = newTestOptimizationClient(transport, nil, func() (int64, error) { return 0, nil }, false)
+	client = newTestOptimizationClient(transport, nil, func() (int64, error) { return 0, nil })
 	if settings := client.GetSettings(); settings != nil {
 		t.Fatalf("expected nil settings on transport error, got %#v", settings)
 	}
@@ -187,7 +183,7 @@ func TestEnsureSettingsInitializationHandlesNilResponsesAfterUpload(t *testing.T
 	transport := &settingsSequenceTransport{
 		settings: []*api.SettingsResponseData{nil},
 	}
-	client := newTestOptimizationClient(transport, nil, func() (int64, error) { return 0, nil }, false)
+	client := newTestOptimizationClient(transport, nil, func() (int64, error) { return 0, nil })
 	if settings := client.GetSettings(); settings != nil {
 		t.Fatalf("expected nil settings from nil response, got %#v", settings)
 	}
@@ -198,7 +194,7 @@ func TestEnsureSettingsInitializationHandlesNilResponsesAfterUpload(t *testing.T
 	transport = &settingsSequenceTransport{
 		settings: []*api.SettingsResponseData{{RequireGit: true}, nil},
 	}
-	client = newTestOptimizationClient(transport, nil, func() (int64, error) { return 0, nil }, false)
+	client = newTestOptimizationClient(transport, nil, func() (int64, error) { return 0, nil })
 	if settings := client.GetSettings(); settings != nil {
 		t.Fatalf("expected nil settings when require-git retry returns nil, got %#v", settings)
 	}
@@ -211,7 +207,7 @@ func TestEnsureSettingsInitializationHandlesNilResponsesAfterUpload(t *testing.T
 		settings: []*api.SettingsResponseData{{RequireGit: true}, nil},
 		errors:   []error{nil, secondErr},
 	}
-	client = newTestOptimizationClient(transport, nil, func() (int64, error) { return 0, nil }, false)
+	client = newTestOptimizationClient(transport, nil, func() (int64, error) { return 0, nil })
 	if settings := client.GetSettings(); settings != nil {
 		t.Fatalf("expected nil settings when require-git retry fails, got %#v", settings)
 	}
@@ -230,11 +226,7 @@ func TestEnsureTestOptimizationSessionInitializationBranches(t *testing.T) {
 	t.Setenv("DD_TRACE_SAMPLE_RATE", "")
 	environment.ResetCITags()
 	t.Cleanup(environment.ResetCITags)
-	t.Cleanup(func() {
-		signal.Reset(syscall.SIGINT, syscall.SIGTERM)
-	})
-
-	client := newTestOptimizationClient(&MockAPIClient{}, nil, func() (int64, error) { return 0, nil }, true)
+	client := newTestOptimizationClient(&MockAPIClient{}, nil, func() (int64, error) { return 0, nil })
 	client.ensureTestOptimizationSessionInitialized()
 
 	if got := os.Getenv(constants.TestOptimizationEnabledEnvironmentVariable); got != "1" {
@@ -284,7 +276,7 @@ func TestTraceDebugEnabled(t *testing.T) {
 }
 
 func TestEnsureTestOptimizationInitializedHandlesNilSettingsAndEndpointErrors(t *testing.T) {
-	client := newTestOptimizationClient(&MockAPIClient{}, nil, func() (int64, error) { return 0, nil }, false)
+	client := newTestOptimizationClient(&MockAPIClient{}, nil, func() (int64, error) { return 0, nil })
 	client.ensureTestOptimizationInitialized()
 
 	settings := &api.SettingsResponseData{
@@ -417,12 +409,12 @@ func TestApplyEnvironmentOverridesInvalidEnvValuesUseDefaults(t *testing.T) {
 
 func TestRepositoryUploadHelpers(t *testing.T) {
 	uploadErr := errors.New("upload failed")
-	client := newTestOptimizationClient(nil, nil, func() (int64, error) { return 0, uploadErr }, false)
+	client := newTestOptimizationClient(nil, nil, func() (int64, error) { return 0, uploadErr })
 	if bytes, err := client.uploadRepositoryChanges(); bytes != 0 || !errors.Is(err, uploadErr) {
 		t.Fatalf("uploadRepositoryChanges() = %d, %v", bytes, err)
 	}
 
-	client = newTestOptimizationClient(nil, nil, func() (int64, error) { return 99, nil }, false)
+	client = newTestOptimizationClient(nil, nil, func() (int64, error) { return 99, nil })
 	if bytes, err := client.uploadRepositoryChanges(); bytes != 99 || err != nil {
 		t.Fatalf("uploadRepositoryChanges() = %d, %v", bytes, err)
 	}
@@ -434,7 +426,7 @@ func TestRepositoryUploadHelpers(t *testing.T) {
 		t.Fatal("uploadRepositoryChangesAsync() did not finish")
 	}
 
-	client = newTestOptimizationClient(&MockAPIClient{}, nil, nil, false)
+	client = newTestOptimizationClient(&MockAPIClient{}, nil, nil)
 	if bytes, err := client.sendObjectsPackFile("commit", nil, nil); bytes != 0 || err != nil {
 		t.Fatalf("sendObjectsPackFile() empty = %d, %v", bytes, err)
 	}
@@ -442,7 +434,7 @@ func TestRepositoryUploadHelpers(t *testing.T) {
 
 func TestRepositoryUploadAsyncErrorAndGitFallback(t *testing.T) {
 	uploadErr := errors.New("upload failed")
-	client := newTestOptimizationClient(nil, nil, func() (int64, error) { return 0, uploadErr }, false)
+	client := newTestOptimizationClient(nil, nil, func() (int64, error) { return 0, uploadErr })
 	done := client.uploadRepositoryChangesAsync()
 	select {
 	case <-done:
@@ -450,7 +442,7 @@ func TestRepositoryUploadAsyncErrorAndGitFallback(t *testing.T) {
 		t.Fatal("uploadRepositoryChangesAsync() with error did not finish")
 	}
 
-	client = newTestOptimizationClient(nil, nil, nil, false)
+	client = newTestOptimizationClient(nil, nil, nil)
 	bytes, err := client.uploadRepositoryChanges()
 	if err != nil || bytes != 0 {
 		t.Fatalf("expected git fallback noop without transport, got bytes=%d err=%v", bytes, err)
@@ -464,7 +456,7 @@ func TestUploadRepositoryChangesFromGitAllCommitsKnown(t *testing.T) {
 	localCommits := []string{repo.Commits[1], repo.Commits[0]}
 
 	mockTransport := &MockAPIClient{RemoteCommits: localCommits}
-	client := newTestOptimizationClient(mockTransport, nil, nil, false)
+	client := newTestOptimizationClient(mockTransport, nil, nil)
 
 	bytes, err := client.uploadRepositoryChangesFromGit()
 	if err != nil {
@@ -491,7 +483,7 @@ func TestUploadRepositoryChangesFromGitSearchError(t *testing.T) {
 	localCommits := []string{repo.Commits[1], repo.Commits[0]}
 
 	searchErr := errors.New("search commits failed")
-	client := newTestOptimizationClient(&MockAPIClient{GetCommitsErr: searchErr}, nil, nil, false)
+	client := newTestOptimizationClient(&MockAPIClient{GetCommitsErr: searchErr}, nil, nil)
 
 	bytes, err := client.uploadRepositoryChangesFromGit()
 	if bytes != 0 {
@@ -516,7 +508,7 @@ func TestUploadRepositoryChangesFromGitUploadsMissingCommits(t *testing.T) {
 		RemoteCommits:      remoteCommits,
 		SendPackFilesBytes: 123,
 	}
-	client := newTestOptimizationClient(mockTransport, nil, nil, false)
+	client := newTestOptimizationClient(mockTransport, nil, nil)
 
 	bytes, err := client.uploadRepositoryChangesFromGit()
 	if err != nil {
@@ -555,7 +547,7 @@ func TestUploadRepositoryChangesFromGitUploadsMissingCommits(t *testing.T) {
 }
 
 func TestUploadRepositoryChangesFromGitWithoutTransportIsNoop(t *testing.T) {
-	client := newTestOptimizationClient(nil, nil, nil, false)
+	client := newTestOptimizationClient(nil, nil, nil)
 	bytes, err := client.uploadRepositoryChangesFromGit()
 	if err != nil || bytes != 0 {
 		t.Fatalf("expected noop without transport, got bytes=%d err=%v", bytes, err)
@@ -568,7 +560,7 @@ func TestGetSearchCommitsBranches(t *testing.T) {
 		t.Skip("no local git commits available")
 	}
 
-	client := newTestOptimizationClient(nil, nil, nil, false)
+	client := newTestOptimizationClient(nil, nil, nil)
 	response, err := client.getSearchCommits()
 	if err != nil {
 		t.Fatalf("getSearchCommits() without transport returned error: %v", err)
@@ -579,7 +571,7 @@ func TestGetSearchCommitsBranches(t *testing.T) {
 
 	searchErr := errors.New("search failed")
 	mockTransport := &MockAPIClient{GetCommitsErr: searchErr}
-	client = newTestOptimizationClient(mockTransport, nil, nil, false)
+	client = newTestOptimizationClient(mockTransport, nil, nil)
 	response, err = client.getSearchCommits()
 	if !errors.Is(err, searchErr) {
 		t.Fatalf("expected search error, got response=%#v err=%v", response, err)
@@ -601,7 +593,7 @@ func TestGetSearchCommitsWithoutGitRepository(t *testing.T) {
 		t.Fatalf("chdir temp dir: %v", err)
 	}
 
-	client := newTestOptimizationClient(&MockAPIClient{}, nil, nil, false)
+	client := newTestOptimizationClient(&MockAPIClient{}, nil, nil)
 	response, err := client.getSearchCommits()
 	if err != nil {
 		t.Fatalf("getSearchCommits() returned error: %v", err)
@@ -718,7 +710,7 @@ func TestSearchCommitsResponseHelpers(t *testing.T) {
 
 func TestExitTestOptimizationRunsCloseActionsOnce(t *testing.T) {
 	var calls []string
-	client := newTestOptimizationClient(nil, nil, nil, false)
+	client := newTestOptimizationClient(nil, nil, nil)
 	client.pushTestOptimizationCloseAction(func() { calls = append(calls, "first") })
 	client.pushTestOptimizationCloseAction(func() { calls = append(calls, "second") })
 

--- a/internal/testoptimization/testoptimization_test.go
+++ b/internal/testoptimization/testoptimization_test.go
@@ -229,7 +229,10 @@ func TestNewTestOptimizationClient(t *testing.T) {
 	client := NewTestOptimizationClient()
 
 	if client == nil {
-		t.Error("NewTestOptimizationClient() should return non-nil client")
+		t.Fatal("NewTestOptimizationClient() should return non-nil client")
+	}
+	if client.enableSignalHandler {
+		t.Error("CLI-owned signal cancellation should disable the legacy process-exit handler")
 	}
 }
 

--- a/internal/testoptimization/testoptimization_test.go
+++ b/internal/testoptimization/testoptimization_test.go
@@ -231,9 +231,6 @@ func TestNewTestOptimizationClient(t *testing.T) {
 	if client == nil {
 		t.Fatal("NewTestOptimizationClient() should return non-nil client")
 	}
-	if client.enableSignalHandler {
-		t.Error("CLI-owned signal cancellation should disable the legacy process-exit handler")
-	}
 }
 
 func TestNewTestOptimizationClientWithDependencies(t *testing.T) {


### PR DESCRIPTION
## What

Prevent `ddtest plan` from hanging when full test discovery is cancelled after Test Impact Analysis returns no skippable tests.

Captured-output commands now run in their own process group on Linux and macOS so cancellation terminates framework wrappers and their descendants. A one-second `WaitDelay` also bounds output-pipe waits when a descendant has detached from that group but still holds stdout or stderr open.

## Why

`exec.CommandContext` previously killed only the direct discovery process. If `bin/rspec` or another wrapper spawned a descendant that inherited its output pipes, `CombinedOutput` continued waiting for EOF after the direct process was cancelled. Planning then remained stuck after logging `No TIA-skippable tests or suites found for this run, cancelling full test discovery`.

## E2E testing

1. In an RSpec project, use a `bin/rspec` wrapper that starts a long-lived child process inheriting stdout and stderr during `--dry-run` discovery.
2. Run `ddtest plan` with test skipping enabled for a commit where the backend returns zero skippable tests.
3. Verify DDTest cancels full discovery and exits promptly instead of waiting for the descendant to close the inherited pipes.

Automated coverage exercises normal descendants, detached descendants during cancellation, and descendants that keep output pipes open after their wrapper exits.

Validation:

- `make test`
- `make lint`
